### PR TITLE
Enable save upload with file as body

### DIFF
--- a/dev/docker-compose.prod.yml
+++ b/dev/docker-compose.prod.yml
@@ -57,6 +57,8 @@ services:
       - "traefik.http.routers.api.tls=true"
       - "traefik.http.routers.api.tls.certresolver=cloudflareresolver"
       - "traefik.http.routers.api.rule=Host(`${PUBLIC_HOST}`) && !PathPrefix(`/api/admin`)"
+      - "traefik.http.middlewares.max-upload-size.buffering.maxRequestBodyBytes=20000000"
+      - "traefik.http.routers.api.middlewares=max-upload-size@docker"
     volumes:
       - ./.env.app:/app/.env:ro
     logging:

--- a/justfile
+++ b/justfile
@@ -84,11 +84,11 @@ test-app *cmd: prep-test-app
 
   export NODE_ENV=test
   APP_OUT="$(mktemp)"
-  trap 'cat "$APP_OUT"' ERR
-  trap 'rm -rf -- "$APP_OUT"' EXIT
+  trap 'cat "$APP_OUT.stdout" "$APP_OUT.stderr"' ERR
+  trap 'rm -rf -- "$APP_OUT.stdout" "$APP_OUT.stderr"' EXIT
 
   # TODO: I need the naked `next` else killing pid doesn't kill next 
-  src/app/node_modules/.bin/next dev src/app 2>&1 >> "$APP_OUT" &
+  src/app/node_modules/.bin/next dev src/app > "$APP_OUT.stdout" 2> "$APP_OUT.stderr" &
   APP_PID=$!
   trap 'kill "$APP_PID"' EXIT
 

--- a/src/app/src/server-lib/models.ts
+++ b/src/app/src/server-lib/models.ts
@@ -1,7 +1,10 @@
 import { ValidationError } from "./errors";
 
 export type UploadType = "gzipText" | "brText" | "brTar" | "zip";
-export function uploadType(type: string, encoding: string | null): UploadType {
+export function deduceUploadType(
+  type: string,
+  encoding: string | null
+): UploadType {
   if (encoding?.toLowerCase() === "gzip") {
     return "gzipText";
   } else if (encoding?.toLowerCase() == "br") {

--- a/src/app/src/server-lib/s3.ts
+++ b/src/app/src/server-lib/s3.ts
@@ -56,13 +56,13 @@ const sizeHistogram = new metrics.Histogram({
 export async function uploadFileToS3(
   filePath: string,
   filename: string,
-  bytes: number,
   upload: UploadType
 ): Promise<void> {
   const contentEncoding = uploadContentEncoding(upload);
   const contentType = uploadContentType(upload);
 
   const end = timeHistogram.startTimer();
+  const { size: bytes } = await fs.promises.stat(filePath);
   const stream = fs.createReadStream(filePath);
 
   await s3client


### PR DESCRIPTION
There's two ways to upload a file. One is through the use of
multipart/form-data, where the file is one part and the metadata is
encoded as JSON in another part. This is how the UI uploads files.

The other way to upload a file is to use HTTP headers to encode metadata
and use the body as the file contents. This is how the CLI client works.
It's simpler a call and could facilitate efficiency for clients that
are able to stream requests from disk.

The second functionality was mistakenly not ported over, so this commit
enables it.

The cap on file size is hoisted up to the reverse proxy.