### PR TITLE
Enable toggle tag filter in info drawer

### DIFF
--- a/src/app/src/features/eu4/features/country-details/CountryDetailsDrawer.tsx
+++ b/src/app/src/features/eu4/features/country-details/CountryDetailsDrawer.tsx
@@ -10,10 +10,7 @@ import {
   selectEu4SelectedTag,
   setEu4SelectedTag,
 } from "@/features/eu4/eu4Slice";
-import {
-  useWorkerOnSave,
-  WorkerClient,
-} from "../../../engine/worker/wasm-worker-context";
+import { useWorkerOnSave, WorkerClient } from "@/features/engine";
 import {
   CountryDetails,
   GreatAdvisor,

--- a/src/app/src/features/eu4/features/info/InfoSideBarButton.tsx
+++ b/src/app/src/features/eu4/features/info/InfoSideBarButton.tsx
@@ -45,6 +45,7 @@ export const InfoSideBarButton: React.FC<SideBarButtonProps> = ({
         closable={true}
         mask={false}
         maskClosable={false}
+        destroyOnClose={true} /* to reset initial map payload */
         onClose={() => setDrawerVisible(false)}
         visible={drawerVisible}
         width="min(800px, 100%)"


### PR DESCRIPTION
When the user clicks on the "Show only X on the map" button in the info
drawer, we show only that tag on the map. It seems reasonable that if
the user were to click the button again, it would reset to the map mode
at the time when the user opened the info drawer.

Closes #13 