### PR TITLE
Move clear select items 'X' from right to left

### DIFF
--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -7,6 +7,12 @@
   height: 100%;
 }
 
+/* To put the close icon of a select on the left side */
+.ant-select-selection-item {
+  flex-direction: row-reverse;
+  gap: 4px;
+}
+
 .antd-center-list-items div.ant-row {
   justify-content: center;
 }


### PR DESCRIPTION
Moving the select items 'X' from right to left means that the 'X' is now
in the same position relative to whatever it's bordering. This means
that one can more easily spam click to remove nations (though, depending
on how many countries one removes, it may be better to start with a
smaller base set of countries, like players and explicitly include
countries).

![image](https://user-images.githubusercontent.com/2106129/150985576-9efb2188-25d7-4641-bab9-b7a79c673c02.png)

Closes #32