### PR TITLE
Fix standalone map asset references

### DIFF
--- a/src/map/src/index.ts
+++ b/src/map/src/index.ts
@@ -6,8 +6,8 @@ import { debounce } from "./debounce";
 import { compile } from "./shaderCompiler";
 
 async function fetchColorData(kind: string) {
-  const raw = await fetch(`assets/game/eu4/data/color-${kind}-data.bin`).then((x) =>
-    x.arrayBuffer()
+  const raw = await fetch(`assets/game/eu4/data/color-${kind}-data.bin`).then(
+    (x) => x.arrayBuffer()
   );
   const primary = new Uint8Array(raw, 0, raw.byteLength / 2);
   const secondary = new Uint8Array(raw, raw.byteLength / 2);

--- a/src/map/src/staticResources.ts
+++ b/src/map/src/staticResources.ts
@@ -19,9 +19,9 @@ export interface StaticResources {
 }
 
 export async function loadStaticResources(): Promise<StaticResources> {
-  const provincesBufferPromise = fetch("assets/eu4/data/color-order.bin").then(
-    (x) => x.arrayBuffer()
-  );
+  const provincesBufferPromise = fetch(
+    "assets/game/eu4/data/color-order.bin"
+  ).then((x) => x.arrayBuffer());
 
   const [
     colorMap,
@@ -39,19 +39,19 @@ export async function loadStaticResources(): Promise<StaticResources> {
     heightMap,
   ] = await Promise.all(
     [
-      "./assets/eu4/images/colormap.webp",
-      "./assets/eu4/images/sea-image.webp",
-      "./assets/eu4/images/world_normal.webp",
-      "./assets/eu4/images/terrain.png",
-      "./assets/eu4/images/rivers.png",
-      "./assets/eu4/images/water.webp",
-      "./assets/eu4/images/provinces.png",
-      "./assets/eu4/images/stripes.png",
-      "./assets/eu4/images/surface_rock.webp",
-      "./assets/eu4/images/surface_green.webp",
-      "./assets/eu4/images/surface_normal_rock.webp",
-      "./assets/eu4/images/surface_normal_green.webp",
-      "./assets/eu4/images/heightmap.webp",
+      "./assets/game/eu4/images/colormap.webp",
+      "./assets/game/eu4/images/sea-image.webp",
+      "./assets/game/eu4/images/world_normal.webp",
+      "./assets/game/eu4/images/terrain.png",
+      "./assets/game/eu4/images/rivers.png",
+      "./assets/game/eu4/images/water.webp",
+      "./assets/game/eu4/images/provinces.png",
+      "./assets/game/eu4/images/stripes.png",
+      "./assets/game/eu4/images/surface_rock.webp",
+      "./assets/game/eu4/images/surface_green.webp",
+      "./assets/game/eu4/images/surface_normal_rock.webp",
+      "./assets/game/eu4/images/surface_normal_green.webp",
+      "./assets/game/eu4/images/heightmap.webp",
     ].map(loadImage)
   );
 
@@ -83,10 +83,10 @@ async function loadImage(src: string): Promise<ImageBitmap> {
 }
 
 export async function loadShaderSource(name: string): Promise<ShaderSource> {
-  const vertexFetch = fetch(`./assets/eu4/shaders/${name}.vert`).then((x) =>
+  const vertexFetch = fetch(`./assets/shaders/${name}.vert`).then((x) =>
     x.text()
   );
-  const fragmentFetch = fetch(`./assets/eu4/shaders/${name}.frag`).then((x) =>
+  const fragmentFetch = fetch(`./assets/shaders/${name}.frag`).then((x) =>
     x.text()
   );
 


### PR DESCRIPTION
When the map repo was integrated into the main repo, some of the map
assets were moved around so that they could be easily positioned in git
lfs to not disturb the weight of the main code and could be easily wiped
as needed.

Unfortunately, I forgot to update the standalone map asset references,
so one couldn't run the map repo anymore.

This commit fixes that issue

Closes #36