### PR TITLE
Splice in external loader sub title

### DIFF
--- a/src/app/src/components/landing/AnalyzeBox.tsx
+++ b/src/app/src/components/landing/AnalyzeBox.tsx
@@ -54,6 +54,7 @@ export const AnalyzeBox: React.FC<{}> = () => {
         label {
           border: 0;
           outline: 0.5rem dashed white;
+          margin: 0.5rem;
           padding: 1rem 2rem;
           border-radius: 1rem;
           background-color: transparent;

--- a/src/app/src/components/landing/Home.tsx
+++ b/src/app/src/components/landing/Home.tsx
@@ -21,7 +21,6 @@ import {
 } from "@/components/icons";
 
 interface HomeProps {
-  openLink?: string;
   subtitle?: React.ReactNode;
 }
 
@@ -47,7 +46,7 @@ const useWaveBackground = ([h, s, l]: number[]) => {
   return waveBackground;
 };
 
-export const Home: React.FC<HomeProps> = () => {
+export const Home: React.FC<HomeProps> = ({ subtitle }) => {
   const secondaryColor: [number, number, number] = [177, 100, 13.7];
   const sc = secondaryColor;
   const waveBackground = useWaveBackground(secondaryColor);
@@ -144,6 +143,10 @@ export const Home: React.FC<HomeProps> = () => {
           height: 24px;
           border-left: 1px dotted #d7d7db;
         }
+
+        .analyze-box {
+          display: flex;
+        }
       `}</style>
 
       <div
@@ -152,12 +155,12 @@ export const Home: React.FC<HomeProps> = () => {
           backgroundImage: waveBackground,
           backgroundPosition: "bottom",
           backgroundRepeat: "repeat-x",
-          paddingBottom: 0,
         }}
       >
-        <section style={{ marginBottom: "3rem" }}>
-          <div>
+        <section className="analyze-box flex-col">
+          <div className="flex-col gap">
             <AnalyzeBox />
+            {subtitle}
             {engineError && (
               <div
                 style={{

--- a/src/app/src/pages/loading.tsx
+++ b/src/app/src/pages/loading.tsx
@@ -1,17 +1,16 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { HtmlHead } from "@/components/head";
 import { Home } from "@/components/landing/Home";
 import { AppStructure } from "@/components/layout";
 import { FileDrop } from "@/features/engine/FileDrop";
 
 export const LoadingPage: React.FC<{}> = () => {
+  useEffect(() => {
+    history.replaceState({}, "", "/");
+  }, []);
+
   return (
     <>
-      <style jsx>{`
-        p {
-          color: white;
-        }
-      `}</style>
       <HtmlHead>
         <title>PDX Tools</title>
         <meta
@@ -23,11 +22,11 @@ export const LoadingPage: React.FC<{}> = () => {
         <FileDrop>
           <Home
             subtitle={
-              <p>
+              <div>
                 Please wait while your save is transferred to PDX Tools. Not
-                working? Ensure that pop-ups are allowed or click the button
-                below to open PDX Tools and manually select your save.
-              </p>
+                working? Ensure that pop-ups are allowed or manually select and
+                drag and drop your save.
+              </div>
             }
           />
         </FileDrop>


### PR DESCRIPTION
This also aesthetically rewrites the url to look like the home page so
that downstream functions that look at the url will treat saves loaded
through the external loader and the analyze box (or drag and drop) the same.

Closes #41