### PR TITLE
Fix initial map render omitting stripes and highlights

### DIFF
--- a/src/app/src/features/eu4/hooks/useMap.tsx
+++ b/src/app/src/features/eu4/hooks/useMap.tsx
@@ -76,7 +76,10 @@ export function useMap() {
       }
 
       const map = getEu4Canvas(mapRef);
-      if (mapColorPayloadPrev != mapColorPayload) {
+      if (
+        mapColorPayloadPrev != mapColorPayload ||
+        canvasState.current != "drawn"
+      ) {
         const [primary, secondary] = await worker.eu4MapColors(mapColorPayload);
         map.map?.updateProvinceColors(primary, secondary);
       }


### PR DESCRIPTION
When two consecutive saves are loaded, we preserve the map mode between
the two to ease a sort of comparison. However, we must always calculate
political borders on save load to allow for "paint country borders"
option to work regardless of map mode.

An issue of missing stripes and highlights occurred due to the first
render using this faux color calculation.

Closes #48 
Closes #37