### PR TITLE
Increase map compatibility with 4096 max texture size and optimize texture loading

### DIFF
--- a/justfile
+++ b/justfile
@@ -255,12 +255,15 @@ prep-frontend:
   for VERSION in $(ls assets/game/eu4/ | grep -v common | sort -n); do
     cat >> "$RESOURCE_OUTPUT" << EOF
     "$VERSION": {
-    provinces: require(\`../../../../assets/game/eu4/$VERSION/map/provinces.png\`),
+    provinces1: require(\`../../../../assets/game/eu4/$VERSION/map/provinces-1.png\`),
+    provinces2: require(\`../../../../assets/game/eu4/$VERSION/map/provinces-2.png\`),
     colorMap: require(\`../../../../assets/game/eu4/$VERSION/map/colormap_summer.webp\`),
     sea: require(\`../../../../assets/game/eu4/$VERSION/map/colormap_water.webp\`),
     normal: require(\`../../../../assets/game/eu4/$VERSION/map/world_normal.webp\`),
-    terrain: require(\`../../../../assets/game/eu4/$VERSION/map/terrain.png\`),
-    rivers: require(\`../../../../assets/game/eu4/$VERSION/map/rivers.png\`),
+    terrain1: require(\`../../../../assets/game/eu4/$VERSION/map/terrain-1.png\`),
+    terrain2: require(\`../../../../assets/game/eu4/$VERSION/map/terrain-2.png\`),
+    rivers1: require(\`../../../../assets/game/eu4/$VERSION/map/rivers-1.png\`),
+    rivers2: require(\`../../../../assets/game/eu4/$VERSION/map/rivers-2.png\`),
     stripes: require(\`../../../../assets/game/eu4/$VERSION/map/occupation.png\`),
     water: require(\`../../../../assets/game/eu4/$VERSION/map/noise-2d.webp\`),
     surfaceRock: require(\`../../../../assets/game/eu4/$VERSION/map/atlas0_rock.webp\`),

--- a/src/app/src/components/landing/BrowserCheck.tsx
+++ b/src/app/src/components/landing/BrowserCheck.tsx
@@ -8,7 +8,7 @@ export const BrowserCheck: React.FC<{}> = () => {
   useEffect(() => {
     const canvas = document.createElement("canvas");
     const gl = canvas.getContext("webgl2");
-    const requiredSize = 8192;
+    const requiredSize = 4096;
     const maxTextureSize = gl ? gl.getParameter(gl.MAX_TEXTURE_SIZE) : 0;
     const performanceCaveat = !canvas.getContext("webgl2", {
       failIfMajorPerformanceCaveat: true,

--- a/src/app/src/features/changelog/changes.tsx
+++ b/src/app/src/features/changelog/changes.tsx
@@ -670,4 +670,19 @@ export const changes: ChangelogEntry[] = [
       );
     },
   },
+  {
+    title: "2022-02-03",
+    render: () => {
+      return (
+        <ChangelogList>
+          <li>
+            ✨ - Add map compatibility with lower end devices with a max texture
+            size of 4096
+          </li>
+          <li>🐛 - Fix poor map visuals on mobile devices</li>
+          <li>🐛 - Fix map flicker on resize</li>
+        </ChangelogList>
+      );
+    },
+  },
 ];

--- a/src/app/src/features/engine/hooks/useAnalyzeProgress.ts
+++ b/src/app/src/features/engine/hooks/useAnalyzeProgress.ts
@@ -6,6 +6,7 @@ import {
   incrementSaveAnalyzePercent,
   setSaveAnalyzePercent,
 } from "../engineSlice";
+import { log } from "@/lib/log";
 
 export function useAnalyzeProgress() {
   const dispatch = useDispatch();
@@ -25,21 +26,21 @@ export function useAnalyzeProgress() {
       switch (evt.kind) {
         case "bytes read": {
           const kb = formatFloat(evt.amount / 1000, 2);
-          console.log(`read ${kb} KB | ${progressTail}`);
+          log(`read ${kb} KB | ${progressTail}`);
           break;
         }
         case "detected": {
-          console.log(`detected data to be ${evt.type} | ${progressTail}`);
+          log(`detected data to be ${evt.type} | ${progressTail}`);
           break;
         }
         case "progress": {
           if (evt.elapsedMs !== 0) {
-            console.log(`${evt.msg} | ${progressTail}`);
+            log(`${evt.msg} | ${progressTail}`);
           }
           break;
         }
         case "incremental progress": {
-          console.log(`${evt.msg} | ${elapsedTime}ms`);
+          log(`${evt.msg} | ${elapsedTime}ms`);
           break;
         }
         case "start poll": {

--- a/src/app/src/features/eu4/Eu4CanvasOverlay.tsx
+++ b/src/app/src/features/eu4/Eu4CanvasOverlay.tsx
@@ -23,6 +23,7 @@ import { selectEu4MapDate } from "./eu4Slice";
 import { selectModuleDrawn } from "../engine";
 import { MapTip } from "./features/map/MapTip";
 import { MapZoomSideBar } from "./components/zoom";
+import { log } from "@/lib/log";
 
 const { className, styles } = css.resolve`
   span {

--- a/src/app/src/features/eu4/Eu4Ui.tsx
+++ b/src/app/src/features/eu4/Eu4Ui.tsx
@@ -1,15 +1,10 @@
 import { useSelector } from "react-redux";
-import {
-  resetSaveAnalysis,
-  selectAnalyzeFileName,
-  selectShowCanvas,
-} from "@/features/engine";
+import { selectAnalyzeFileName, selectShowCanvas } from "@/features/engine";
 import { useMap } from "./hooks/useMap";
 import { useEffect } from "react";
 import { useAppDispatch } from "@/lib/store";
 import { toggleShowTerrain, useEu4Meta } from "./eu4Slice";
 import { Eu4CanvasOverlay } from "./Eu4CanvasOverlay";
-import { useRouter } from "next/router";
 import Head from "next/head";
 
 export const Eu4Ui: React.FC<{}> = () => {

--- a/src/app/src/features/eu4/hooks/useCanvasPointerEvents.tsx
+++ b/src/app/src/features/eu4/hooks/useCanvasPointerEvents.tsx
@@ -25,7 +25,6 @@ export function useCanvasPointerEvents() {
 
     function handleMouseUp(e: MouseEvent) {
       map.onMouseUp(e);
-      map.redrawViewport();
       window.removeEventListener("pointermove", moveCamera);
       window.removeEventListener("pointerup", handleMouseUp);
     }

--- a/src/app/src/features/eu4/hooks/useMap.tsx
+++ b/src/app/src/features/eu4/hooks/useMap.tsx
@@ -70,6 +70,7 @@ export function useMap() {
 
     const map = getEu4Canvas(mapRef);
     map.resize(canvasWidth, Math.floor(canvasHeight));
+    map.redrawViewport();
   }, [mapRef, canvasState, canvasWidth, canvasHeight]);
 
   const updateMapColorsCb = useCallback(
@@ -79,6 +80,10 @@ export function useMap() {
       }
 
       const map = getEu4Canvas(mapRef);
+      if (mapDecorativeSettings.showTerrain) {
+        await map.enableTerrainOverlay();
+      }
+
       if (
         mapColorPayloadPrev != mapColorPayload ||
         canvasState.current != "drawn"

--- a/src/app/src/lib/isPresent.ts
+++ b/src/app/src/lib/isPresent.ts
@@ -2,3 +2,11 @@
 export function isPresent<T>(t: T | undefined | null | void): t is T {
   return t !== undefined && t !== null;
 }
+
+export function check<T>(t: T | undefined | null): T {
+  if (t === undefined || t === null) {
+    throw new Error("unexpected null or undefined");
+  } else {
+    return t;
+  }
+}

--- a/src/app/src/lib/log.ts
+++ b/src/app/src/lib/log.ts
@@ -1,0 +1,3 @@
+export function log(...data: any[]) {
+  console.log(`${new Date().toISOString()}:`, ...data);
+}

--- a/src/app/src/lib/url_types.ts
+++ b/src/app/src/lib/url_types.ts
@@ -1,10 +1,13 @@
 export interface ResourceUrls {
-  provinces: string;
+  provinces1: string;
+  provinces2: string;
+  terrain1: string;
+  terrain2: string;
   colorMap: string;
   sea: string;
   normal: string;
-  terrain: string;
-  rivers: string;
+  rivers1: string;
+  rivers2: string;
   stripes: string;
   water: string;
   surfaceRock: string;

--- a/src/map/assets/game/eu4/images/heightmap.webp
+++ b/src/map/assets/game/eu4/images/heightmap.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab3b9a8a143c27c1e44acc5b6b618b6e9bcfc9cff055930ef7db4e05459c4fc2
-size 138468
+oid sha256:c5b7bb86ad0055dfc78ef8a19e8ed919567475fc54fc0a7d8a681373d0bdf709
+size 51532

--- a/src/map/assets/game/eu4/images/provinces-1.png
+++ b/src/map/assets/game/eu4/images/provinces-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b48a710538edda4f44d89e1409fc5f28e3422084035e1076b0716f19b4486248
+size 185865

--- a/src/map/assets/game/eu4/images/provinces-2.png
+++ b/src/map/assets/game/eu4/images/provinces-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:266d5002fcad2cb47f1388ada9d544f59a4e1eed7aefeb6fc3ed4008b3c32815
+size 274106

--- a/src/map/assets/game/eu4/images/provinces.png
+++ b/src/map/assets/game/eu4/images/provinces.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c243017b418e8d9af2864494af1ed90bedff673da0055a843c5de87e76e92c89
-size 484802

--- a/src/map/assets/game/eu4/images/rivers-1.png
+++ b/src/map/assets/game/eu4/images/rivers-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0db691b412e2fb56214d9c78216c46712dd18e652026668469842abd09c004b2
+size 71153

--- a/src/map/assets/game/eu4/images/rivers-2.png
+++ b/src/map/assets/game/eu4/images/rivers-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd1d5b8d234c6712d846c0b2b134b62ded3613af80cccb263cff0dbdbf3e3d4b
+size 109380

--- a/src/map/assets/game/eu4/images/rivers.png
+++ b/src/map/assets/game/eu4/images/rivers.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59d28862556158525ebcc97c229c93906834df024d97c22f6c77e9bc0652a16a
-size 181624

--- a/src/map/assets/game/eu4/images/terrain-1.png
+++ b/src/map/assets/game/eu4/images/terrain-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a911f6f4222b894bb72770bcd02ae046da2de559234e61d5e2bbf765ef0b135
+size 146158

--- a/src/map/assets/game/eu4/images/terrain-2.png
+++ b/src/map/assets/game/eu4/images/terrain-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce115cda3f5ea76b3c84f9d2a801bdfc3c936b5cf2cdeb1a18d68ad49ce700cb
+size 267247

--- a/src/map/assets/game/eu4/images/terrain.png
+++ b/src/map/assets/game/eu4/images/terrain.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bdb41b9b5cb084336704b0565f451e7fe93b6e37c26470c05373a8e6bf2ce856
-size 425205

--- a/src/map/assets/shaders/xbr.frag
+++ b/src/map/assets/shaders/xbr.frag
@@ -8,8 +8,10 @@
 
 precision mediump float;
 
-uniform sampler2D u_mapEdgesTexture;
-uniform sampler2D u_mapTexture;
+uniform sampler2D u_mapEdgesTexture1;
+uniform sampler2D u_mapEdgesTexture2;
+uniform sampler2D u_mapTexture1;
+uniform sampler2D u_mapTexture2;
 uniform sampler2D u_normalImage;
 uniform sampler2D u_waterImage;
 uniform sampler2D u_colormapImage;
@@ -25,14 +27,14 @@ uniform float u_scale;
 uniform float u_maxScale;
 uniform bool u_renderTerrain;
 
-in vec4 v_t1;
-in vec4 v_t2;
-in vec4 v_t3;
-in vec4 v_t4;
-in vec4 v_t5;
-in vec4 v_t6;
-in vec4 v_t7;
-in vec2 v_texCoord;
+in highp vec4 v_t1;
+in highp vec4 v_t2;
+in highp vec4 v_t3;
+in highp vec4 v_t4;
+in highp vec4 v_t5;
+in highp vec4 v_t6;
+in highp vec4 v_t7;
+in highp vec2 v_texCoord;
 
 out vec4 outColor;
 
@@ -72,7 +74,7 @@ vec4 weighted_distance(vec4 a, vec4 b, vec4 c, vec4 d, vec4 e, vec4 f, vec4 g, v
 }
 
 
-float frac(float v)
+float frac(highp float v)
 {
   return v - floor(v);
 }
@@ -112,8 +114,16 @@ bool isHigherMountain(vec3 color) {
 	return b;
 }
 
-vec3 postProcess(vec2 tc) {
-	vec4 map = texture(u_mapTexture, tc);
+vec4 rawMapAt(highp vec2 tc) {
+	if (tc.x <= 0.5) {
+		return texture(u_mapTexture1, vec2(tc.x * 2.0, tc.y));
+	} else {
+		return texture(u_mapTexture2, vec2((tc.x - 0.5) * 2.0, tc.y));
+	}
+}
+
+vec3 postProcess(highp vec2 tc) {
+	vec4 map = rawMapAt(tc);
 
 	if (!u_renderTerrain) {
 		// Sea
@@ -203,18 +213,23 @@ vec3 postProcess(vec2 tc) {
 	return res;
 }
 
-vec3 image(vec2 tc) {
+vec3 image(highp vec2 tc) {
 	return postProcess(tc);
 }
 
-vec3 edgeDetectionImage(vec2 tc) {
-	return texture(u_mapEdgesTexture, tc).rgb;
+vec3 edgeDetectionImage(highp vec2 tc) {
+	if (tc.x <= 0.5) {
+		return texture(u_mapEdgesTexture1, vec2(tc.x * 2.0, tc.y)).rgb;
+	} else {
+		return texture(u_mapEdgesTexture2, vec2((tc.x - 0.5) * 2.0, tc.y)).rgb;
+	}
 }
 
 void main() {
-	//outColor = vec4(edgeDetectionImage(v_texCoord), 1.0);
-	//outColor =  texture(u_mapTexture, v_texCoord);
-	//return;
+	// outColor = vec4(edgeDetectionImage(v_texCoord), 1.0);
+	// outColor = rawMapAt(v_texCoord);
+	// outColor = vec4(postProcess(v_texCoord), 1.0);
+	// return;
 
     bvec4 edri, edr, edr_left, edr_up, px; // px = pixel, edr = edge detection rule
 	bvec4 interp_restriction_lv0, interp_restriction_lv1, interp_restriction_lv2_left, interp_restriction_lv2_up;

--- a/src/map/src/ProvinceFinder.ts
+++ b/src/map/src/ProvinceFinder.ts
@@ -1,19 +1,27 @@
 export class ProvinceFinder {
   private ctx: CanvasRenderingContext2D;
   constructor(
-    provinces: ImageBitmap,
+    provinces1: ImageBitmap,
+    provinces2: ImageBitmap,
     private sortedColors: Uint8Array,
     private provinceColorIndex: Uint16Array
   ) {
     const provinceCanvas = document.createElement("canvas");
-    provinceCanvas.width = provinces.width;
-    provinceCanvas.height = provinces.height;
+    provinceCanvas.width = provinces1.width * 2;
+    provinceCanvas.height = provinces2.height;
 
     this.ctx = provinceCanvas.getContext("2d")!;
 
     // turn off anti-aliasing else we will get color values that don't exist
     this.ctx.imageSmoothingEnabled = false;
-    this.ctx.drawImage(provinces, 0, 0, provinces.width, provinces.height);
+    this.ctx.drawImage(provinces1, 0, 0, provinces1.width, provinces1.height);
+    this.ctx.drawImage(
+      provinces2,
+      provinces1.width,
+      0,
+      provinces2.width,
+      provinces2.height
+    );
   }
 
   findProvinceId(x: number, y: number) {

--- a/src/map/src/mapShader.ts
+++ b/src/map/src/mapShader.ts
@@ -11,9 +11,12 @@ export class MapShader {
     private uRenderProvinceBorders: WebGLUniformLocation,
     private uRenderMapmodeBorders: WebGLUniformLocation,
     private uRenderCountryBorders: WebGLUniformLocation,
-    private uTerrain: WebGLUniformLocation,
-    private uRivers: WebGLUniformLocation,
-    private uProvinces: WebGLUniformLocation,
+    private uTerrain1: WebGLUniformLocation,
+    private uTerrain2: WebGLUniformLocation,
+    private uRivers1: WebGLUniformLocation,
+    private uRivers2: WebGLUniformLocation,
+    private uProvinces1: WebGLUniformLocation,
+    private uProvinces2: WebGLUniformLocation,
     private uStripes: WebGLUniformLocation,
     private uProvincesUniqueColors: WebGLUniformLocation,
     private uCountryProvinceColor: WebGLUniformLocation,
@@ -32,9 +35,12 @@ export class MapShader {
       notNull(gl.getUniformLocation(program, "u_renderProvinceBorders")),
       notNull(gl.getUniformLocation(program, "u_renderMapmodeBorders")),
       notNull(gl.getUniformLocation(program, "u_renderCountryBorders")),
-      notNull(gl.getUniformLocation(program, "u_terrainImage")),
-      notNull(gl.getUniformLocation(program, "u_riversImage")),
-      notNull(gl.getUniformLocation(program, "u_provincesImage")),
+      notNull(gl.getUniformLocation(program, "u_terrainImage1")),
+      notNull(gl.getUniformLocation(program, "u_terrainImage2")),
+      notNull(gl.getUniformLocation(program, "u_riversImage1")),
+      notNull(gl.getUniformLocation(program, "u_riversImage2")),
+      notNull(gl.getUniformLocation(program, "u_provincesImage1")),
+      notNull(gl.getUniformLocation(program, "u_provincesImage2")),
       notNull(gl.getUniformLocation(program, "u_stripesImage")),
       notNull(gl.getUniformLocation(program, "u_provincesUniqueColorsImage")),
       notNull(gl.getUniformLocation(program, "u_countryProvincesColorImage")),
@@ -56,36 +62,48 @@ export class MapShader {
     let gl = this.gl;
 
     gl.activeTexture(gl.TEXTURE0);
-    gl.bindTexture(gl.TEXTURE_2D, res.terrain);
-    gl.uniform1i(this.uTerrain, 0);
+    gl.bindTexture(gl.TEXTURE_2D, res.terrain1);
+    gl.uniform1i(this.uTerrain1, 0);
 
     gl.activeTexture(gl.TEXTURE1);
-    gl.bindTexture(gl.TEXTURE_2D, res.rivers);
-    gl.uniform1i(this.uRivers, 1);
+    gl.bindTexture(gl.TEXTURE_2D, res.terrain2);
+    gl.uniform1i(this.uTerrain2, 1);
 
     gl.activeTexture(gl.TEXTURE2);
-    gl.bindTexture(gl.TEXTURE_2D, res.provinces);
-    gl.uniform1i(this.uProvinces, 2);
+    gl.bindTexture(gl.TEXTURE_2D, res.rivers1);
+    gl.uniform1i(this.uRivers1, 2);
 
     gl.activeTexture(gl.TEXTURE3);
-    gl.bindTexture(gl.TEXTURE_2D, res.stripes);
-    gl.uniform1i(this.uStripes, 3);
+    gl.bindTexture(gl.TEXTURE_2D, res.rivers2);
+    gl.uniform1i(this.uRivers2, 3);
 
     gl.activeTexture(gl.TEXTURE4);
-    gl.bindTexture(gl.TEXTURE_2D, res.provincesUniqueColor);
-    gl.uniform1i(this.uProvincesUniqueColors, 4);
+    gl.bindTexture(gl.TEXTURE_2D, res.provinces1);
+    gl.uniform1i(this.uProvinces1, 4);
 
     gl.activeTexture(gl.TEXTURE5);
-    gl.bindTexture(gl.TEXTURE_2D, res.countryProvinceColors);
-    gl.uniform1i(this.uCountryProvinceColor, 5);
+    gl.bindTexture(gl.TEXTURE_2D, res.provinces2);
+    gl.uniform1i(this.uProvinces2, 5);
 
     gl.activeTexture(gl.TEXTURE6);
-    gl.bindTexture(gl.TEXTURE_2D, res.primaryProvinceColors);
-    gl.uniform1i(this.uPrimaryProvinceColor, 6);
+    gl.bindTexture(gl.TEXTURE_2D, res.stripes);
+    gl.uniform1i(this.uStripes, 6);
 
     gl.activeTexture(gl.TEXTURE7);
+    gl.bindTexture(gl.TEXTURE_2D, res.provincesUniqueColor);
+    gl.uniform1i(this.uProvincesUniqueColors, 7);
+
+    gl.activeTexture(gl.TEXTURE8);
+    gl.bindTexture(gl.TEXTURE_2D, res.countryProvinceColors);
+    gl.uniform1i(this.uCountryProvinceColor, 8);
+
+    gl.activeTexture(gl.TEXTURE9);
+    gl.bindTexture(gl.TEXTURE_2D, res.primaryProvinceColors);
+    gl.uniform1i(this.uPrimaryProvinceColor, 9);
+
+    gl.activeTexture(gl.TEXTURE10);
     gl.bindTexture(gl.TEXTURE_2D, res.secondaryProvinceColors);
-    gl.uniform1i(this.uSecondaryProvinceColor, 7);
+    gl.uniform1i(this.uSecondaryProvinceColor, 10);
   }
 
   setProvinceCount(count: number) {

--- a/src/map/src/staticResources.ts
+++ b/src/map/src/staticResources.ts
@@ -2,20 +2,26 @@ import { ShaderSource } from "./types";
 
 // Stores all static resource data like images, shader source code, etc.
 export interface StaticResources {
+  provinces1: ImageBitmap;
+  provinces2: ImageBitmap;
+  terrain1: ImageBitmap;
+  terrain2: ImageBitmap;
+  provincesUniqueColor: Uint8Array;
+  stripes: ImageBitmap;
+}
+
+export interface TerrainOverlayResources {
   colorMap: ImageBitmap;
   sea: ImageBitmap;
   normal: ImageBitmap;
-  terrain: ImageBitmap;
-  rivers: ImageBitmap;
+  rivers1: ImageBitmap;
+  rivers2: ImageBitmap;
   water: ImageBitmap;
-  provinces: ImageBitmap;
-  stripes: ImageBitmap;
   surfaceRock: ImageBitmap;
   surfaceGreen: ImageBitmap;
   surfaceNormalRock: ImageBitmap;
   surfaceNormalGreen: ImageBitmap;
   heightMap: ImageBitmap;
-  provincesUniqueColor: Uint8Array;
 }
 
 export async function loadStaticResources(): Promise<StaticResources> {
@@ -23,15 +29,37 @@ export async function loadStaticResources(): Promise<StaticResources> {
     "assets/game/eu4/data/color-order.bin"
   ).then((x) => x.arrayBuffer());
 
+  const [terrain1, terrain2, provinces1, provinces2, stripes] =
+    await Promise.all(
+      [
+        "./assets/game/eu4/images/terrain-1.png",
+        "./assets/game/eu4/images/terrain-2.png",
+        "./assets/game/eu4/images/provinces-1.png",
+        "./assets/game/eu4/images/provinces-2.png",
+        "./assets/game/eu4/images/stripes.png",
+      ].map(loadImage)
+    );
+
+  const provincesUniqueColor = new Uint8Array(await provincesBufferPromise);
+
+  return {
+    provinces1,
+    provinces2,
+    terrain1,
+    terrain2,
+    provincesUniqueColor,
+    stripes,
+  };
+}
+
+export async function loadTerrainResources(): Promise<TerrainOverlayResources> {
   const [
     colorMap,
     sea,
     normal,
-    terrain,
-    rivers,
+    rivers1,
+    rivers2,
     water,
-    provinces,
-    stripes,
     surfaceRock,
     surfaceGreen,
     surfaceNormalRock,
@@ -42,11 +70,9 @@ export async function loadStaticResources(): Promise<StaticResources> {
       "./assets/game/eu4/images/colormap.webp",
       "./assets/game/eu4/images/sea-image.webp",
       "./assets/game/eu4/images/world_normal.webp",
-      "./assets/game/eu4/images/terrain.png",
-      "./assets/game/eu4/images/rivers.png",
+      "./assets/game/eu4/images/rivers-1.png",
+      "./assets/game/eu4/images/rivers-2.png",
       "./assets/game/eu4/images/water.webp",
-      "./assets/game/eu4/images/provinces.png",
-      "./assets/game/eu4/images/stripes.png",
       "./assets/game/eu4/images/surface_rock.webp",
       "./assets/game/eu4/images/surface_green.webp",
       "./assets/game/eu4/images/surface_normal_rock.webp",
@@ -55,27 +81,22 @@ export async function loadStaticResources(): Promise<StaticResources> {
     ].map(loadImage)
   );
 
-  const provincesUniqueColor = new Uint8Array(await provincesBufferPromise);
-
   return {
     colorMap,
     sea,
     normal,
-    terrain,
-    rivers,
+    rivers1,
+    rivers2,
     water,
-    provinces,
-    stripes,
     surfaceRock,
     surfaceGreen,
     surfaceNormalRock,
     surfaceNormalGreen,
     heightMap,
-    provincesUniqueColor,
   };
 }
 
-async function loadImage(src: string): Promise<ImageBitmap> {
+export async function loadImage(src: string): Promise<ImageBitmap> {
   // Download as blobs per this 2021-06-04 chronium comment:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=580202#c53
   const image = await fetch(src).then((x) => x.blob());

--- a/src/map/src/xbrShader.ts
+++ b/src/map/src/xbrShader.ts
@@ -15,8 +15,10 @@ export class XbrShader {
     private uRenderTerrain: WebGLUniformLocation,
     private aPos: GLuint,
     private aTexCoord: GLuint,
-    private uMapEdgesTexture: WebGLUniformLocation,
-    private uMapTexture: WebGLUniformLocation,
+    private uRawMapEdgesTexture1: WebGLUniformLocation,
+    private uRawMapEdgesTexture2: WebGLUniformLocation,
+    private uRawMapTexture1: WebGLUniformLocation,
+    private uRawMapTexture2: WebGLUniformLocation,
     private uNormal: WebGLUniformLocation,
     private uWater: WebGLUniformLocation,
     private uColormap: WebGLUniformLocation,
@@ -42,8 +44,10 @@ export class XbrShader {
       notNull(gl.getUniformLocation(program, "u_renderTerrain")),
       notNull(gl.getAttribLocation(program, "a_position")),
       notNull(gl.getAttribLocation(program, "a_texCoord")),
-      notNull(gl.getUniformLocation(program, "u_mapEdgesTexture")),
-      notNull(gl.getUniformLocation(program, "u_mapTexture")),
+      notNull(gl.getUniformLocation(program, "u_mapEdgesTexture1")),
+      notNull(gl.getUniformLocation(program, "u_mapEdgesTexture2")),
+      notNull(gl.getUniformLocation(program, "u_mapTexture1")),
+      notNull(gl.getUniformLocation(program, "u_mapTexture2")),
       notNull(gl.getUniformLocation(program, "u_normalImage")),
       notNull(gl.getUniformLocation(program, "u_waterImage")),
       notNull(gl.getUniformLocation(program, "u_colormapImage")),
@@ -68,12 +72,12 @@ export class XbrShader {
     let gl = this.gl;
 
     gl.activeTexture(gl.TEXTURE0);
-    gl.bindTexture(gl.TEXTURE_2D, res.framebufferEdgesTexture);
-    gl.uniform1i(this.uMapEdgesTexture, 0);
+    gl.bindTexture(gl.TEXTURE_2D, res.framebufferRawMapEdgesTexture1);
+    gl.uniform1i(this.uRawMapEdgesTexture1, 0);
 
     gl.activeTexture(gl.TEXTURE1);
-    gl.bindTexture(gl.TEXTURE_2D, res.framebufferTexture);
-    gl.uniform1i(this.uMapTexture, 1);
+    gl.bindTexture(gl.TEXTURE_2D, res.framebufferRawMapTexture1);
+    gl.uniform1i(this.uRawMapTexture1, 1);
 
     gl.activeTexture(gl.TEXTURE2);
     gl.bindTexture(gl.TEXTURE_2D, res.normal);
@@ -110,6 +114,14 @@ export class XbrShader {
     gl.activeTexture(gl.TEXTURE12);
     gl.bindTexture(gl.TEXTURE_2D, res.surfaceNormalGreen);
     gl.uniform1i(this.uSurfaceNormalGreen, 12);
+
+    gl.activeTexture(gl.TEXTURE13);
+    gl.bindTexture(gl.TEXTURE_2D, res.framebufferRawMapEdgesTexture2);
+    gl.uniform1i(this.uRawMapEdgesTexture2, 13);
+
+    gl.activeTexture(gl.TEXTURE14);
+    gl.bindTexture(gl.TEXTURE_2D, res.framebufferRawMapTexture2);
+    gl.uniform1i(this.uRawMapTexture2, 14);
   }
 
   setScale(scale: number) {


### PR DESCRIPTION
After enabling user metrics for wegbl max texture size in #56, it was
revealed that the second most common reported max texture size was 4096.
This is a problem as the minimum size we support is 8192. Not meeting
this mimimum requirement would leave the map completely black. Having a
chunk of our visitors unable to see our glorious map is a shame, so this
PR reduces the max texture size requirements from 8192 to 4096.

This reduction was done by splitting the map static images that are 5632
pixels wide (provinces, terrain, rivers) into left and right components
of 2816 pixels wide. The individual components have suffixes of `1` and
`2` (numbered from left to right) in order so that this naming scheme
can survive whenever we need to break images up into more than just two
parts (eg: future game support with enhanced textures).

The framebuffer used as a pipeline between the shaders needed to be
broken up into two halves as well.

Last but not least, the provice arrays needed to be adjusted. Since
there are provinces that exceed ID 4096, the texture that province data
is uploaded to needed to wrap onto additional rows. So now when binary
searching for province info, we convert the index into a vector to
fetch. This does require us to allocate a larger array and copy the
province data into it so that resulting data completely fills declared
dimensions (ie: 4096x2), else a warning is emitted.

Another important change is that certain parameters and variables are
declared to have high floating point precision (`highp`). While
`mediump` has seemingly been sufficient on most desktop systems, lower
specced hardware rendered the map poorly as can be seen in [another
issue][0]. With [WebGL2 being based on OpenGL ES 3.0][1], the [OpenGL ES
3.0][2] spec gives flexibility about what exactly `mediump` and `highp`
mean (Section 4.5.1 Range and Precision) but define the `mediump` as at
least a 16 bit floating point number. Per this [stackoverflow
answer][3], it's common for desktop GPUs to map all precision qualifiers
to 32 bit, while mobile GPUs map `mediump` to 16 bits and `highp` to 32
bits. Since 16 bits is not enough to represent every number between 0
and 5632 (citation is needed but basically [go here][4] and enter 5000,
5001, 5002 and see they have the same binary representation), it
therefore is unable to represent every 1/5632 interval between 0 and 1
texture coordinates. The solution is to sprinkle `highp` everywhere that
we are dealing with texture coordinates, so that we can represent every
number in the interval unambiguously. The map now renders beautifully on
mobile GPUs.

The webgl context options have been updated and is reported to close #55

This commit also creates the notion of lazily loading and decoding the
terrain overlay textures. If the user opts into the terrain overlay, the
textures are then fetched and decoded. Not opted users in could see the
map render up to 1 second faster.

The map class now exposes an `onDraw` event handler so that it is easier
to configure logging of map events.

[0]: https://github.com/pdx-tools/pdx-tools/issues/16#issuecomment-1020096549
[1]: https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext
[2]: https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf
[3]: https://stackoverflow.com/a/46833587
[4]: https://evanw.github.io/float-toy/