### PR TITLE
Configure and update sentry to latest

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ export EU4_IRONMAN_TOKENS := `pwd | xargs printf "%s/assets/tokens/eu4.txt"`
 export HOI4_IRONMAN_TOKENS := `pwd | xargs printf "%s/assets/tokens/hoi4.txt"`
 export CK3_IRONMAN_TOKENS := `pwd | xargs printf "%s/assets/tokens/ck3.txt"`
 export IMPERATOR_TOKENS := `pwd | xargs printf "%s/assets/tokens/imperator.txt"`
+export NEXT_PUBLIC_SENTRY_DSN := `echo ${SENTRY_DSN:-''}`
 
 build: touch-tokens build-wasm build-napi build-app build-docker
 

--- a/src/app/next.config.js
+++ b/src/app/next.config.js
@@ -42,11 +42,11 @@ let nextConfig = {
 };
 
 if (process.env.SENTRY_DSN) {
-  nextConfig = withSentryConfig(nextConfig, {
+  nextConfig = withSentryConfig(nextConfig,{
     silent: true,
-    include: [
-      { paths: [".next/static/chunks"], urlPrefix: "~/_next/static/chunks" },
-    ],
+    include: [{
+      paths: [".next/static/chunks"], urlPrefix: "~/_next/static/chunks"
+    }],
   });
 }
 

--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -11,7 +11,7 @@
         "@ant-design/charts": "^1.2.5",
         "@prisma/client": "^3.8.1",
         "@reduxjs/toolkit": "^1.7.1",
-        "@sentry/nextjs": "^6.16.1",
+        "@sentry/nextjs": "^6.17.4",
         "antd": "^4.15.6",
         "aws-sdk": "^2.1054.0",
         "comlink": "^4.3.1",
@@ -2433,13 +2433,13 @@
       "dev": true
     },
     "node_modules/@sentry/browser": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.16.1.tgz",
-      "integrity": "sha512-F2I5RL7RTLQF9CccMrqt73GRdK3FdqaChED3RulGQX5lH6U3exHGFxwyZxSrY4x6FedfBFYlfXWWCJXpLnFkow==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.17.4.tgz",
+      "integrity": "sha512-ezLZ/FP2ZJPPemzGKMiu8RCHvuRYfDYXbkQb9KhUbpylJokL4GSRZHy8EYkcHugnvAiov7p8cdj7QgOZQPDAgw==",
       "dependencies": {
-        "@sentry/core": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/core": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2452,14 +2452,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/cli": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.71.0.tgz",
-      "integrity": "sha512-Z8TzH7PkiRfjWSzjXOfPWWp6wxjr+n39Jdrt26OcInVQZM1sx/gZULrDiQZ1L2dy9Fe9AR4SF4nt2/7h2GmLQQ==",
+      "version": "1.72.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.72.1.tgz",
+      "integrity": "sha512-SCh32bMYnkCZd4Old/GjArnjtyt3PuQXC6fOmBqKWPpvi56H3rYYjrT0FVxRRu8ovU2Qws1AhPdUbLPOEEj8lQ==",
       "hasInstallScript": true,
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
         "mkdirp": "^0.5.5",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.7",
         "npmlog": "^4.1.2",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0"
@@ -2471,15 +2471,34 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@sentry/core": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.16.1.tgz",
-      "integrity": "sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==",
+    "node_modules/@sentry/cli/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.17.4.tgz",
+      "integrity": "sha512-7QFgw+I9YK/X1Gie0c7phwT5pHMow66UCXHzDzHR2aK/0X3Lhn8OWlcGjIt5zmiBK/LHwNfQBNMskbktbYHgdA==",
+      "dependencies": {
+        "@sentry/hub": "6.17.4",
+        "@sentry/minimal": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2492,12 +2511,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/hub": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.16.1.tgz",
-      "integrity": "sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.17.4.tgz",
+      "integrity": "sha512-6+EvPcrPCwUmayeieIpm1ZrRNWriqMHWZFyw+MzunFLgG8IH8G45cJU1zNnTY9Jwwg4sFIS9xrHy3AOkctnIGw==",
       "dependencies": {
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2510,12 +2529,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/integrations": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.16.1.tgz",
-      "integrity": "sha512-YobbH3jWMRJxCeFzr8USlju1Up0EJoxaAT4y+LQQ0ZLfyfOdPX0d0iFnWMCar8gwR1nRujFS0HM0BBKY3an0LA==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.17.4.tgz",
+      "integrity": "sha512-NmFbv9w4AK1d4NYi0beTuJgn6t81bdiGZmkNZ9VKVI0mBfoZfwxIo7fGNrla3HMkeTwLHntXuzUu4v+w1EARqA==",
       "dependencies": {
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       },
@@ -2529,12 +2548,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.16.1.tgz",
-      "integrity": "sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.17.4.tgz",
+      "integrity": "sha512-p1A8UTtRt7bhV4ygu7yDNCannFr9E9dmqgeZWC7HrrTfygcnhNRFvTXTj92wEb0bFKuZr67wPSKnoXlkqkGxsw==",
       "dependencies": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/types": "6.16.1",
+        "@sentry/hub": "6.17.4",
+        "@sentry/types": "6.17.4",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2547,18 +2566,18 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/nextjs": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-6.16.1.tgz",
-      "integrity": "sha512-HrQGJ7Y4MLDC3BVS5z4BPiGZAa3Ed0sjiMAcWeBXyCF2pBZNzfhE63v26nBYcHQfKEncGkXScxBAeDfz0EcusQ==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-6.17.4.tgz",
+      "integrity": "sha512-qdXKo/GjXmYJr5rZs2CbTh17vj+H+/rH1HYJvVnhK1XFflCx0qUn5M2hV/nfuDFzKk2Bo9HKNNl7jxHB1nlVjg==",
       "dependencies": {
-        "@sentry/core": "6.16.1",
-        "@sentry/hub": "6.16.1",
-        "@sentry/integrations": "6.16.1",
-        "@sentry/node": "6.16.1",
-        "@sentry/react": "6.16.1",
-        "@sentry/tracing": "6.16.1",
-        "@sentry/utils": "6.16.1",
-        "@sentry/webpack-plugin": "1.18.3",
+        "@sentry/core": "6.17.4",
+        "@sentry/hub": "6.17.4",
+        "@sentry/integrations": "6.17.4",
+        "@sentry/node": "6.17.4",
+        "@sentry/react": "6.17.4",
+        "@sentry/tracing": "6.17.4",
+        "@sentry/utils": "6.17.4",
+        "@sentry/webpack-plugin": "1.18.4",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2576,15 +2595,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.16.1.tgz",
-      "integrity": "sha512-SeDDoug2kUxeF1D7JGPa3h5EXxKtmA01mITBPYx5xbJ0sMksnv5I5bC1SJ8arRRzq6+W1C4IEeDBQtrVCk6ixA==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.17.4.tgz",
+      "integrity": "sha512-LpC07HsobBiFrNLe16ubgHGw95+7+3fEBhSn58r48j68c4Qak3fDmpR1Uy0rhyX1Nr/WFdlE/4npkgJw+1lN/w==",
       "dependencies": {
-        "@sentry/core": "6.16.1",
-        "@sentry/hub": "6.16.1",
-        "@sentry/tracing": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/core": "6.17.4",
+        "@sentry/hub": "6.17.4",
+        "@sentry/tracing": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -2600,14 +2619,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/react": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.16.1.tgz",
-      "integrity": "sha512-n8fOEKbym4kBi946q3AWXBNy1UKTmABj/hE2nAJbTWhi5IwdM7WBG6QCT2yq7oTHLuTxQrAwgKQc+A6zFTyVHg==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.17.4.tgz",
+      "integrity": "sha512-MNS207wkjhUOLmbqvvtObLwTmT0+lBT0r9IAC1rSyzfrlS3teUEn36ycg0wP7S32VDkqM8kic6yQHCzCIAvj8A==",
       "dependencies": {
-        "@sentry/browser": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/browser": "6.17.4",
+        "@sentry/minimal": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
       },
@@ -2624,14 +2643,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.16.1.tgz",
-      "integrity": "sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.17.4.tgz",
+      "integrity": "sha512-UV6wWH/fqndts0k0cptsNtzD0h8KXqHInJSCGqlWDlygFRO16jwMKv0wfXgqsgc3cBGDlsl8C4l6COSwz9ROdg==",
       "dependencies": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/hub": "6.17.4",
+        "@sentry/minimal": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2644,19 +2663,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
-      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.17.4.tgz",
+      "integrity": "sha512-RUyiXCKf61k2GIMP7FQX0naoSew4zLxe+UrtbjwVcWU4AFPZfH7tLNtTpVE85zAKbxsaiq3OD2FPtTZarHcwxQ==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
-      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.17.4.tgz",
+      "integrity": "sha512-+ENzZbrlVL1JJ+FoK2EOS27nbA/yToeaJPFlyVOnbthUxVyN3TTi9Uzn9F05fIE/2BTkOEk89wPtgcHafgrD6A==",
       "dependencies": {
-        "@sentry/types": "6.16.1",
+        "@sentry/types": "6.17.4",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2669,11 +2688,11 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/webpack-plugin": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.18.3.tgz",
-      "integrity": "sha512-Qk3Jevislc5DZK0X/WwRVcOtO7iatnWARsEgTV/TuXvDN+fUDDpD/2MytAWAbpLaLy3xEB/cXGeLsbv6d1XNkQ==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.18.4.tgz",
+      "integrity": "sha512-1NVnxCmNxcJ7+UQwpMGiSEFNgc52vGCZ0pjpfvmmtJMxnJFYnSNy2vTVStL4xwGMe6vLR9luJRT9Smoy3lxJYg==",
       "dependencies": {
-        "@sentry/cli": "^1.70.1"
+        "@sentry/cli": "^1.72.0"
       },
       "engines": {
         "node": ">= 8"
@@ -11356,6 +11375,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
@@ -11602,6 +11626,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
     "node_modules/webpack": {
       "version": "5.65.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.65.0.tgz",
@@ -11718,6 +11747,15 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
       "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -13814,13 +13852,13 @@
       "dev": true
     },
     "@sentry/browser": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.16.1.tgz",
-      "integrity": "sha512-F2I5RL7RTLQF9CccMrqt73GRdK3FdqaChED3RulGQX5lH6U3exHGFxwyZxSrY4x6FedfBFYlfXWWCJXpLnFkow==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.17.4.tgz",
+      "integrity": "sha512-ezLZ/FP2ZJPPemzGKMiu8RCHvuRYfDYXbkQb9KhUbpylJokL4GSRZHy8EYkcHugnvAiov7p8cdj7QgOZQPDAgw==",
       "requires": {
-        "@sentry/core": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/core": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -13832,27 +13870,37 @@
       }
     },
     "@sentry/cli": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.71.0.tgz",
-      "integrity": "sha512-Z8TzH7PkiRfjWSzjXOfPWWp6wxjr+n39Jdrt26OcInVQZM1sx/gZULrDiQZ1L2dy9Fe9AR4SF4nt2/7h2GmLQQ==",
+      "version": "1.72.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.72.1.tgz",
+      "integrity": "sha512-SCh32bMYnkCZd4Old/GjArnjtyt3PuQXC6fOmBqKWPpvi56H3rYYjrT0FVxRRu8ovU2Qws1AhPdUbLPOEEj8lQ==",
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "mkdirp": "^0.5.5",
-        "node-fetch": "^2.6.0",
+        "node-fetch": "^2.6.7",
         "npmlog": "^4.1.2",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "@sentry/core": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.16.1.tgz",
-      "integrity": "sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.17.4.tgz",
+      "integrity": "sha512-7QFgw+I9YK/X1Gie0c7phwT5pHMow66UCXHzDzHR2aK/0X3Lhn8OWlcGjIt5zmiBK/LHwNfQBNMskbktbYHgdA==",
       "requires": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/hub": "6.17.4",
+        "@sentry/minimal": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -13864,12 +13912,12 @@
       }
     },
     "@sentry/hub": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.16.1.tgz",
-      "integrity": "sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.17.4.tgz",
+      "integrity": "sha512-6+EvPcrPCwUmayeieIpm1ZrRNWriqMHWZFyw+MzunFLgG8IH8G45cJU1zNnTY9Jwwg4sFIS9xrHy3AOkctnIGw==",
       "requires": {
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -13881,12 +13929,12 @@
       }
     },
     "@sentry/integrations": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.16.1.tgz",
-      "integrity": "sha512-YobbH3jWMRJxCeFzr8USlju1Up0EJoxaAT4y+LQQ0ZLfyfOdPX0d0iFnWMCar8gwR1nRujFS0HM0BBKY3an0LA==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.17.4.tgz",
+      "integrity": "sha512-NmFbv9w4AK1d4NYi0beTuJgn6t81bdiGZmkNZ9VKVI0mBfoZfwxIo7fGNrla3HMkeTwLHntXuzUu4v+w1EARqA==",
       "requires": {
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       },
@@ -13899,12 +13947,12 @@
       }
     },
     "@sentry/minimal": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.16.1.tgz",
-      "integrity": "sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.17.4.tgz",
+      "integrity": "sha512-p1A8UTtRt7bhV4ygu7yDNCannFr9E9dmqgeZWC7HrrTfygcnhNRFvTXTj92wEb0bFKuZr67wPSKnoXlkqkGxsw==",
       "requires": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/types": "6.16.1",
+        "@sentry/hub": "6.17.4",
+        "@sentry/types": "6.17.4",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -13916,18 +13964,18 @@
       }
     },
     "@sentry/nextjs": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-6.16.1.tgz",
-      "integrity": "sha512-HrQGJ7Y4MLDC3BVS5z4BPiGZAa3Ed0sjiMAcWeBXyCF2pBZNzfhE63v26nBYcHQfKEncGkXScxBAeDfz0EcusQ==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-6.17.4.tgz",
+      "integrity": "sha512-qdXKo/GjXmYJr5rZs2CbTh17vj+H+/rH1HYJvVnhK1XFflCx0qUn5M2hV/nfuDFzKk2Bo9HKNNl7jxHB1nlVjg==",
       "requires": {
-        "@sentry/core": "6.16.1",
-        "@sentry/hub": "6.16.1",
-        "@sentry/integrations": "6.16.1",
-        "@sentry/node": "6.16.1",
-        "@sentry/react": "6.16.1",
-        "@sentry/tracing": "6.16.1",
-        "@sentry/utils": "6.16.1",
-        "@sentry/webpack-plugin": "1.18.3",
+        "@sentry/core": "6.17.4",
+        "@sentry/hub": "6.17.4",
+        "@sentry/integrations": "6.17.4",
+        "@sentry/node": "6.17.4",
+        "@sentry/react": "6.17.4",
+        "@sentry/tracing": "6.17.4",
+        "@sentry/utils": "6.17.4",
+        "@sentry/webpack-plugin": "1.18.4",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -13939,15 +13987,15 @@
       }
     },
     "@sentry/node": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.16.1.tgz",
-      "integrity": "sha512-SeDDoug2kUxeF1D7JGPa3h5EXxKtmA01mITBPYx5xbJ0sMksnv5I5bC1SJ8arRRzq6+W1C4IEeDBQtrVCk6ixA==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.17.4.tgz",
+      "integrity": "sha512-LpC07HsobBiFrNLe16ubgHGw95+7+3fEBhSn58r48j68c4Qak3fDmpR1Uy0rhyX1Nr/WFdlE/4npkgJw+1lN/w==",
       "requires": {
-        "@sentry/core": "6.16.1",
-        "@sentry/hub": "6.16.1",
-        "@sentry/tracing": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/core": "6.17.4",
+        "@sentry/hub": "6.17.4",
+        "@sentry/tracing": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -13962,14 +14010,14 @@
       }
     },
     "@sentry/react": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.16.1.tgz",
-      "integrity": "sha512-n8fOEKbym4kBi946q3AWXBNy1UKTmABj/hE2nAJbTWhi5IwdM7WBG6QCT2yq7oTHLuTxQrAwgKQc+A6zFTyVHg==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-6.17.4.tgz",
+      "integrity": "sha512-MNS207wkjhUOLmbqvvtObLwTmT0+lBT0r9IAC1rSyzfrlS3teUEn36ycg0wP7S32VDkqM8kic6yQHCzCIAvj8A==",
       "requires": {
-        "@sentry/browser": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/browser": "6.17.4",
+        "@sentry/minimal": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "hoist-non-react-statics": "^3.3.2",
         "tslib": "^1.9.3"
       },
@@ -13982,14 +14030,14 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.16.1.tgz",
-      "integrity": "sha512-MPSbqXX59P+OEeST+U2V/8Hu/8QjpTUxTNeNyTHWIbbchdcMMjDbXTS3etCgajZR6Ro+DHElOz5cdSxH6IBGlA==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.17.4.tgz",
+      "integrity": "sha512-UV6wWH/fqndts0k0cptsNtzD0h8KXqHInJSCGqlWDlygFRO16jwMKv0wfXgqsgc3cBGDlsl8C4l6COSwz9ROdg==",
       "requires": {
-        "@sentry/hub": "6.16.1",
-        "@sentry/minimal": "6.16.1",
-        "@sentry/types": "6.16.1",
-        "@sentry/utils": "6.16.1",
+        "@sentry/hub": "6.17.4",
+        "@sentry/minimal": "6.17.4",
+        "@sentry/types": "6.17.4",
+        "@sentry/utils": "6.17.4",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -14001,16 +14049,16 @@
       }
     },
     "@sentry/types": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.16.1.tgz",
-      "integrity": "sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ=="
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.17.4.tgz",
+      "integrity": "sha512-RUyiXCKf61k2GIMP7FQX0naoSew4zLxe+UrtbjwVcWU4AFPZfH7tLNtTpVE85zAKbxsaiq3OD2FPtTZarHcwxQ=="
     },
     "@sentry/utils": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.16.1.tgz",
-      "integrity": "sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==",
+      "version": "6.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.17.4.tgz",
+      "integrity": "sha512-+ENzZbrlVL1JJ+FoK2EOS27nbA/yToeaJPFlyVOnbthUxVyN3TTi9Uzn9F05fIE/2BTkOEk89wPtgcHafgrD6A==",
       "requires": {
-        "@sentry/types": "6.16.1",
+        "@sentry/types": "6.17.4",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -14022,11 +14070,11 @@
       }
     },
     "@sentry/webpack-plugin": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.18.3.tgz",
-      "integrity": "sha512-Qk3Jevislc5DZK0X/WwRVcOtO7iatnWARsEgTV/TuXvDN+fUDDpD/2MytAWAbpLaLy3xEB/cXGeLsbv6d1XNkQ==",
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.18.4.tgz",
+      "integrity": "sha512-1NVnxCmNxcJ7+UQwpMGiSEFNgc52vGCZ0pjpfvmmtJMxnJFYnSNy2vTVStL4xwGMe6vLR9luJRT9Smoy3lxJYg==",
       "requires": {
-        "@sentry/cli": "^1.70.1"
+        "@sentry/cli": "^1.72.0"
       }
     },
     "@sinonjs/commons": {
@@ -20655,6 +20703,11 @@
         "universalify": "^0.1.2"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "tsconfig-paths": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
@@ -20854,6 +20907,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
     "webpack": {
       "version": "5.65.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.65.0.tgz",
@@ -20942,6 +21000,15 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
       "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -14,7 +14,7 @@
     "@ant-design/charts": "^1.2.5",
     "@prisma/client": "^3.8.1",
     "@reduxjs/toolkit": "^1.7.1",
-    "@sentry/nextjs": "^6.16.1",
+    "@sentry/nextjs": "^6.17.4",
     "antd": "^4.15.6",
     "aws-sdk": "^2.1054.0",
     "comlink": "^4.3.1",

--- a/src/app/sentry.client.config.js
+++ b/src/app/sentry.client.config.js
@@ -8,8 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN,
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.0,
   enabled: process.env.NODE_ENV === "production",
   tunnel: process.env.NODE_ENV === "production" ? "/api/tunnel" : undefined,
   // ...

--- a/src/app/sentry.server.config.js
+++ b/src/app/sentry.server.config.js
@@ -8,8 +8,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
   dsn: SENTRY_DSN,
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.0,
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/src/app/src/features/notifications/hooks.ts
+++ b/src/app/src/features/notifications/hooks.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub } from "@sentry/nextjs";
-import { Event, Dsn } from "@sentry/types";
+import { Event, DsnComponents } from "@sentry/types";
 import { askToSendErrorReport } from "./ReportErrorConfirm";
 
 function eventProcessor(file: File, err: any) {
@@ -29,7 +29,7 @@ function eventProcessor(file: File, err: any) {
   };
 }
 
-function attachmentUrlFromDsn(dsn: Dsn, eventId: string) {
+function attachmentUrlFromDsn(dsn: DsnComponents, eventId: string) {
   const { host, path, projectId, port, protocol, user } = dsn;
   return `${protocol}://${host}${port !== "" ? `:${port}` : ""}${
     path !== "" ? `/${path}` : ""


### PR DESCRIPTION
As part of the migration to pdx.tools, the sentry environment variable
stopped being [exposed to the browser][1]. This cut the app off from
error reporting, leaving us a bit blind to user errors. The fix is to
export `SENTRY_DSN` as `NEXT_PUBLIC_SENTRY_DSN` so that the browser sees
it.

This commit also updates sentry's library to the latest version.

This commit also removes performance trace sampling so that we won't
have to worry about exceeding our quota again.

[1]: https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser