### PR TITLE
Use RAF to avoid resize observer warnings

### DIFF
--- a/src/app/src/features/engine/persistant-canvas-context.tsx
+++ b/src/app/src/features/engine/persistant-canvas-context.tsx
@@ -29,9 +29,14 @@ export const CanvasContextProvider: React.FC<{}> = ({ children }) => {
     const canvas = canvasRef.current;
 
     if (container && canvas) {
+      let resiveObserverAF = 0;
       const ro = new ResizeObserver((_entries) => {
-        const bounds = container.getBoundingClientRect();
-        dispatch(canvasResize([bounds.width, bounds.height]));
+        // Why resive observer has RAF: https://stackoverflow.com/a/58701523
+        cancelAnimationFrame(resiveObserverAF);
+        resiveObserverAF = requestAnimationFrame(() => {
+          const bounds = container.getBoundingClientRect();
+          dispatch(canvasResize([bounds.width, bounds.height]));
+        });
       });
       ro.observe(container);
     }


### PR DESCRIPTION
Should also clear out sentry errors that don't affect site behavior.