### PR TITLE
Fix permission issue for saves on google drive

### DIFF
--- a/src/app/src/features/changelog/changes.tsx
+++ b/src/app/src/features/changelog/changes.tsx
@@ -719,4 +719,14 @@ export const changes: ChangelogEntry[] = [
       );
     },
   },
+  {
+    title: "2022-02-18",
+    render: () => {
+      return (
+        <ChangelogList>
+          <li>🐛 - Fix permission issue for saves on google drive</li>
+        </ChangelogList>
+      );
+    },
+  },
 ];

--- a/src/app/src/features/engine/worker/worker.ts
+++ b/src/app/src/features/engine/worker/worker.ts
@@ -18,9 +18,9 @@ import {
 } from "./imperator";
 
 export type AnalyzeSource =
-  | { kind: "local"; file: File }
-  | { kind: "server"; saveId: string }
-  | { kind: "skanderbeg"; skanId: string };
+  | { kind: "local"; data: Uint8Array; name: string }
+  | { kind: "server"; saveId: string; data: Uint8Array }
+  | { kind: "skanderbeg"; skanId: string; data: Uint8Array };
 
 export type AnalyzeResponse =
   | { kind: "eu4"; meta: EnhancedMeta; achievements: Achievements }
@@ -54,21 +54,11 @@ const obj = {
   ): Promise<AnalyzeResponse> {
     switch (source.kind) {
       case "local": {
-        var [bytes, elapsedMs] = await timeit(
-          async () => new Uint8Array(await source.file.arrayBuffer())
-        );
-
-        options?.progress({
-          kind: "bytes read",
-          amount: bytes.length,
-          percent: 10,
-          elapsedMs: elapsedMs,
-        });
-
+        const bytes = source.data;
         setRawData(bytes);
 
         const kind =
-          extensionType(source.file.name) ?? (await detectType(bytes, options));
+          extensionType(source.name) ?? (await detectType(bytes, options));
         switch (kind) {
           case "eu4": {
             const results = await initializeEu4(bytes, options);


### PR DESCRIPTION
On my phone I was receiving the following error when I selected a save
in google drive:

> The requested file could not be read, typically due to permission
> problems that have occurred after a reference to a file was acquired.

The fix is to read the save before transferring it to a web worker. Not
sure of the technical explanation of this or where it is documented, but
it worked, so I won't question it.

After this fix, I can confirm that I can load saves from google drive
and microsoft one drive from my phone and so closes #78