### PR TITLE
Hide map tip while pointer is down

### DIFF
--- a/src/app/src/features/changelog/changes.tsx
+++ b/src/app/src/features/changelog/changes.tsx
@@ -725,6 +725,7 @@ export const changes: ChangelogEntry[] = [
       return (
         <ChangelogList>
           <li>🐛 - Fix permission issue for saves on google drive</li>
+          <li>🐛 - Fix map tips appearing when panning the map</li>
         </ChangelogList>
       );
     },

--- a/src/app/src/features/eu4/features/map/MapTip.tsx
+++ b/src/app/src/features/eu4/features/map/MapTip.tsx
@@ -32,16 +32,30 @@ export const MapTip: React.FC<{}> = () => {
   const isMounted = useIsMounted();
 
   useEffect(() => {
+    let isDown = false;
+
     function pointerMove(e: PointerEvent) {
       setPointerDisplay(
-        e.target instanceof Element && e.target.nodeName == "CANVAS"
+        !isDown && e.target instanceof Element && e.target.nodeName == "CANVAS"
       );
       setPointer({ x: e.x, y: e.y });
     }
 
+    function pointerDown() {
+      isDown = true;
+    }
+
+    function pointerUp() {
+      isDown = false;
+    }
+
     document.addEventListener("pointermove", pointerMove, false);
+    document.addEventListener("pointerdown", pointerDown, false);
+    document.addEventListener("pointerup", pointerUp, false);
     return () => {
       document.removeEventListener("pointermove", pointerMove, false);
+      document.removeEventListener("pointerdown", pointerDown, false);
+      document.removeEventListener("pointerup", pointerUp, false);
     };
   }, [toolTipRef]);
 


### PR DESCRIPTION
If someone is panning on the map, the map tip should not be visible.

Closes #76