### PR TITLE
Disable zooming on canvas UI on touchscreens

### DIFF
--- a/src/app/src/features/changelog/changes.tsx
+++ b/src/app/src/features/changelog/changes.tsx
@@ -726,6 +726,7 @@ export const changes: ChangelogEntry[] = [
         <ChangelogList>
           <li>🐛 - Fix permission issue for saves on google drive</li>
           <li>🐛 - Fix map tips appearing when panning the map</li>
+          <li>🐛 - Fix possibility for accidental zoom on map UI controls</li>
         </ChangelogList>
       );
     },

--- a/src/app/src/features/eu4/Eu4CanvasOverlay.tsx
+++ b/src/app/src/features/eu4/Eu4CanvasOverlay.tsx
@@ -23,7 +23,6 @@ import { selectEu4MapDate } from "./eu4Slice";
 import { selectModuleDrawn } from "../engine";
 import { MapTip } from "./features/map/MapTip";
 import { MapZoomSideBar } from "./components/zoom";
-import { log } from "@/lib/log";
 
 const { className, styles } = css.resolve`
   span {
@@ -81,8 +80,8 @@ export const Eu4CanvasOverlay: React.FC<{}> = () => {
   return (
     <>
       <MapTip />
-      <div className="date-overlay">{mapDate.text}</div>
-      <div className="ui-sidebar">
+      <div className="date-overlay touch-none">{mapDate.text}</div>
+      <div className="ui-sidebar touch-none">
         <div className="flex-col gap">{buttons.map((x, i) => x(i))}</div>
         {styles}
       </div>

--- a/src/app/src/features/eu4/components/map-modes/MapModeBar.tsx
+++ b/src/app/src/features/eu4/components/map-modes/MapModeBar.tsx
@@ -6,7 +6,7 @@ import { selectModuleDrawn } from "@/features/engine";
 export const MapModeSideBar: React.FC<{}> = () => {
   const hasDrawn = useSelector(selectModuleDrawn);
   return (
-    <div className="map-mode-sidebar">
+    <div className="map-mode-sidebar touch-none">
       <div className="map-mode-container">
         <MapModeButtonGroup />
       </div>

--- a/src/app/src/features/eu4/components/zoom/MapZoomSideBar.tsx
+++ b/src/app/src/features/eu4/components/zoom/MapZoomSideBar.tsx
@@ -4,7 +4,7 @@ import { ZoomOutSideBarButton } from "./ZoomOutSideBarButton";
 
 export const MapZoomSideBar: React.FC<{}> = () => {
   return (
-    <div className="container">
+    <div className="container touch-none">
       <ZoomInSideBarButton key="zoom-in">
         <PlusOutlined />
       </ZoomInSideBarButton>

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -94,3 +94,7 @@
 .font-bold {
   font-weight: 700;
 }
+
+.touch-none {
+  touch-action: none;
+}


### PR DESCRIPTION
Does not effect desktop as it matches google maps behavior of zoom on
desktop.

Closes #75