### PR TITLE
Decouple binary tokens from Wasm and support CK3 1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,11 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-s3",
+ "brotli",
  "chrono",
  "filetime",
  "pico-args",
+ "schemas",
  "tokio",
  "tokio-stream",
  "walkdir",
@@ -539,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "ck3save"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c883ac5c6dbb3e51d3856008e2c998b3296d57d6aa8fe73cc02025778f89f87"
+checksum = "a3bc057fddadf0ecef12d9f6a70b6c6874b03f5681eef968d15b6deda9c1224f"
 dependencies = [
  "jomini",
  "serde",
@@ -773,6 +775,7 @@ dependencies = [
  "base64",
  "eu4save",
  "highway",
+ "jomini",
  "regex",
  "schemas",
  "serde",
@@ -783,8 +786,8 @@ dependencies = [
 
 [[package]]
 name = "eu4save"
-version = "0.5.4-pre"
-source = "git+https://github.com/rakaly/eu4save.git#14fd0338d219871d36e16f7bcadf1ea58643b446"
+version = "0.6.0"
+source = "git+https://github.com/rakaly/eu4save.git#b34bd28dcafcd60808b839315f28c225c01f945f"
 dependencies = [
  "jomini",
  "once_cell",
@@ -982,9 +985,9 @@ checksum = "a310093553e2397bd2936564960446b23233864bbffee554ec5847572e2dfd93"
 
 [[package]]
 name = "hoi4save"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83fcd7db71013cc05f9861bdc772f747d78e366699d655c076223cb843a47f3"
+checksum = "267f861faa547084e68733a120421d80e47fb136a905d8f4027f722fb0674228"
 dependencies = [
  "jomini",
  "serde",
@@ -1093,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "imperator-save"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e16910112cc2b321a1855c762031e1ab981f9bf2116bdaffe7406c8a741b2d7"
+checksum = "17bff072bd99f8d72007d837f41a6242a8c0d065e5afdc5e32bbea19b8384cd3"
 dependencies = [
  "jomini",
  "serde",
@@ -1154,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "jomini"
-version = "0.16.4"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384eb9d2415aeaaf18ec9cac341262c3d6a52fa7553232ce134f61ecfed31def"
+checksum = "727d2dad092c91afd844ddc524b8ba2c2b8bb4d6bc86099a65d00ba266d20e75"
 dependencies = [
  "jomini_derive",
  "serde",
@@ -2401,7 +2404,9 @@ name = "wasm-ck3"
 version = "0.1.0"
 dependencies = [
  "ck3save",
+ "jomini",
  "js-sys",
+ "schemas",
  "serde",
  "wasm-bindgen",
 ]
@@ -2420,6 +2425,7 @@ version = "0.1.0"
 dependencies = [
  "eu4game",
  "eu4save",
+ "jomini",
  "js-sys",
  "schemas",
  "serde",
@@ -2435,7 +2441,9 @@ name = "wasm-hoi4"
 version = "0.1.0"
 dependencies = [
  "hoi4save",
+ "jomini",
  "js-sys",
+ "schemas",
  "serde",
  "wasm-bindgen",
 ]
@@ -2445,7 +2453,9 @@ name = "wasm-imperator"
 version = "0.1.0"
 dependencies = [
  "imperator-save",
+ "jomini",
  "js-sys",
+ "schemas",
  "serde",
  "wasm-bindgen",
 ]

--- a/justfile
+++ b/justfile
@@ -118,6 +118,13 @@ build-wasm: build-wasm-dev
   wait
 
 build-wasm-dev:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  unset EU4_IRONMAN_TOKENS
+  unset HOI4_IRONMAN_TOKENS
+  unset CK3_IRONMAN_TOKENS
+  unset IMPERATOR_TOKENS
+
   wasm-pack build -t web src/wasm-br
   wasm-pack build -t web src/wasm-ck3
   wasm-pack build -t web src/wasm-detect
@@ -129,7 +136,7 @@ build-napi:
   cargo build --release -p applib-node
   cp -f ./target/release/libapplib_node.so ./src/app/src/server-lib/applib.node
 
-package-all *opts: touch-tokens
+package-all *opts: touch-tokens admin-tokenize
   #!/usr/bin/env bash
   set -euxo pipefail
   package() {
@@ -207,6 +214,9 @@ backup-saves ENVIRONMENT:
 admin-sync-assets:
   cargo build --release -p assets
   ACCESS_KEY="${ASSETS_ACCESS_KEY}" SECRET_KEY="${ASSETS_SECRET_KEY}" ./target/release/assets sync-assets
+
+admin-tokenize:
+  cargo run --release -p assets -- tokenize
 
 format:
   cargo fmt

--- a/src/app/src/features/engine/worker/ck3/init.ts
+++ b/src/app/src/features/engine/worker/ck3/init.ts
@@ -5,12 +5,22 @@ import { ck3Metadata } from "./module";
 import { timeit } from "../worker-lib";
 import { AnalyzeOptions } from "../worker-types";
 
-let wasmInitialized: Promise<wasmModule.InitOutput> | undefined = undefined;
+let wasmInitialized: Promise<void> | undefined = undefined;
+
+async function loadWasm() {
+  const wasmInit = init(wasmPath);
+  const tokenLocation = require("../../../../../../../assets/tokens/ck3.bin");
+  const tokenResp = await fetch(tokenLocation);
+  const tokenData = await tokenResp.arrayBuffer();
+  await wasmInit;
+  wasmModule.set_tokens(new Uint8Array(tokenData));
+}
 
 async function initializeWasm() {
   if (wasmInitialized === undefined) {
-    wasmInitialized = init(wasmPath);
+    wasmInitialized = loadWasm();
   }
+
   await wasmInitialized;
 }
 

--- a/src/app/src/features/engine/worker/eu4/init.ts
+++ b/src/app/src/features/engine/worker/eu4/init.ts
@@ -11,12 +11,22 @@ import { eu4SetMeta, eu4SetSaveFile } from "./common";
 import { timeit } from "../worker-lib";
 import { AnalyzeOptions } from "../worker-types";
 
-let wasmInitialized: Promise<wasmModule.InitOutput> | undefined = undefined;
+let wasmInitialized: Promise<void> | undefined = undefined;
+
+async function loadWasm() {
+  const wasmInit = init(wasmPath);
+  const tokenLocation = require("../../../../../../../assets/tokens/eu4.bin");
+  const tokenResp = await fetch(tokenLocation);
+  const tokenData = await tokenResp.arrayBuffer();
+  await wasmInit;
+  wasmModule.set_tokens(new Uint8Array(tokenData));
+}
 
 async function initializeWasm() {
   if (wasmInitialized === undefined) {
-    wasmInitialized = init(wasmPath);
+    wasmInitialized = loadWasm();
   }
+
   await wasmInitialized;
 }
 

--- a/src/app/src/features/engine/worker/hoi4/init.ts
+++ b/src/app/src/features/engine/worker/hoi4/init.ts
@@ -5,12 +5,22 @@ import { hoi4Metadata } from "./module";
 import { timeit } from "../worker-lib";
 import { AnalyzeOptions } from "../worker-types";
 
-let wasmInitialized: Promise<wasmModule.InitOutput> | undefined = undefined;
+let wasmInitialized: Promise<void> | undefined = undefined;
+
+async function loadWasm() {
+  const wasmInit = init(wasmPath);
+  const tokenLocation = require("../../../../../../../assets/tokens/hoi4.bin");
+  const tokenResp = await fetch(tokenLocation);
+  const tokenData = await tokenResp.arrayBuffer();
+  await wasmInit;
+  wasmModule.set_tokens(new Uint8Array(tokenData));
+}
 
 async function initializeWasm() {
   if (wasmInitialized === undefined) {
-    wasmInitialized = init(wasmPath);
+    wasmInitialized = loadWasm();
   }
+
   await wasmInitialized;
 }
 

--- a/src/app/src/features/engine/worker/imperator/init.ts
+++ b/src/app/src/features/engine/worker/imperator/init.ts
@@ -5,12 +5,22 @@ import { imperatorMetadata } from "./module";
 import { timeit } from "../worker-lib";
 import { AnalyzeOptions } from "../worker-types";
 
-let wasmInitialized: Promise<wasmModule.InitOutput> | undefined = undefined;
+let wasmInitialized: Promise<void> | undefined = undefined;
+
+async function loadWasm() {
+  const wasmInit = init(wasmPath);
+  const tokenLocation = require("../../../../../../../assets/tokens/imperator.bin");
+  const tokenResp = await fetch(tokenLocation);
+  const tokenData = await tokenResp.arrayBuffer();
+  await wasmInit;
+  wasmModule.set_tokens(new Uint8Array(tokenData));
+}
 
 async function initializeWasm() {
   if (wasmInitialized === undefined) {
-    wasmInitialized = init(wasmPath);
+    wasmInitialized = loadWasm();
   }
+
   await wasmInitialized;
 }
 

--- a/src/assets/Cargo.toml
+++ b/src/assets/Cargo.toml
@@ -10,9 +10,11 @@ publish = false
 anyhow = "1"
 aws-config = "0.4.1"
 aws-sdk-s3 = "0.4.1"
+brotli = "3"
 chrono = "0.4"
 filetime = "0.2"
 pico-args = "0.4"
+schemas = { path = "../schemas" }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1.8"
 walkdir = "2"

--- a/src/assets/src/brotli_tee.rs
+++ b/src/assets/src/brotli_tee.rs
@@ -1,0 +1,1 @@
+../../packager/src/brotli_tee.rs

--- a/src/assets/src/main.rs
+++ b/src/assets/src/main.rs
@@ -1,14 +1,18 @@
 use anyhow::bail;
 
+mod brotli_tee;
 mod sync_assets;
+mod tokenize;
 
 enum Subcommand {
     SyncAssets,
+    Tokenize,
 }
 
 fn interpret_subcommand(input: Option<&str>) -> anyhow::Result<Subcommand> {
     match input {
         Some("sync-assets") => Ok(Subcommand::SyncAssets),
+        Some("tokenize") => Ok(Subcommand::Tokenize),
         Some(_) => bail!("unrecognized subcommand, must be reprocess"),
         None => bail!("must provide subcommand"),
     }
@@ -20,5 +24,6 @@ fn main() -> anyhow::Result<()> {
 
     match command {
         Subcommand::SyncAssets => sync_assets::cmd(args),
+        Subcommand::Tokenize => tokenize::cmd(args),
     }
 }

--- a/src/assets/src/tokenize.rs
+++ b/src/assets/src/tokenize.rs
@@ -1,0 +1,80 @@
+use anyhow::Context;
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader},
+    path::Path,
+};
+
+use crate::brotli_tee::BrotliTee;
+
+pub fn cmd(_: pico_args::Arguments) -> anyhow::Result<()> {
+    if let Ok(e) = std::env::var("EU4_IRONMAN_TOKENS") {
+        tokenize_path(&e, Path::new("assets").join("tokens").join("eu4"))?
+    }
+
+    if let Ok(e) = std::env::var("HOI4_IRONMAN_TOKENS") {
+        tokenize_path(&e, Path::new("assets").join("tokens").join("hoi4"))?
+    }
+
+    if let Ok(e) = std::env::var("CK3_IRONMAN_TOKENS") {
+        tokenize_path(&e, Path::new("assets").join("tokens").join("ck3"))?
+    }
+
+    if let Ok(e) = std::env::var("IMPERATOR_TOKENS") {
+        tokenize_path(&e, Path::new("assets").join("tokens").join("imperator"))?
+    }
+
+    Ok(())
+}
+
+fn tokenize_path<P>(path: &str, out: P) -> anyhow::Result<()>
+where
+    P: AsRef<Path>,
+{
+    let reader = File::open(&path).with_context(|| format!("unable to open {path}"))?;
+    let writer = BrotliTee::create(out.as_ref());
+
+    tokenize(reader, writer)
+}
+
+fn tokenize<R, W>(reader: R, mut writer: W) -> anyhow::Result<()>
+where
+    R: io::Read,
+    W: io::Write,
+{
+    let mut buffer = schemas::flatbuffers::FlatBufferBuilder::new();
+    let mut reader = BufReader::new(reader);
+
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = 0u16;
+    let mut line = String::new();
+
+    while reader.read_line(&mut line).unwrap() != 0 {
+        let mut splits = line.splitn(2, ' ');
+        let token_val = splits.next().context("missing token value")?;
+        let z = u16::from_str_radix(token_val.trim_start_matches("0x"), 16)
+            .with_context(|| format!("unable to parse {token_val}"))?;
+
+        for _ in current..z {
+            tokens.push(String::from(""));
+        }
+
+        let token_s = splits.next().context("missing token string")?;
+        tokens.push(String::from(token_s.trim()));
+        current = z + 1;
+        line.clear();
+    }
+
+    let arg: Vec<_> = tokens.iter().map(|x| x.as_ref()).collect();
+    let off = buffer.create_vector_of_strings(&arg);
+
+    let root = schemas::tokens::Tokens::create(
+        &mut buffer,
+        &schemas::tokens::TokensArgs { values: Some(off) },
+    );
+
+    buffer.finish(root, None);
+    let raw = buffer.finished_data();
+    writer.write_all(raw)?;
+    Ok(())
+}

--- a/src/eu4game/Cargo.toml
+++ b/src/eu4game/Cargo.toml
@@ -10,6 +10,7 @@ default = ["embedded"]
 embedded = []
 
 [dependencies]
+jomini = "0.17"
 eu4save = { git = "https://github.com/rakaly/eu4save.git" }
 schemas = { path = "../schemas" }
 tarsave = { path = "../tarsave" }

--- a/src/eu4game/build.rs
+++ b/src/eu4game/build.rs
@@ -6,7 +6,6 @@ use std::{env, fs};
 use regex::Regex;
 
 fn main() {
-    let _ = std::env::var("EU4_IRONMAN_TOKENS").unwrap();
     let entries = fs::read_dir("../../assets/game/eu4").unwrap();
     let re = Regex::new(r"(\d+)\.(\d+)").unwrap();
     let entries = entries.filter_map(|x| x.ok());

--- a/src/packager/Cargo.toml
+++ b/src/packager/Cargo.toml
@@ -11,7 +11,7 @@ tar = "0.4"
 tempfile = "3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-jomini = "0.16"
+jomini = "0.17"
 regex = "1"
 walkdir = "2.3.1" 
 zstd = { version = "0.9", features = ["zstdmt"] }

--- a/src/schemas/build.rs
+++ b/src/schemas/build.rs
@@ -3,8 +3,9 @@ use std::path::Path;
 fn main() {
     if std::env::var("XARGO_HOME").is_err() {
         println!("cargo:rerun-if-changed=src/eu4.fbs");
+        println!("cargo:rerun-if-changed=src/tokens.fbs");
         flatc_rust::run(flatc_rust::Args {
-            inputs: &[Path::new("src/eu4.fbs")],
+            inputs: &[Path::new("src/eu4.fbs"), Path::new("src/tokens.fbs")],
             out_dir: Path::new("target/flatbuffers/"),
             ..Default::default()
         })

--- a/src/schemas/src/lib.rs
+++ b/src/schemas/src/lib.rs
@@ -2,5 +2,10 @@
 #[path = "../target/flatbuffers/eu4_generated.rs"]
 mod eu4_flatbuffers;
 
+#[allow(non_snake_case, unused_imports, clippy::all)]
+#[path = "../target/flatbuffers/tokens_generated.rs"]
+mod tokens_flatbuffers;
+
 pub use eu4_flatbuffers::rakaly::eu_4 as eu4;
 pub use flatbuffers;
+pub use tokens_flatbuffers::rakaly::tokens;

--- a/src/schemas/src/tokens.fbs
+++ b/src/schemas/src/tokens.fbs
@@ -1,0 +1,7 @@
+namespace Rakaly.Tokens;
+
+table Tokens {
+  values:[string];
+}
+
+root_type Tokens;

--- a/src/wasm-ck3/Cargo.toml
+++ b/src/wasm-ck3/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+jomini = "0.17.0"
+schemas = { path = "../schemas" }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 serde = { version = "1", features = ["derive"] }
 ck3save = "0.2"

--- a/src/wasm-ck3/src/lib.rs
+++ b/src/wasm-ck3/src/lib.rs
@@ -2,6 +2,8 @@ use ck3save::{models::HeaderOwned, Encoding, FailedResolveStrategy};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
+mod tokens;
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Ck3Metadata {
@@ -39,7 +41,8 @@ impl SaveFileImpl {
 
 #[wasm_bindgen]
 pub fn parse_save(data: &[u8]) -> Result<SaveFile, JsValue> {
-    let (header, encoding) = ck3save::Ck3Extractor::extract_header(data)
+    let (header, encoding) = ck3save::Ck3Extractor::builder()
+        .extract_header_with_tokens_as(data, tokens::get_tokens())
         .map_err(|e| JsValue::from_str(e.to_string().as_str()))?;
 
     Ok(SaveFile(SaveFileImpl { header, encoding }))
@@ -49,7 +52,7 @@ pub fn parse_save(data: &[u8]) -> Result<SaveFile, JsValue> {
 pub fn melt(data: &[u8]) -> Result<js_sys::Uint8Array, JsValue> {
     let melter = ck3save::Melter::new().with_on_failed_resolve(FailedResolveStrategy::Ignore);
     melter
-        .melt(data)
+        .melt_with_tokens(data, tokens::get_tokens())
         .map(|(x, _)| js_sys::Uint8Array::from(&x[..]))
         .map_err(|e| JsValue::from_str(e.to_string().as_str()))
 }

--- a/src/wasm-ck3/src/tokens.rs
+++ b/src/wasm-ck3/src/tokens.rs
@@ -1,0 +1,1 @@
+../../wasm-eu4/src/tokens.rs

--- a/src/wasm-eu4/Cargo.toml
+++ b/src/wasm-eu4/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+jomini = "0.17"
 js-sys = "0.3"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/wasm-eu4/src/lib.rs
+++ b/src/wasm-eu4/src/lib.rs
@@ -29,6 +29,7 @@ mod country_details;
 mod log;
 mod map;
 mod tag_filter;
+mod tokens;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct LocalizedObj {
@@ -2614,8 +2615,8 @@ impl SaveFileParsed {
 
 #[wasm_bindgen]
 pub fn parse_save(data: &[u8]) -> Result<SaveFileParsed, JsValue> {
-    let (save, encoding) =
-        eu4game::shared::parse_save(data).map_err(|e| JsValue::from_str(e.to_string().as_str()))?;
+    let (save, encoding) = eu4game::shared::parse_save_with_tokens(data, tokens::get_tokens())
+        .map_err(|e| JsValue::from_str(e.to_string().as_str()))?;
 
     Ok(SaveFileParsed(save, encoding))
 }
@@ -2657,12 +2658,12 @@ pub fn melt(data: &[u8]) -> Result<js_sys::Uint8Array, JsValue> {
 
     if let Some(tsave) = tarsave::extract_tarsave(data) {
         melter
-            .melt_entries(tsave.meta, tsave.gamestate, tsave.ai)
+            .melt_entries_with_tokens(tsave.meta, tsave.gamestate, tsave.ai, tokens::get_tokens())
             .map(|(x, _)| js_sys::Uint8Array::from(&x[..]))
             .map_err(|e| JsValue::from_str(e.to_string().as_str()))
     } else {
         melter
-            .melt(data)
+            .melt_with_tokens(data, tokens::get_tokens())
             .map(|(x, _)| js_sys::Uint8Array::from(&x[..]))
             .map_err(|e| JsValue::from_str(e.to_string().as_str()))
     }

--- a/src/wasm-eu4/src/tokens.rs
+++ b/src/wasm-eu4/src/tokens.rs
@@ -1,0 +1,33 @@
+use wasm_bindgen::prelude::*;
+
+static mut TOKEN_DATA: Option<Vec<u8>> = None;
+static mut TOKEN_LOOKUP: Option<TokenIndex<'static>> = None;
+
+pub(crate) struct TokenIndex<'a> {
+    data: Vec<&'a str>,
+}
+
+impl<'a> jomini::TokenResolver for TokenIndex<'a> {
+    fn resolve(&self, token: u16) -> Option<&str> {
+        self.data
+            .get(usize::from(token))
+            .and_then(|x| (!x.is_empty()).then(|| *x))
+    }
+}
+
+pub(crate) fn get_tokens() -> &'static TokenIndex<'static> {
+    let raw = unsafe { &TOKEN_LOOKUP };
+    raw.as_ref().unwrap()
+}
+
+#[wasm_bindgen]
+pub fn set_tokens(data: Vec<u8>) {
+    let sl: &'static [u8] = unsafe { std::mem::transmute(data.as_slice()) };
+    let xb: schemas::tokens::Tokens = schemas::tokens::root_as_tokens(&sl).unwrap();
+    let values = xb.values().unwrap();
+    let tokens = values.iter().collect::<Vec<_>>();
+    unsafe {
+        TOKEN_DATA = Some(data);
+        TOKEN_LOOKUP = Some(TokenIndex { data: tokens })
+    }
+}

--- a/src/wasm-hoi4/Cargo.toml
+++ b/src/wasm-hoi4/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+jomini = "0.17.0"
+schemas = { path = "../schemas" }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 serde = { version = "1", features = ["derive"] }
 hoi4save = "0.1"

--- a/src/wasm-hoi4/src/lib.rs
+++ b/src/wasm-hoi4/src/lib.rs
@@ -2,6 +2,8 @@ use hoi4save::{models::Hoi4Save, Encoding, FailedResolveStrategy, Hoi4Date};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
+mod tokens;
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Hoi4Metadata {
@@ -40,7 +42,7 @@ impl SaveFileImpl {
 #[wasm_bindgen]
 pub fn parse_save(data: &[u8]) -> Result<SaveFile, JsValue> {
     let (save, encoding) = hoi4save::Hoi4Extractor::builder()
-        .extract_save(data)
+        .extract_save_with_tokens(data, tokens::get_tokens())
         .map_err(|e| JsValue::from_str(e.to_string().as_str()))?;
 
     Ok(SaveFile(SaveFileImpl { save, encoding }))
@@ -50,7 +52,7 @@ pub fn parse_save(data: &[u8]) -> Result<SaveFile, JsValue> {
 pub fn melt(data: &[u8]) -> Result<js_sys::Uint8Array, JsValue> {
     let melter = hoi4save::Melter::new().with_on_failed_resolve(FailedResolveStrategy::Ignore);
     melter
-        .melt(data)
+        .melt_with_tokens(data, tokens::get_tokens())
         .map(|(x, _)| js_sys::Uint8Array::from(&x[..]))
         .map_err(|e| JsValue::from_str(e.to_string().as_str()))
 }

--- a/src/wasm-hoi4/src/tokens.rs
+++ b/src/wasm-hoi4/src/tokens.rs
@@ -1,0 +1,1 @@
+../../wasm-eu4/src/tokens.rs

--- a/src/wasm-imperator/Cargo.toml
+++ b/src/wasm-imperator/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+jomini = "0.17.0"
+schemas = { path = "../schemas" }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 serde = { version = "1", features = ["derive"] }
 imperator-save = "0.2"

--- a/src/wasm-imperator/src/lib.rs
+++ b/src/wasm-imperator/src/lib.rs
@@ -2,6 +2,8 @@ use imperator_save::{models::HeaderOwned, Encoding, FailedResolveStrategy, Imper
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
+mod tokens;
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImperatorMetadata {
@@ -41,7 +43,8 @@ impl SaveFileImpl {
 
 #[wasm_bindgen]
 pub fn parse_save(data: &[u8]) -> Result<SaveFile, JsValue> {
-    let (header, encoding) = imperator_save::ImperatorExtractor::extract_header(data)
+    let (header, encoding) = imperator_save::ImperatorExtractor::builder()
+        .extract_header_with_tokens_as(data, tokens::get_tokens())
         .map_err(|e| JsValue::from_str(e.to_string().as_str()))?;
 
     Ok(SaveFile(SaveFileImpl { header, encoding }))
@@ -52,7 +55,7 @@ pub fn melt(data: &[u8]) -> Result<js_sys::Uint8Array, JsValue> {
     let melter =
         imperator_save::Melter::new().with_on_failed_resolve(FailedResolveStrategy::Ignore);
     melter
-        .melt(data)
+        .melt_with_tokens(data, tokens::get_tokens())
         .map(|(x, _)| js_sys::Uint8Array::from(&x[..]))
         .map_err(|e| JsValue::from_str(e.to_string().as_str()))
 }

--- a/src/wasm-imperator/src/tokens.rs
+++ b/src/wasm-imperator/src/tokens.rs
@@ -1,0 +1,1 @@
+../../wasm-eu4/src/tokens.rs


### PR DESCRIPTION
First and foremost this updates CK3 support to melt 1.5 save games.

But the more interesting update is that the binary tokens are no longer
compiled into the Wasm. Now when a game module is instantiated, instead
of fetching just the wasm payload, the tokens are fetched too. This was
done for several reasons:

- As a form of code splitting. Now if only one of the payloads (the wasm
  or tokens) change, the other doesn't need to be redundantly fetched
  too.
- Compile times. Previously it would take 6 minutes (2 to compile, 4 to
  optimize) the HOI4 module. Now it is much shorter -- about 12 seconds
- Preparation for a future where token incompatibility is real and we
  may need to fetch a different token list depending on the save version

Performance thus far seems unaffected.