### PR TITLE
Add support for uploading 1.33 saves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ assets/game/eu4/1.29
 assets/game/eu4/1.30
 assets/game/eu4/1.31
 assets/game/eu4/1.32
+assets/game/eu4/1.33
 assets/game/eu4/common/images/advisors
 assets/game/eu4/common/images/buildings
 assets/game/eu4/common/images/flags

--- a/src/app/src/features/eu4/features/map/Eu4Canvas.ts
+++ b/src/app/src/features/eu4/features/map/Eu4Canvas.ts
@@ -46,10 +46,10 @@ export class Eu4Canvas {
       saveVersion.first == this.loadedVersion?.first &&
       saveVersion.second == this.loadedVersion?.second
     ) {
-      // 1.31 and 1.32 share same map asset
+      // 1.31, 1.32, 1.33 share same map asset
       return (
         [saveVersion.second, this.loadedVersion?.second].filter(
-          (x) => x == 31 || x == 32
+          (x) => x == 31 || x == 32 || x == 33
         ).length == 2
       );
     }

--- a/src/eu4game/src/achievements.rs
+++ b/src/eu4game/src/achievements.rs
@@ -531,10 +531,11 @@ impl WeightedScore {
 
 pub fn weighted_factor(major: u16, minor: u16) -> Option<f64> {
     match (major, minor) {
-        (1, 29) => Some(1.3),
-        (1, 30) => Some(1.2),
-        (1, 31) => Some(1.1),
-        (1, 32) => Some(1.0),
+        (1, 29) => Some(1.4),
+        (1, 30) => Some(1.3),
+        (1, 31) => Some(1.2),
+        (1, 32) => Some(1.1),
+        (1, 33) => Some(1.0),
         _ => None,
     }
 }
@@ -2533,8 +2534,8 @@ impl<'a> AchievementHunter<'a> {
 
         let provinces = if result.completed() {
             [
-                320, 321, 163, 164, 2348, 3003, 4700, 145, 1773, 4701, 4698, 142, 2982, 124, 125,
-                4737, 4736, 2954, 126, 127, 1247, 4559, 4560, 333, 112, 2986,
+                320, 321, 163, 164, 2348, 3003, 4700, 4698, 142, 2982, 124, 125, 4737, 4736, 2954,
+                126, 127, 1247, 4559, 4560, 333, 112, 4735, 2986,
             ]
             .iter()
             .all(|id| self.owns_core_province_id(ProvinceId::from(*id)))

--- a/src/eu4game/tests/it/ironman.rs
+++ b/src/eu4game/tests/it/ironman.rs
@@ -439,3 +439,19 @@ fn test_dracula() {
         .collect();
     assert!(completed_ids.contains(&110));
 }
+
+#[test]
+fn test_not_just_pizza() {
+    let data = utils::request("naples.eu4");
+    let (save, encoding) = Eu4Extractor::extract_save(Cursor::new(&data[..])).unwrap();
+    let game = Game::new(&save.meta.savegame_version);
+    let query = Query::from_save(save);
+    let achievements = AchievementHunter::new(encoding, &query, &game).unwrap();
+    let completed_ids: Vec<i32> = achievements
+        .achievements()
+        .iter()
+        .filter(|x| x.completed())
+        .map(|x| x.id)
+        .collect();
+    assert!(completed_ids.contains(&198));
+}


### PR DESCRIPTION
- Map asset checksums did not change, so we can reuse map assets between 1.31-1.33
- Knights of the Caribbean province requirements changed. Not sure what the best solution is. Some achievements have conditions gated by patch (like voltaire's nightmare with), but changing these province requirements may be seen as more of a bugfix. This should not effect any uploaded save.
- The naples test case is achieved on patch 1.33

This PR should be merged when 1.33 is officially released so that the leaderboard can be recalculated with latest weights.