### PR TITLE
Allow recording map timelapse into a video

### DIFF
--- a/src/app/next.config.js
+++ b/src/app/next.config.js
@@ -26,6 +26,19 @@ let nextConfig = {
   async headers() {
     return [
       {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Cross-Origin-Embedder-Policy",
+            value: "require-corp",
+          },
+          {
+            key: "Cross-Origin-Opener-Policy",
+            value: "same-origin",
+          },
+        ],
+      },
+      {
         source: "/:path*.bin",
         headers: [
           {
@@ -42,11 +55,14 @@ let nextConfig = {
 };
 
 if (process.env.SENTRY_DSN) {
-  nextConfig = withSentryConfig(nextConfig,{
+  nextConfig = withSentryConfig(nextConfig, {
     silent: true,
-    include: [{
-      paths: [".next/static/chunks"], urlPrefix: "~/_next/static/chunks"
-    }],
+    include: [
+      {
+        paths: [".next/static/chunks"],
+        urlPrefix: "~/_next/static/chunks",
+      },
+    ],
   });
 }
 

--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/charts": "^1.2.5",
+        "@ffmpeg/ffmpeg": "^0.10.1",
         "@prisma/client": "^3.9.2",
         "@reduxjs/toolkit": "^1.8.0",
         "@sentry/nextjs": "^6.19.3",
@@ -1112,6 +1113,20 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@ffmpeg/ffmpeg": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
+      "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
+      "dependencies": {
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.1",
+        "regenerator-runtime": "^0.13.7",
+        "resolve-url": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=12.16.1"
       }
     },
     "node_modules/@hapi/b64": {
@@ -5446,6 +5461,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -8092,6 +8112,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+    },
     "node_modules/resolve.exports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
@@ -10077,6 +10103,17 @@
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@ffmpeg/ffmpeg": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
+      "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
+      "requires": {
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.1",
+        "regenerator-runtime": "^0.13.7",
+        "resolve-url": "^0.2.1"
       }
     },
     "@hapi/b64": {
@@ -13445,6 +13482,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -15429,6 +15471,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "resolve.exports": {
       "version": "1.1.0",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ant-design/charts": "^1.2.5",
+    "@ffmpeg/ffmpeg": "^0.10.1",
     "@prisma/client": "^3.9.2",
     "@reduxjs/toolkit": "^1.8.0",
     "@sentry/nextjs": "^6.19.3",

--- a/src/app/src/components/HelpTooltip.tsx
+++ b/src/app/src/components/HelpTooltip.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from "antd";
 import css from "styled-jsx/css";
 
 const { className, styles } = css.resolve`
-  button {
+  span.anticon {
     color: rgba(0, 0, 0, 0.45);
     cursor: help;
   }

--- a/src/app/src/features/engine/index.tsx
+++ b/src/app/src/features/engine/index.tsx
@@ -15,4 +15,5 @@ export {
   getEu4Map,
   useCanvasRef,
   getCanvas,
+  useCanvasContext,
 } from "./persistant-canvas-context";

--- a/src/app/src/features/eu4/Eu4CanvasOverlay.tsx
+++ b/src/app/src/features/eu4/Eu4CanvasOverlay.tsx
@@ -19,10 +19,10 @@ import { CountrySideBarButton } from "@/features/eu4/features/country-details";
 import { ProvinceSelectListener } from "./features/map/ProvinceSelectListener";
 import { UploadSideBarButton } from "@/features/eu4/features/upload";
 import { MapSettingsSideBarButton } from "@/features/eu4/features/settings";
-import { selectEu4MapDate } from "./eu4Slice";
 import { selectModuleDrawn } from "../engine";
 import { MapTip } from "./features/map/MapTip";
 import { MapZoomSideBar } from "./components/zoom";
+import { DateOverlay } from "./components/DateOverlay";
 
 const { className, styles } = css.resolve`
   span {
@@ -33,7 +33,6 @@ const { className, styles } = css.resolve`
 
 export const Eu4CanvasOverlay: React.FC<{}> = () => {
   const hasDrawn = useSelector(selectModuleDrawn);
-  const mapDate = useSelector(selectEu4MapDate);
   const serverFile = useAppSelector((state) => state.eu4.serverSaveFile);
 
   const buttons = [
@@ -80,7 +79,7 @@ export const Eu4CanvasOverlay: React.FC<{}> = () => {
   return (
     <>
       <MapTip />
-      <div className="date-overlay touch-none">{mapDate.text}</div>
+      <DateOverlay />
       <div className="ui-sidebar touch-none">
         <div className="flex-col gap">{buttons.map((x, i) => x(i))}</div>
         {styles}
@@ -95,24 +94,6 @@ export const Eu4CanvasOverlay: React.FC<{}> = () => {
           display: flex;
           flex-direction: column;
           user-select: none;
-        }
-
-        .date-overlay {
-          position: fixed;
-          right: 60px;
-          height: 60px;
-          display: flex;
-
-          // This is the background color in EU4 date
-          background-color: #20272c;
-          place-items: center;
-          color: white;
-          padding-left: 1rem;
-          padding-right: 1rem;
-          font-size: 1.25rem;
-          box-shadow: inset 0 0 30px #333;
-          font-weight: bold;
-          border: 2px solid black;
         }
       `}</style>
       <SaveWarnings />

--- a/src/app/src/features/eu4/components/DateOverlay.tsx
+++ b/src/app/src/features/eu4/components/DateOverlay.tsx
@@ -1,0 +1,31 @@
+import { useSelector } from "react-redux";
+import { selectEu4MapDate } from "../eu4Slice";
+
+export const DateOverlay: React.FC = () => {
+  const mapDate = useSelector(selectEu4MapDate);
+  return (
+    <div className="date-overlay touch-none">
+      {mapDate.text}
+
+      <style jsx>{`
+        .date-overlay {
+          position: fixed;
+          right: 60px;
+          height: 60px;
+          display: flex;
+
+          // This is the background color in EU4 date
+          background-color: #20272c;
+          place-items: center;
+          color: white;
+          padding-left: 1rem;
+          padding-right: 1rem;
+          font-size: 1.25rem;
+          box-shadow: inset 0 0 30px #333;
+          font-weight: bold;
+          border: 2px solid black;
+        }
+      `}</style>
+    </div>
+  );
+};

--- a/src/app/src/features/eu4/eu4Slice.ts
+++ b/src/app/src/features/eu4/eu4Slice.ts
@@ -131,6 +131,9 @@ const eu4Slice = createSlice({
       state.mapControls.showMapModeBorders =
         action.payload ?? !state.mapControls.showMapModeBorders;
     },
+    setMapControls(state, action: PayloadAction<MapControls>) {
+      state.mapControls = action.payload;
+    },
     setMapDate(state, action: PayloadAction<MapDate>) {
       state.mapDate.days = action.payload.days;
       state.mapDate.text = action.payload.text;
@@ -234,6 +237,7 @@ export const {
   setEu4SelectedTag,
   setEu4ServerSaveFile,
   setMapDate,
+  setMapControls,
   togglePaintSubjectInOverlordHue,
   toggleShowController,
   toggleShowTerrain,

--- a/src/app/src/features/eu4/features/settings/Timelapse.tsx
+++ b/src/app/src/features/eu4/features/settings/Timelapse.tsx
@@ -1,19 +1,272 @@
 import { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Button, Radio } from "antd";
-import { CaretRightOutlined, PauseOutlined } from "@ant-design/icons";
-import { getWasmWorker, useWasmWorker } from "@/features/engine";
-import { selectEu4MapDate, setMapDate, useEu4Meta } from "../../eu4Slice";
+import {
+  Button,
+  Radio,
+  Tooltip,
+  Form,
+  InputNumber,
+  Row,
+  Col,
+  Slider,
+  Modal,
+} from "antd";
+import {
+  CaretRightOutlined,
+  PauseOutlined,
+  VideoCameraOutlined,
+  VideoCameraTwoTone,
+} from "@ant-design/icons";
+import {
+  getWasmWorker,
+  useWasmWorker,
+  getEu4Map,
+  getCanvas,
+  getEu4Canvas,
+  useCanvasContext,
+  selectAnalyzeFileName,
+} from "@/features/engine";
+import {
+  selectEu4MapDate,
+  setMapControls,
+  setMapDate,
+  useEu4Meta,
+} from "../../eu4Slice";
 import { MapDate } from "../../types/models";
+import { downloadData } from "@/lib/downloadData";
+import { ToggleRow } from "./ToggleRow";
+import { IMG_HEIGHT, IMG_WIDTH, WebGLMap } from "@/map/map";
+import { selectIsDeveloper } from "@/features/account";
+import { MapControls } from "../../types/map";
+import { useAppSelector } from "@/lib/store";
+import type { FFmpeg } from "@ffmpeg/ffmpeg";
+
+function getSupportedCodec() {
+  const vp9 = "video/webm;codecs=vp8";
+  const vp8 = "video/webm;codecs=vp8";
+  if (MediaRecorder.isTypeSupported(vp9)) {
+    return vp9;
+  } else if (MediaRecorder.isTypeSupported(vp8)) {
+    return vp8;
+  } else {
+    throw new Error("VP9 and VP8 codecs are not supported by current browser");
+  }
+}
+
+let ffmpegModule: Promise<FFmpeg> | undefined = undefined;
+
+async function transcode(webmInput: Uint8Array, isDeveloper: boolean) {
+  if (ffmpegModule === undefined) {
+    // ffmpeg has a bit of a weird way of initializing itself, where it will do a
+    // string replace on "ffmpeg-core.js" for hard-coded paths of where the wasm
+    // should be. I don't want to fiddle around with how to cater to this, so we
+    // just pull the library and wasm from jsdelivr. ref:
+    // https://github.com/ffmpegwasm/ffmpeg.wasm/blob/4c3a85b2e6617b8b0692edaf87936a290ecfbdf2/src/browser/getCreateFFmpegCore.js#L31
+    ffmpegModule = import("@ffmpeg/ffmpeg").then(async (mod) => {
+      const x = mod.createFFmpeg({
+        log: isDeveloper,
+        corePath:
+          "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
+      });
+      await x.load();
+      return x;
+    });
+  }
+
+  const ffmpeg = await ffmpegModule;
+  ffmpeg.FS("writeFile", "recording.webm", new Uint8Array(webmInput));
+  try {
+    await ffmpeg.run(
+      "-i",
+      "recording.webm",
+      "-vf",
+
+      // ref: https://stackoverflow.com/a/20848224/433785
+      "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+      "-vcodec",
+      "libx264",
+      "recording.mp4"
+    );
+    const mp4Data = ffmpeg.FS("readFile", "recording.mp4");
+    const mp4Blob = new Blob([mp4Data], {
+      type: "video/mp4",
+    });
+
+    // can't call ffmpeg.exit here due to
+    // https://github.com/ffmpegwasm/ffmpeg.wasm/issues/242 so we just keep
+    // around a single instance of ffmpeg
+    return mp4Blob;
+  } finally {
+    ffmpeg.FS("unlink", "recording.mp4");
+  }
+}
+
+class MapRecorder {
+  chunks: Blob[] = [];
+  recorder: MediaRecorder;
+  stopPromise: Promise<void>;
+  postTimelapseRaf = 0;
+  preTimelapseRaf = 0;
+  hasStarted: Promise<void> | undefined = undefined;
+  hasStopped = false;
+
+  constructor(private recordingCanvas: HTMLCanvasElement, maxFps: number) {
+    // Side note: for some reason chrome media recorder won't record changes
+    // that occur more than 250ms apart (in spite of the framerate that we
+    // capture the stream at), so we set force the interval to be a max of 250ms
+    // apart from each other.
+    const stream = recordingCanvas.captureStream(Math.ceil(maxFps * 1.25));
+    this.recorder = new MediaRecorder(stream, {
+      mimeType: getSupportedCodec(),
+    });
+
+    this.recorder.addEventListener("dataavailable", (e) => {
+      if (e.data.size !== 0) {
+        this.chunks.push(e.data);
+      }
+    });
+
+    this.stopPromise = new Promise((resolve) => {
+      this.recorder.addEventListener("stop", () => {
+        resolve();
+      });
+    });
+
+    // This kludge is for making sure that the recording starts at the right
+    // date, as it's possible for the recording to not start until several
+    // intervals into the timelapse, so this promise is used to pause the
+    // timelapse until we've written at least one frame.
+    this.hasStarted = new Promise((resolve) => {
+      const gotData = (e: BlobEvent) => {
+        if (e.data.size !== 0) {
+          this.recorder.removeEventListener("dataavailable", gotData);
+          cancelAnimationFrame(this.preTimelapseRaf);
+          this.preTimelapseRaf = 0;
+          requestAnimationFrame(() => resolve());
+        }
+      };
+      this.recorder.addEventListener("dataavailable", gotData);
+    });
+  }
+
+  start() {
+    this.recorder.start();
+    this.preTimelapseRaf = requestAnimationFrame(() => this.preTimelapseLoop());
+  }
+
+  /// Write a blank rectangle to the recording canvas to try and coax
+  /// the recorder to capture additional data.
+  private drawNoop() {
+    const ctx = this.recordingCanvas?.getContext("2d");
+    if (ctx) {
+      ctx.fillStyle = "rgb(0,0,0,0)";
+      ctx.fillRect(0, 0, 1, 1);
+    }
+  }
+
+  private preTimelapseLoop() {
+    if (this.recorder.state === "inactive") {
+      return;
+    }
+
+    if (this.chunks.length !== 0) {
+      return;
+    }
+
+    this.drawNoop();
+    this.recorder.requestData();
+    this.preTimelapseRaf = requestAnimationFrame(() => this.preTimelapseLoop());
+  }
+
+  // After we're done recording, create an animation loop to write
+  // blank data to the canvas as chrome is cutting us short
+  // and stops the recording wayyyyy too early.
+  // ref: https://stackoverflow.com/q/66813248/433785
+  private postTimelapseLoop(startTime: number, freezeFrameSeconds: number) {
+    if (this.recorder.state === "inactive") {
+      return;
+    }
+
+    this.drawNoop();
+    this.postTimelapseRaf = requestAnimationFrame((t) => {
+      const hasHitFreezeFrameTarget =
+        (t - startTime) / 1000 > freezeFrameSeconds;
+      if (hasHitFreezeFrameTarget) {
+        this.hasStopped = true;
+        if (this.recorder.state !== "inactive") {
+          this.recorder.requestData();
+        }
+      }
+
+      this.postTimelapseLoop(startTime, freezeFrameSeconds);
+    });
+  }
+
+  async stopCapture(freezeFrameSeconds: number): Promise<Blob[]> {
+    const startTime = performance.now();
+    this.recorder.requestData();
+    this.postTimelapseLoop(startTime, freezeFrameSeconds);
+
+    // Now wait until we've written out the final frame
+    await new Promise((resolve) => {
+      const gotData = (e: BlobEvent) => {
+        if (this.hasStopped && e.data.size !== 0) {
+          this.recorder.removeEventListener("dataavailable", gotData);
+          resolve(void 0);
+        }
+      };
+
+      this.recorder.addEventListener("dataavailable", gotData);
+    });
+
+    this.recorder.stop();
+    await this.stopPromise;
+
+    const result = this.chunks;
+    this.teardown();
+    return result;
+  }
+
+  teardown() {
+    cancelAnimationFrame(this.postTimelapseRaf);
+    this.chunks = [];
+    this.recordingCanvas.remove();
+  }
+}
+
+interface MapState {
+  focusPoint: [number, number];
+  scale: number;
+  width: number;
+  height: number;
+}
 
 export const Timelapse: React.FC<{}> = () => {
   const dispatch = useDispatch();
   const meta = useEu4Meta();
   const workerRef = useWasmWorker();
   const [isPlaying, setIsPlaying] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [syncRecording, setSyncRecording] = useState(true);
+  const [isTranscoding, setIsTranscoding] = useState(false);
+  const [recordingFrame, setRecordingFrame] = useState("None");
+  const [maxFps, setMaxFps] = useState(8);
+  const [exportAsMp4, setExportAsMp4] = useState(false);
+  const [freezeFrameSeconds, setFreezeFrameSeconds] = useState(0);
   const [intervalSelection, setIntervalSelection] = useState<string>("Year");
   const currentMapDate = useSelector(selectEu4MapDate);
+  const savedMapStateRef = useRef<MapState | undefined>(undefined);
+  const mapControls = useAppSelector((x) => x.eu4.mapControls);
+  const savedMapControls = useRef<MapControls>(mapControls);
   const rafId = useRef(0);
+  const currentDateText = useRef(meta.start_date);
+  const canvasContext = useCanvasContext();
+  const recorder = useRef<MapRecorder | undefined>(undefined);
+  const stopRecordingOnNextCommit = useRef<boolean>(false);
+  const finalDrawCommitted = useRef<Promise<void> | undefined>(undefined);
+  const [form] = Form.useForm();
+  const isDeveloper = useSelector(selectIsDeveloper);
+  const filename = useSelector(selectAnalyzeFileName);
 
   useEffect(() => {
     return () => {
@@ -21,89 +274,426 @@ export const Timelapse: React.FC<{}> = () => {
     };
   }, []);
 
-  const timelapseClick = () => {
-    if (isPlaying) {
-      cancelAnimationFrame(rafId.current);
-      setIsPlaying(false);
-    } else {
-      const startDate: MapDate =
-        currentMapDate.days == meta.total_days
-          ? {
-              days: 0,
-              text: meta.start_date,
-            }
-          : currentMapDate;
+  useEffect(() => {
+    return () => {
+      recorder.current?.teardown();
+    };
+  }, []);
 
-      setIsPlaying(true);
-      const worker = getWasmWorker(workerRef);
+  const startTimelapse = () => {
+    const startDate: MapDate =
+      currentMapDate.days == meta.total_days
+        ? {
+            days: 0,
+            text: meta.start_date,
+          }
+        : currentMapDate;
 
-      let lastTimestamp = 0;
-      let date = startDate;
-      const maxFps = 8;
-      const timestep = 1000 / maxFps;
+    setIsPlaying(true);
+    const worker = getWasmWorker(workerRef);
 
-      const rafUpdate: FrameRequestCallback = async (timestamp) => {
-        rafId.current = requestAnimationFrame(rafUpdate);
+    let lastTimestamp = 0;
+    let date = startDate;
+    const timestep = 1000 / maxFps;
 
-        if (timestamp - lastTimestamp < timestep) {
-          return;
-        }
+    if (syncRecording) {
+      // When we're recording a timelapse, we don't want the last frame to
+      // include map options excluded from previous frames. Ie: we don't want
+      // the last frame to show striped political provinces when the timelapse
+      // didn't. So we save the current controls to restore them later.
+      savedMapControls.current = mapControls;
+      dispatch(
+        setMapControls({
+          ...mapControls,
+          mode: "political",
+          borderFill: "Provinces",
+          showController: false,
+          showCountryBorders: false,
+          showMapModeBorders: false,
+          paintSubjectInOverlordHue: false,
+        })
+      );
 
-        lastTimestamp = timestamp;
+      // Prime the recording to start at the correct date
+      dispatch(setMapDate(date));
+    }
 
-        dispatch(setMapDate(date));
-
-        if (date.days == meta.total_days) {
-          setIsPlaying(false);
-          cancelAnimationFrame(rafId.current);
-          return;
-        }
-
-        date = await worker.eu4IncrementDate(date.days, intervalSelection);
-
-        if (date.days > meta.total_days) {
-          date = {
-            days: meta.total_days,
-            text: meta.date,
-          };
-        }
-      };
+    let recorderLock = false;
+    const rafUpdate: FrameRequestCallback = async (timestamp) => {
       rafId.current = requestAnimationFrame(rafUpdate);
+
+      if (timestamp - lastTimestamp < timestep) {
+        return;
+      }
+
+      // If we are recording, stall until the recorder has started,
+      if (recorderLock) {
+        return;
+      } else if (recorder.current?.hasStarted) {
+        recorderLock = true;
+        await recorder.current.hasStarted;
+        recorderLock = false;
+      }
+
+      lastTimestamp = timestamp;
+
+      // If we're recording and it's been more than 3 seconds then we will
+      // assume the user navigated away. Navigating away during a recording will
+      // cause issues and there is no way to persist animation frames when in a
+      // background tab.
+      if (recorder.current && timestamp - (lastTimestamp || timestamp) > 3000) {
+        recorder.current.teardown();
+        recorder.current = undefined;
+        stopTimelapse();
+        setIsRecording(false);
+        restoreMapPriorToRecording();
+
+        Modal.warning({
+          title: "Gap in recording",
+          content:
+            "Navigating away while recording may corrupt the output. Please do not navigate away while recording. During the transcoding to MP4 phase, it is ok to navigate away",
+        });
+        return;
+      }
+
+      dispatch(setMapDate(date));
+
+      if (date.days == meta.total_days) {
+        stopTimelapseWithSync();
+        return;
+      }
+
+      date = await worker.eu4IncrementDate(date.days, intervalSelection);
+      if (date.days > meta.total_days) {
+        date = {
+          days: meta.total_days,
+          text: meta.date,
+        };
+      }
+      currentDateText.current = date.text;
+    };
+    rafId.current = requestAnimationFrame(rafUpdate);
+  };
+
+  const stopTimelapseWithSync = () => {
+    setIsPlaying(false);
+    cancelAnimationFrame(rafId.current);
+    const prevRafId = rafId.current;
+    rafId.current = 0;
+
+    if (syncRecording && prevRafId !== 0) {
+      stopRecordingOnNextCommit.current = true;
     }
   };
+
+  const stopTimelapse = () => {
+    setIsPlaying(false);
+    cancelAnimationFrame(rafId.current);
+    rafId.current = 0;
+  };
+
+  const startRecording = async () => {
+    stopRecordingOnNextCommit.current = false;
+    finalDrawCommitted.current = undefined;
+    setIsRecording(true);
+
+    const canvas = getCanvas(canvasContext.canvasRef);
+    const eu4Canvas = getEu4Canvas(canvasContext.eu4CanvasRef);
+    const eu4Map = getEu4Map(canvasContext.eu4CanvasRef);
+    if (recordingFrame !== "None") {
+      const zoom = recordingFrame.charCodeAt(0) - "0".charCodeAt(0);
+
+      savedMapStateRef.current = {
+        width: canvas.width,
+        height: canvas.height,
+        focusPoint: eu4Map.focusPoint,
+        scale: eu4Map.scale,
+      };
+
+      canvasContext.sizeOverrideRef.current = true;
+      canvas.style.removeProperty("max-width");
+      eu4Map.focusPoint = [0, 0];
+      eu4Map.scale = 1;
+      eu4Canvas.resize(IMG_WIDTH / zoom, IMG_HEIGHT / zoom);
+      eu4Canvas.redrawViewport();
+    }
+
+    const recordingCanvas = document.createElement("canvas");
+    recordingCanvas.width = canvas.width;
+    recordingCanvas.height = canvas.height;
+
+    // get 2d context without alpha:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas#turn_off_transparency
+    const ctx2d = recordingCanvas.getContext("2d", { alpha: false });
+    if (ctx2d === null) {
+      throw new Error("expected recording canvas 2d contex to be defined");
+    }
+
+    recorder.current = new MapRecorder(recordingCanvas, maxFps);
+
+    if (syncRecording) {
+      startTimelapse();
+
+      // A heuristic to wait for the timelapse to get us to the starting date
+      await new Promise((resolve) => {
+        const origDraw = eu4Map.onDraw;
+        eu4Map.onDraw = (...args) => {
+          origDraw?.(...args);
+          resolve(void 0);
+          eu4Map.onDraw = origDraw;
+        };
+      });
+    }
+
+    const create2dFrame = (ctx: WebGL2RenderingContext) => {
+      const scale = recordingCanvas.width > 2000 ? 2 : 1;
+
+      // Create rectangle to hold text
+      ctx2d.drawImage(ctx.canvas, 0, 0);
+      ctx2d.fillStyle = "#20272c";
+      ctx2d.fillRect(
+        recordingCanvas.width - 130 * scale,
+        0,
+        130 * scale,
+        50 * scale
+      );
+
+      const fontFamily =
+        "-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif";
+      ctx2d.fillStyle = "#ffffff";
+      ctx2d.textAlign = "right";
+      ctx2d.font = `700 ${12 * scale}px ${fontFamily}`;
+      ctx2d.fillText(
+        `PDX.TOOLS`,
+        recordingCanvas.width - 11 * scale,
+        15 * scale
+      );
+      ctx2d.font = `700 ${20 * scale}px ${fontFamily}`;
+      ctx2d.fillText(
+        currentDateText.current,
+        recordingCanvas.width - 10 * scale,
+        35 * scale
+      );
+
+      if (stopRecordingOnNextCommit.current) {
+        stopRecording();
+      }
+    };
+
+    // We don't want our recording to start with a black map so we're going to
+    // wait to start the recording until we've drawn at least one frame.
+    const waitForFirst2dFrame = new Promise((resolve) => {
+      eu4Map.onCommit = (ctx) => {
+        create2dFrame(ctx);
+        requestAnimationFrame(() => resolve(void 0));
+      };
+    });
+
+    eu4Map.redrawViewport();
+    await waitForFirst2dFrame;
+
+    eu4Map.onCommit = create2dFrame;
+    recorder.current?.start();
+  };
+
+  const stopRecordingWithSync = async () => {
+    if (syncRecording) {
+      stopTimelapse();
+      dispatch(setMapControls(savedMapControls.current));
+    }
+
+    stopRecording();
+  };
+
+  const stopRecording = async () => {
+    setIsRecording(false);
+
+    if (!recorder.current) {
+      return;
+    }
+
+    if (freezeFrameSeconds !== 0) {
+      setIsTranscoding(true);
+    }
+
+    const data = await recorder.current.stopCapture(freezeFrameSeconds);
+    recorder.current = undefined;
+
+    const eu4Map = getEu4Map(canvasContext.eu4CanvasRef);
+    eu4Map.onCommit = undefined;
+
+    const blob = new Blob(data, {
+      type: "video/webm",
+    });
+
+    const extension = exportAsMp4 ? "mp4" : "webm";
+    const nameInd = filename.lastIndexOf(".");
+    const outputName =
+      nameInd == -1
+        ? `${filename}.${extension}`
+        : `${filename.substring(0, nameInd)}.${extension}`;
+
+    if (exportAsMp4) {
+      setIsTranscoding(true);
+      const blobBuffer = new Uint8Array(await blob.arrayBuffer());
+      const output = await transcode(blobBuffer, isDeveloper);
+      downloadData(output, outputName);
+    } else {
+      downloadData(blob, outputName);
+    }
+
+    setIsTranscoding(false);
+    restoreMapPriorToRecording();
+  };
+
+  function restoreMapPriorToRecording() {
+    if (savedMapStateRef.current) {
+      const eu4Map = getEu4Map(canvasContext.eu4CanvasRef);
+      const eu4Canvas = getEu4Canvas(canvasContext.eu4CanvasRef);
+
+      canvasContext.sizeOverrideRef.current = false;
+      eu4Map.focusPoint = savedMapStateRef.current.focusPoint;
+      eu4Map.scale = savedMapStateRef.current.scale;
+      eu4Canvas.resize(
+        savedMapStateRef.current.width,
+        savedMapStateRef.current.height
+      );
+      eu4Canvas.redrawViewport();
+      savedMapStateRef.current = undefined;
+    }
+  }
 
   return (
     <>
       <div className="flex-row gap justify-center">
-        <Radio.Group
-          value={intervalSelection}
-          onChange={(e) => setIntervalSelection(e.target.value)}
-          optionType="button"
-          options={[
-            {
-              label: "Year",
-              value: "Year",
-            },
-            {
-              label: "Month",
-              value: "Month",
-            },
-            {
-              label: "Week",
-              value: "Week",
-            },
-            {
-              label: "Day",
-              value: "Day",
-            },
-          ]}
-        />
-        <Button
-          shape="circle"
-          icon={!isPlaying ? <CaretRightOutlined /> : <PauseOutlined />}
-          onClick={timelapseClick}
-        />
+        <Tooltip title={!isPlaying ? "Start timelapse" : "Stop timelapse"}>
+          <Button
+            shape="circle"
+            icon={!isPlaying ? <CaretRightOutlined /> : <PauseOutlined />}
+            onClick={!isPlaying ? startTimelapse : stopTimelapseWithSync}
+          />
+        </Tooltip>
+        <Tooltip title={!isPlaying ? "Start recording" : "Stop recording"}>
+          <Button
+            shape="circle"
+            loading={isTranscoding}
+            icon={
+              !isRecording ? <VideoCameraOutlined /> : <VideoCameraTwoTone />
+            }
+            onClick={!isRecording ? startRecording : stopRecordingWithSync}
+          />
+        </Tooltip>
       </div>
+      <Form
+        form={form}
+        layout="vertical"
+        onFieldsChange={(_e, x) => {
+          const find = (field: string) =>
+            x.find((prop) => Array.isArray(prop.name) && prop.name[0] == field)
+              ?.value;
+
+          setIntervalSelection(find("interval"));
+          setRecordingFrame(find("frame"));
+          setMaxFps(+find("maxFps"));
+        }}
+        initialValues={{
+          interval: intervalSelection,
+          frame: recordingFrame,
+          maxFps,
+        }}
+      >
+        <Form.Item label="Interval" name="interval">
+          <Radio.Group
+            optionType="button"
+            options={[
+              {
+                label: "Year",
+                value: "Year",
+              },
+              {
+                label: "Month",
+                value: "Month",
+              },
+              {
+                label: "Week",
+                value: "Week",
+              },
+              {
+                label: "Day",
+                value: "Day",
+              },
+            ]}
+          />
+        </Form.Item>
+        <Form.Item
+          label="Max intervals per second"
+          name="maxFps"
+          tooltip="The number of intervals to step through per second. A beefy computer may be required to hit more than 8 intervals per second."
+        >
+          <Slider
+            min={4}
+            max={16}
+            marks={{ 4: "4", 8: "8", 12: "12", 16: "16" }}
+          />
+        </Form.Item>
+        <Form.Item
+          label="Recording Frame"
+          name="frame"
+          tooltip="Determines the size of the map for recording. 'None' will record the current view in the browser. The other numerical options represent the zoom level of the map and will temporarily resize the map so that the entire map is visible at the zoom level. The 2x zoom level is recommended as a good mix between quality and render times."
+        >
+          <Radio.Group
+            optionType="button"
+            options={[
+              {
+                label: "None",
+                value: "None",
+              },
+              {
+                label: "8x",
+                value: "8x",
+              },
+              {
+                label: "4x",
+                value: "4x",
+              },
+              {
+                label: "2x",
+                value: "2x",
+              },
+              {
+                label: "1x",
+                value: "1x",
+              },
+            ]}
+          />
+        </Form.Item>
+      </Form>
+      <Row className="flex-row">
+        <Col span={4}>
+          <InputNumber
+            min={0}
+            max={8}
+            defaultValue={0}
+            value={freezeFrameSeconds}
+            onChange={setFreezeFrameSeconds}
+            style={{ width: "calc(100% - 5px)" }}
+          />
+        </Col>
+        <Col span={24 - 4}>Seconds of final freeze frame</Col>
+      </Row>
+
+      <ToggleRow
+        text="Sync recording with timelapse"
+        onChange={setSyncRecording}
+        value={syncRecording}
+        help="Synchronizes the recording with the timelapse such that when a recording starts the timelapse starts too and each continue until one or the other stops"
+      />
+      <ToggleRow
+        text="Export as MP4 (slow)"
+        onChange={setExportAsMp4}
+        value={exportAsMp4}
+        help="After the recording is finished, it will be transcoded into an mp4. May take several minutes"
+      />
     </>
   );
 };

--- a/src/app/src/features/eu4/features/settings/ToggleRow.tsx
+++ b/src/app/src/features/eu4/features/settings/ToggleRow.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { Col, Row, Switch } from "antd";
+import { HelpTooltip } from "@/components/HelpTooltip";
 
 export interface ToggleRowProps {
   value: boolean;
   onChange: (value: boolean) => void;
   text: string;
   disabled?: boolean;
+  help?: string;
 }
 
 export const ToggleRow: React.FC<ToggleRowProps> = ({
@@ -13,6 +15,7 @@ export const ToggleRow: React.FC<ToggleRowProps> = ({
   onChange,
   text,
   disabled = false,
+  help,
 }) => {
   const controlSpan = 4;
   const labelSpan = 24 - controlSpan;
@@ -40,6 +43,11 @@ export const ToggleRow: React.FC<ToggleRowProps> = ({
         onClick={disabled ? () => {} : () => onChange(!value)}
       >
         {text}
+        {help && (
+          <span style={{ marginLeft: "4px" }}>
+            <HelpTooltip help={help} />
+          </span>
+        )}
       </Col>
     </Row>
   );

--- a/src/app/workers-site/index.ts
+++ b/src/app/workers-site/index.ts
@@ -195,6 +195,8 @@ function withSecurityHeaders(response: Response, pathname: string) {
   );
   newResponse.headers.set("X-XSS-Protection", "1; mode=block");
   newResponse.headers.set("X-Content-Type-Options", "nosniff");
+  newResponse.headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+  newResponse.headers.set("Cross-Origin-Opener-Policy", "same-origin");
   return newResponse;
 }
 

--- a/src/map/src/map.ts
+++ b/src/map/src/map.ts
@@ -71,6 +71,7 @@ export class WebGLMap {
   public onProvinceHover?: (proinceId: number) => void;
   public onProvinceSelection?: (proinceId: number) => void;
   public onDraw?: (event: DrawEvent) => void;
+  public onCommit?: (context: WebGL2RenderingContext) => void;
 
   constructor(
     private gl: WebGL2RenderingContext,
@@ -269,6 +270,7 @@ export class WebGLMap {
     gl.drawArrays(gl.TRIANGLES, 0, 6);
     gl.bindVertexArray(null);
 
+    this.onCommit?.(gl);
     this.glResources.xbrShaderProgram.clear();
     this.cancelQueuedViewportAnimation();
     this.viewportAnimationRequestCancelled = 0;


### PR DESCRIPTION
This feature allows users to capture a timelapse into a video recording
to download and share. This implemented at a high level by using a
[canvas's `captureStream`][2] and piping that to a [`MediaRecorder`][3].

Users may choose what resolution to render the map as well as the how
fast the timelapse progresses.

Conceptually simple, but several problems arose.

Capturing the map's canvas omits UI elements like the current date in a
timelapse, something that seems critical when evaluating a timelapse. To
embed a date in the recording, we'd need to either send text into the
map or we could copy the map's canvas into a separate canvas that uses
the 2d api, which has better support for text and we could record that
one instead. While copying around map canvas data seems inefficient, it
was deemed better than needing to figure how to embed rapidly updating
text into WebGL. To support the copy use case the webgl map exposes a
callback (`onCommit`) right after it has rendered so the recording
canvas can copy it hot off the press.

Since users will want the option to record the entire map, the recording
logic communicates to the canvas that it'll be assuming control of the
size of the canvas. Seeing the canvas expand beyond one's viewport may
be unsightly, but it was the most intuitive way to get the resolution
necessary for the recording. The good news is that we restore the map
state when the recording is done so the user's focus point and scale
will not have changed.

The hardest part about the implemenation is all the coordination between
updating the map, progressing the timelapse, and making sure that
recording captures both the start and tail end of the timelapse.

For instance, there are some variations in browser implementations of a
canvas's capture stream and the media recorder. The biggest one is that
chrome would cut several seconds out of a recording especially when
there was a lack of data (like when using a freeze frame at the end).
The solution is extremely hacky: when the recording stops, repeatedly
write a transparent rectangle until we the media recorder emit non-empty
data.

That same technique (writing transparent data) is used to synchronize
the start of the recording with the start of the timelapse.

Another variation is that Chrome's canvas stream needed to be updated
every 250ms or it wouldn't register any changes. This is why the minimum
intervals per second is 4.

The output of a recording is a webm file. While this format is the [
recommended approach for video playback][4], webm upload is not often
supported sites like reddit. The solution is that after the recording is
finished, transcode it into an mp4 file using [`ffmpeg.wasm`][5]. This
is a pretty extreme approach as ffmpeg is a large download (several
times larger than all the pdx.tools wasm bundles put together), and may
take several minutes to complete while using 100% CPU usage. But the end
result is worth it if users can take the download and immediately upload
it elsewhere with minimal hassle.

However I still view the mp4 export as a bit experimental as every few
recordings ffmpeg takes 10x as long to process the input and the output
is horribly choppy. I'm not sure what causes this, but I'm assuming
other users will experience this issue, so my recommendation to those
who constantly experience it is to accept the webm output and convert it
to mp4 through a 3rd party tool.

Needed to add two new headers: `Cross-Origin-Embedder-Policy:
require-corp` and `Cross-Origin-Opener-Policy: same-origin` in order to
get [ffmpeg.wasm to work][0] as it relies on `SharedArrayBuffer` and its
[security requirements][1]

The timelapse and recording work through `requestAnimationFrame` which
is paused when running in a background tab ([source][6]), so in order to
avoid corrupting the canvas capture, a warning is presented to the user
when they switch back to our tab (as one can't eagerly detect tab
switching in the browser beforehand), informing them of this
restriction. At least the MP4 transcoding can happen in the background.

https://user-images.githubusercontent.com/2106129/161973456-86ee298a-8e17-47ad-bd85-1a3a789c6d43.mp4


[0]: https://github.com/ffmpegwasm/ffmpeg.wasm#installation
[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
[2]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/captureStream
[3]: https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder
[4]: https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#recommendations_for_everyday_videos
[5]: https://github.com/ffmpegwasm/ffmpeg.wasm
[6]: https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
