### PR TITLE
Add map timelapse controls to map settings

### DIFF
--- a/src/app/src/features/engine/worker/eu4/module.ts
+++ b/src/app/src/features/engine/worker/eu4/module.ts
@@ -23,6 +23,7 @@ import type {
   LocalizedCountryExpense,
   LocalizedCountryIncome,
   LocalizedTag,
+  MapDate,
   PlayerHistory,
   ProvinceDetails,
   RawWarInfo,
@@ -297,6 +298,10 @@ export function eu4DateToDays(s: string): number {
 
 export function eu4DaysToDate(s: number): string {
   return loadedSave().days_to_date(s);
+}
+
+export function eu4IncrementDate(days: number, increment: string): MapDate {
+  return loadedSave().increment_date(days, increment);
 }
 
 export function eu4GetProvinceDeteails(id: number): ProvinceDetails {

--- a/src/app/src/features/eu4/eu4Slice.ts
+++ b/src/app/src/features/eu4/eu4Slice.ts
@@ -4,15 +4,11 @@ import {
   CountryMatcher,
   EnhancedCountryInfo,
   EnhancedMeta,
+  MapDate,
 } from "./types/models";
 import { MapControls, MapOnlyControls, MapPayload } from "./types/map";
 import { RootState, useAppSelector } from "@/lib/store";
 import { SaveFile } from "@/services/appApi";
-
-interface MapDate {
-  days: number;
-  text: string;
-}
 
 interface EndEu4AnalyzePayload {
   date: string;

--- a/src/app/src/features/eu4/features/settings/DateTimeline.tsx
+++ b/src/app/src/features/eu4/features/settings/DateTimeline.tsx
@@ -10,10 +10,7 @@ import {
   setMapDate,
   useEu4Meta,
 } from "@/features/eu4/eu4Slice";
-import {
-  getWasmWorker,
-  useWasmWorker,
-} from "../../../engine/worker/wasm-worker-context";
+import { getWasmWorker, useWasmWorker } from "@/features/engine";
 
 export const DateTimeline: React.FC<{}> = () => {
   const dispatch = useAppDispatch();

--- a/src/app/src/features/eu4/features/settings/MapSettings.tsx
+++ b/src/app/src/features/eu4/features/settings/MapSettings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Spin, Dropdown, Button } from "antd";
+import { Spin, Dropdown, Button, Divider } from "antd";
 import { DownOutlined } from "@ant-design/icons";
 import { useSelector } from "react-redux";
 import { useAppDispatch } from "@/lib/store";
@@ -20,6 +20,7 @@ import { CountryFilterButton } from "../country-filter";
 import { DateTimeline } from "./DateTimeline";
 import { MapExportMenu } from "./MapExportMenu";
 import { ToggleRow } from "./ToggleRow";
+import { Timelapse } from "./Timelapse";
 
 export const MapSettings: React.FC<{}> = () => {
   const [isExporting, setIsExporting] = useState(false);
@@ -93,7 +94,11 @@ export const MapSettings: React.FC<{}> = () => {
         text="Paint map mode borders"
       />
 
+      <Divider orientation="left">Date Controls</Divider>
       <DateTimeline />
+
+      <Divider orientation="left">Timelapse</Divider>
+      <Timelapse />
     </>
   );
 };

--- a/src/app/src/features/eu4/features/settings/Timelapse.tsx
+++ b/src/app/src/features/eu4/features/settings/Timelapse.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Button, Radio } from "antd";
+import { CaretRightOutlined, PauseOutlined } from "@ant-design/icons";
+import { getWasmWorker, useWasmWorker } from "@/features/engine";
+import { selectEu4MapDate, setMapDate, useEu4Meta } from "../../eu4Slice";
+import { MapDate } from "../../types/models";
+
+export const Timelapse: React.FC<{}> = () => {
+  const dispatch = useDispatch();
+  const meta = useEu4Meta();
+  const workerRef = useWasmWorker();
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [intervalSelection, setIntervalSelection] = useState<string>("Day");
+  const currentMapDate = useSelector(selectEu4MapDate);
+  const rafId = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      cancelAnimationFrame(rafId.current);
+    };
+  }, []);
+
+  const timelapseClick = () => {
+    if (isPlaying) {
+      cancelAnimationFrame(rafId.current);
+      setIsPlaying(false);
+    } else {
+      const startDate: MapDate =
+        currentMapDate.days == meta.total_days
+          ? {
+              days: 0,
+              text: meta.start_date,
+            }
+          : currentMapDate;
+
+      setIsPlaying(true);
+      const worker = getWasmWorker(workerRef);
+
+      let lastTimestamp = 0;
+      let date = startDate;
+      const maxFps = 8;
+      const timestep = 1000 / maxFps;
+
+      const rafUpdate: FrameRequestCallback = async (timestamp) => {
+        rafId.current = requestAnimationFrame(rafUpdate);
+
+        if (timestamp - lastTimestamp < timestep) {
+          return;
+        }
+
+        lastTimestamp = timestamp;
+
+        dispatch(setMapDate(date));
+
+        if (date.days == meta.total_days) {
+          setIsPlaying(false);
+          cancelAnimationFrame(rafId.current);
+          return;
+        }
+
+        date = await worker.eu4IncrementDate(date.days, intervalSelection);
+
+        if (date.days > meta.total_days) {
+          date = {
+            days: meta.total_days,
+            text: meta.date,
+          };
+        }
+      };
+      rafId.current = requestAnimationFrame(rafUpdate);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex-row gap justify-center">
+        <Radio.Group
+          value={intervalSelection}
+          onChange={(e) => setIntervalSelection(e.target.value)}
+          optionType="button"
+          options={[
+            {
+              label: "Day",
+              value: "Day",
+            },
+            {
+              label: "Week",
+              value: "Week",
+            },
+            {
+              label: "Month",
+              value: "Month",
+            },
+            {
+              label: "Year",
+              value: "Year",
+            },
+          ]}
+        />
+        <Button
+          shape="circle"
+          icon={!isPlaying ? <CaretRightOutlined /> : <PauseOutlined />}
+          onClick={timelapseClick}
+        />
+      </div>
+    </>
+  );
+};

--- a/src/app/src/features/eu4/types/models.ts
+++ b/src/app/src/features/eu4/types/models.ts
@@ -602,3 +602,8 @@ export interface CountryLeader {
   activation: string | null;
   monarch_stats: MonarchStats | null;
 }
+
+export interface MapDate {
+  days: number;
+  text: string;
+}

--- a/src/app/src/lib/downloadData.ts
+++ b/src/app/src/lib/downloadData.ts
@@ -1,10 +1,14 @@
-export function downloadData(data: BlobPart, fileName: string) {
+export function downloadData(data: BlobPart | Blob, fileName: string) {
   const link = document.createElement("a");
   link.style.display = "none";
   document.body.append(link);
-  const blob = new Blob([data], {
-    type: "application/octet-stream",
-  });
+
+  const blob =
+    data instanceof Blob
+      ? data
+      : new Blob([data], {
+          type: "application/octet-stream",
+        });
 
   link.href = URL.createObjectURL(blob);
   link.download = fileName;


### PR DESCRIPTION
It is inconvenient for users to drag the date slider around to get a
sense of progression for their world. With these new controls, players
have the ability to advance their world by day, week, month, and year.

![timelapse](https://user-images.githubusercontent.com/2106129/160828066-c89f540a-fe09-4c58-af92-bac3504be180.gif)

