### PR TITLE
Reset game analysis on unmount to fix canvas undefined errors

### DIFF
--- a/src/app/src/features/engine/GameView.tsx
+++ b/src/app/src/features/engine/GameView.tsx
@@ -55,6 +55,12 @@ export const GameView: React.FC<{}> = () => {
     };
   }, [dispatch, router.events]);
 
+  useEffect(() => {
+    return () => {
+      dispatch(resetSaveAnalysis());
+    };
+  }, [dispatch]);
+
   switch (game) {
     case "ck3": {
       return <Ck3View />;

--- a/src/app/src/features/engine/worker/eu4/common.ts
+++ b/src/app/src/features/engine/worker/eu4/common.ts
@@ -12,6 +12,10 @@ export function loadedSave() {
   }
 }
 
+export function eu4GetSaveFile() {
+  return savefile;
+}
+
 export function eu4SetSaveFile(aSavefile: SaveFile) {
   savefile?.free();
   savefile = aSavefile;

--- a/src/app/src/features/engine/worker/eu4/module.ts
+++ b/src/app/src/features/engine/worker/eu4/module.ts
@@ -38,7 +38,7 @@ import { MapPayload, QuickTipPayload } from "../../../eu4/types/map";
 import { getRawData } from "../storage";
 import { LedgerDataRaw, workLedgerData } from "../../../eu4/utils/ledger";
 import { expandLosses } from "../../../eu4/utils/losses";
-import { eu4GetMeta, loadedSave } from "./common";
+import { eu4GetMeta, eu4GetSaveFile, loadedSave } from "./common";
 
 let provinceIdToColorIndex = new Uint16Array();
 
@@ -312,7 +312,7 @@ export function eu4GetMapTooltip(
   province: number,
   payload: MapPayload
 ): QuickTipPayload | null {
-  return loadedSave().map_quick_tip(province, payload);
+  return eu4GetSaveFile()?.map_quick_tip(province, payload) ?? null;
 }
 
 export async function eu4SaveHash(): Promise<string> {

--- a/src/app/src/features/engine/worker/wasm-worker-context.tsx
+++ b/src/app/src/features/engine/worker/wasm-worker-context.tsx
@@ -83,7 +83,7 @@ export const useWorkerOnSave = (cb: (arg0: WorkerClient) => Promise<void>) => {
   useEffect(() => {
     async function getData() {
       try {
-        if (isMounted.current) {
+        if (isMounted()) {
           setLoading(true);
           const worker = getWasmWorker(workerRef);
           await cb(worker);
@@ -92,13 +92,13 @@ export const useWorkerOnSave = (cb: (arg0: WorkerClient) => Promise<void>) => {
         captureException(error);
         dispatch(newError(error));
       } finally {
-        if (isMounted.current) {
+        if (isMounted()) {
           setLoading(false);
         }
       }
     }
     getData();
-  }, [workerRef, cb, analyzeId, dispatch, isMounted]);
+  }, [workerRef, cb, dispatch, isMounted, analyzeId]);
 
   return loading;
 };
@@ -124,16 +124,14 @@ export const useAnalysisWorker = (
 ) => {
   const loading = useWorkerOnSave(cb);
   const visualizationDispatch = useVisualizationDispatch();
-  const hasMounted = useRef(false);
+  const isMounted = useIsMounted();
   useEffect(() => {
-    if (hasMounted.current) {
+    if (isMounted()) {
       if (loading) {
         visualizationDispatch({ type: "enqueue-loading" });
       } else {
         visualizationDispatch({ type: "dequeue-loading" });
       }
-    } else {
-      hasMounted.current = true;
     }
-  }, [loading, visualizationDispatch]);
+  }, [loading, visualizationDispatch, isMounted]);
 };

--- a/src/app/src/features/eu4/features/country-details/CountryDetailsDrawer.tsx
+++ b/src/app/src/features/eu4/features/country-details/CountryDetailsDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Button, Divider, Drawer, Grid, Tabs } from "antd";
 import { useDispatch, useSelector } from "react-redux";
 import {

--- a/src/app/src/features/eu4/features/map/MapTip.tsx
+++ b/src/app/src/features/eu4/features/map/MapTip.tsx
@@ -96,12 +96,14 @@ export const MapTip: React.FC<{}> = () => {
   }, [mapTip]);
 
   useEffect(() => {
-    const map = getEu4Map(eu4CanvasRef);
-    map.onProvinceHover = (e) => {
-      if (isMounted.current) {
-        setProvinceId(e);
-      }
-    };
+    const map = eu4CanvasRef.current?.map;
+    if (map) {
+      map.onProvinceHover = (e) => {
+        if (isMounted()) {
+          setProvinceId(e);
+        }
+      };
+    }
   }, [eu4CanvasRef, isMounted]);
 
   useEffect(() => {
@@ -117,7 +119,7 @@ export const MapTip: React.FC<{}> = () => {
 
     tooltipTimer.current = setTimeout(async () => {
       const data = await worker.eu4GetMapTooltip(provinceId, mapColor);
-      if (isMounted.current) {
+      if (isMounted()) {
         setMapTip(data);
       }
     }, 250);

--- a/src/app/src/features/eu4/features/map/ProvinceSelectListener.tsx
+++ b/src/app/src/features/eu4/features/map/ProvinceSelectListener.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/features/engine";
 
 export const ProvinceSelectListener: React.FC<{}> = () => {
-  const canvasRef = useEu4CanvasRef();
+  const eu4CanvasRef = useEu4CanvasRef();
   const [drawerVisible, setDrawerVisible] = useState(false);
   const [provinceDetails, setProvinceDetails] = useState<
     ProvinceDetails | undefined
@@ -19,11 +19,11 @@ export const ProvinceSelectListener: React.FC<{}> = () => {
   const [provinceId, setProvinceId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    const map = getEu4Canvas(canvasRef);
-    if (map.map) {
-      map.map.onProvinceSelection = (id) => setProvinceId(id);
+    const map = eu4CanvasRef.current?.map;
+    if (map) {
+      map.onProvinceSelection = (id) => setProvinceId(id);
     }
-  }, [canvasRef]);
+  }, [eu4CanvasRef]);
 
   const cb = useCallback(
     async (worker: WorkerClient) => {

--- a/src/app/src/features/eu4/hooks/useMap.tsx
+++ b/src/app/src/features/eu4/hooks/useMap.tsx
@@ -48,7 +48,7 @@ export function useMap() {
       }
 
       const map = getEu4Canvas(mapRef);
-      if (canvasState.current == "initial") {
+      if (canvasState.current == "initial" && map.map) {
         map.resize(canvasWidth, canvasHeight);
 
         map.cameraFromDimesions(

--- a/src/app/src/hooks/useIsMounted.ts
+++ b/src/app/src/hooks/useIsMounted.ts
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
+// https://usehooks-ts.com/react-hook/use-is-mounted
 export const useIsMounted = () => {
   const isMounted = useRef(false);
 
@@ -8,7 +9,7 @@ export const useIsMounted = () => {
     return () => {
       isMounted.current = false;
     };
-  }, [isMounted]);
+  }, []);
 
-  return isMounted;
+  return useCallback(() => isMounted.current, []);
 };


### PR DESCRIPTION
The error is reproducible when a save is uploaded and then the permalink
is clicked.

We need to reset game analysis, otherwise deeply nested components
within the EU4 view will be triggered and assume that a save is loaded
when reality is that the new save hasn't finished parsing.