### PR TITLE
Add export to csv to chart view

### DIFF
--- a/src/app/src/components/viz/index.tsx
+++ b/src/app/src/components/viz/index.tsx
@@ -39,6 +39,7 @@ export const Bar: ComponentType<BarConfig> = React.memo(
 export {
   VisualizationProvider,
   useVisualizationDispatch,
+  useVisualization,
   useIsLoading,
 } from "./visualization-context";
 

--- a/src/app/src/components/viz/visualization-context.tsx
+++ b/src/app/src/components/viz/visualization-context.tsx
@@ -2,9 +2,13 @@ import React from "react";
 
 interface VisualizationState {
   loading: number;
+  getCsvData: () => Promise<string>;
 }
 
-type Action = { type: "enqueue-loading" } | { type: "dequeue-loading" };
+type Action =
+  | { type: "enqueue-loading" }
+  | { type: "dequeue-loading" }
+  | { type: "update-csv-data"; getCsvData: VisualizationState["getCsvData"] };
 
 type Dispatch = (action: Action) => void;
 const VisualizationContext = React.createContext<
@@ -23,12 +27,15 @@ function visualizationReducer(
       return { ...state, loading: state.loading + 1 };
     case "dequeue-loading":
       return { ...state, loading: state.loading - 1 };
+    case "update-csv-data":
+      return { ...state, getCsvData: action.getCsvData };
   }
 }
 
 export const VisualizationProvider: React.FC<{}> = ({ children }) => {
   const [state, dispatch] = React.useReducer(visualizationReducer, {
     loading: 0,
+    getCsvData: async () => "",
   });
 
   return (
@@ -40,7 +47,7 @@ export const VisualizationProvider: React.FC<{}> = ({ children }) => {
   );
 };
 
-function useVisualization() {
+export function useVisualization() {
   const data = React.useContext(VisualizationContext);
   if (data === undefined) {
     throw new Error("visualization context is undefined");

--- a/src/app/src/features/eu4/features/charts/ChartDrawer.tsx
+++ b/src/app/src/features/eu4/features/charts/ChartDrawer.tsx
@@ -1,20 +1,11 @@
 import React, { useState } from "react";
-import { Drawer, Button, Select, Grid, Spin } from "antd";
-import {
-  MenuFoldOutlined,
-  MenuUnfoldOutlined,
-  QuestionCircleOutlined,
-} from "@ant-design/icons";
-import { useIsLoading } from "@/components/viz/visualization-context";
+import { Drawer } from "antd";
 import { VizRenderer } from "./VizRenderer";
 import { DisplayLimitAlert } from "./DisplayLimitAlert";
-import { CountryFilterButton } from "@/features/eu4/features/country-filter";
 import { VizModules } from "../../types/visualizations";
 import { Help } from "./Help";
 import { useSideBarContainerRef } from "../../components/SideBarContainer";
-
-const { useBreakpoint } = Grid;
-const { Option } = Select;
+import { ChartDrawerTitle } from "./ChartDrawerTitle";
 
 interface ChartDrawerProps {
   visible: boolean;
@@ -34,16 +25,17 @@ const vizModuleDisplayLimit = (module: VizModules) => {
   }
 };
 
+const DEFAULT_VIZUALIZATION_SELECTION = "monthly-income";
+
 export const ChartDrawer: React.FC<ChartDrawerProps> = ({
   visible,
   closeDrawer,
 }) => {
-  const defaultValue = "monthly-income";
-  const [selectedViz, setSelectedViz] = useState<VizModules>(defaultValue);
+  const [selectedViz, setSelectedViz] = useState<VizModules>(
+    DEFAULT_VIZUALIZATION_SELECTION
+  );
   const [expanded, setExpanded] = useState(false);
   const [helpVisible, setHelpVisible] = useState(false);
-  const { md } = useBreakpoint();
-  const isLoading = useIsLoading();
   const displayLimit = vizModuleDisplayLimit(selectedViz);
   const sideBarContainerRef = useSideBarContainerRef();
 
@@ -57,82 +49,13 @@ export const ChartDrawer: React.FC<ChartDrawerProps> = ({
       onClose={closeDrawer}
       width={!expanded ? "min(800px, 100%)" : "100%"}
       title={
-        <div className="flex-row gap">
-          {md && (
-            <Button
-              icon={expanded ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-              onClick={() => setExpanded(!expanded)}
-            />
-          )}
-
-          <Select
-            showSearch
-            defaultValue={defaultValue}
-            value={selectedViz}
-            onChange={(e: VizModules) => setSelectedViz(e)}
-            style={{ width: 200 }}
-            filterOption={(input, option) => {
-              if (Array.isArray(option?.options)) {
-                return false;
-              }
-
-              return option?.searchlabel?.toLowerCase().includes(input);
-            }}
-          >
-            <Select.OptGroup label="Annual Charts">
-              <Option value="monthly-income" searchlabel="Monthly Income">
-                Monthly Income
-              </Option>
-              <Option value="nation-size" searchlabel="Nation Size">
-                Nation Size
-              </Option>
-              <Option value="score" searchlabel="Score">
-                Score
-              </Option>
-              <Option value="inflation" searchlabel="Inflation">
-                Inflation
-              </Option>
-            </Select.OptGroup>
-            <Select.OptGroup label="Tables">
-              <Option value="army-casualties" searchlabel="Army Casualties">
-                Army Casualties
-              </Option>
-              <Option value="navy-casualties" searchlabel="Navy Casualties">
-                Navy Casualties
-              </Option>
-              <Option value="wars" searchlabel="Wars and Battles">
-                Wars and Battles
-              </Option>
-
-              <Option value="income-table" searchlabel="Last Month Income">
-                Last Month's Income
-              </Option>
-              <Option value="expense-table" searchlabel="Last Month Expenses">
-                Last Month's Expenses
-              </Option>
-              <Option
-                value="total-expense-table"
-                searchlabel="Accumulated Expenses"
-              >
-                Accumulated Expenses
-              </Option>
-            </Select.OptGroup>
-            <Select.OptGroup label="Other">
-              <Option value="idea-group" searchlabel="Idea Groups Picked">
-                Idea Groups Picked
-              </Option>
-              <Option value="health" searchlabel="Health Heatmap">
-                Health Heatmap
-              </Option>
-            </Select.OptGroup>
-          </Select>
-          <CountryFilterButton />
-          <Button
-            onClick={() => setHelpVisible(true)}
-            icon={<QuestionCircleOutlined />}
-          />
-          <Spin spinning={isLoading} />
-        </div>
+        <ChartDrawerTitle
+          selectedViz={selectedViz}
+          setSelectedViz={setSelectedViz}
+          expanded={expanded}
+          setExpanded={setExpanded}
+          onHelp={() => setHelpVisible(true)}
+        />
       }
     >
       <Drawer visible={helpVisible} onClose={() => setHelpVisible(false)}>

--- a/src/app/src/features/eu4/features/charts/ChartDrawerTitle.tsx
+++ b/src/app/src/features/eu4/features/charts/ChartDrawerTitle.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { Button, Grid, Select, Spin, Tooltip } from "antd";
+import { useIsLoading, useVisualization } from "@/components/viz";
+import {
+  MenuFoldOutlined,
+  MenuUnfoldOutlined,
+  QuestionCircleOutlined,
+  ProfileOutlined,
+} from "@ant-design/icons";
+import { VizModules } from "../../types/visualizations";
+import { CountryFilterButton } from "../country-filter";
+import { downloadData } from "@/lib/downloadData";
+import { useSelector } from "react-redux";
+import { selectAnalyzeFileName } from "@/features/engine";
+
+const { useBreakpoint } = Grid;
+const { Option } = Select;
+
+interface ChartDrawerTitleProps {
+  selectedViz: VizModules;
+  setSelectedViz: (arg: VizModules) => void;
+  expanded: boolean;
+  setExpanded: (arg: boolean) => void;
+  onHelp: () => void;
+}
+
+export const ChartDrawerTitle: React.FC<ChartDrawerTitleProps> = ({
+  selectedViz,
+  setSelectedViz,
+  expanded,
+  setExpanded,
+  onHelp,
+}) => {
+  const { md } = useBreakpoint();
+  const isLoading = useIsLoading();
+  const viz = useVisualization();
+  const filename = useSelector(selectAnalyzeFileName);
+
+  return (
+    <div className="flex-row gap">
+      {md && (
+        <Button
+          icon={expanded ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+          onClick={() => setExpanded(!expanded)}
+        />
+      )}
+
+      <Select
+        showSearch
+        value={selectedViz}
+        onChange={(e: VizModules) => setSelectedViz(e)}
+        style={{ width: 200 }}
+        filterOption={(input, option) => {
+          if (Array.isArray(option?.options)) {
+            return false;
+          }
+
+          return option?.searchlabel?.toLowerCase().includes(input);
+        }}
+      >
+        <Select.OptGroup label="Annual Charts">
+          <Option value="monthly-income" searchlabel="Monthly Income">
+            Monthly Income
+          </Option>
+          <Option value="nation-size" searchlabel="Nation Size">
+            Nation Size
+          </Option>
+          <Option value="score" searchlabel="Score">
+            Score
+          </Option>
+          <Option value="inflation" searchlabel="Inflation">
+            Inflation
+          </Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="Tables">
+          <Option value="army-casualties" searchlabel="Army Casualties">
+            Army Casualties
+          </Option>
+          <Option value="navy-casualties" searchlabel="Navy Casualties">
+            Navy Casualties
+          </Option>
+          <Option value="wars" searchlabel="Wars and Battles">
+            Wars and Battles
+          </Option>
+
+          <Option value="income-table" searchlabel="Last Month Income">
+            Last Month's Income
+          </Option>
+          <Option value="expense-table" searchlabel="Last Month Expenses">
+            Last Month's Expenses
+          </Option>
+          <Option
+            value="total-expense-table"
+            searchlabel="Accumulated Expenses"
+          >
+            Accumulated Expenses
+          </Option>
+        </Select.OptGroup>
+        <Select.OptGroup label="Other">
+          <Option value="idea-group" searchlabel="Idea Groups Picked">
+            Idea Groups Picked
+          </Option>
+          <Option value="health" searchlabel="Health Heatmap">
+            Health Heatmap
+          </Option>
+        </Select.OptGroup>
+      </Select>
+      <CountryFilterButton />
+      <Tooltip title="download data as csv">
+        <Button
+          icon={<ProfileOutlined />}
+          onClick={async () => {
+            const csvData = await viz.getCsvData();
+
+            const nameInd = filename.lastIndexOf(".");
+            const outputName =
+              nameInd == -1
+                ? `${filename}`
+                : `${filename.substring(0, nameInd)}`;
+
+            downloadData(
+              new Blob([csvData], { type: "text/csv" }),
+              `${outputName}-${selectedViz}.csv`
+            );
+          }}
+        />
+      </Tooltip>
+      <Button onClick={onHelp} icon={<QuestionCircleOutlined />} />
+      <Spin spinning={isLoading} />
+    </div>
+  );
+};

--- a/src/app/src/features/eu4/features/charts/annual-ledger/AnnualLedger.tsx
+++ b/src/app/src/features/eu4/features/charts/annual-ledger/AnnualLedger.tsx
@@ -1,8 +1,13 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
-import { Line, LineConfig } from "@/components/viz";
+import { Line, LineConfig, useVisualizationDispatch } from "@/components/viz";
 import { LedgerDatum } from "@/features/eu4/types/models";
 import { selectEu4CountryNameLookup } from "@/features/eu4/eu4Slice";
+import { Button, Tooltip } from "antd";
+import { FileExcelOutlined } from "@ant-design/icons";
+import { useVisualization } from "@/components/viz/visualization-context";
+import { downloadData } from "@/lib/downloadData";
+import { createCsv } from "@/lib/csv";
 
 interface LedgerProps {
   ledger: LedgerDatum[];
@@ -41,5 +46,17 @@ const AnnualLedgerPropped: React.FC<MemoProps> = React.memo(
 
 export const AnnualLedger: React.FC<LedgerProps> = ({ ledger }) => {
   const lookup = useSelector(selectEu4CountryNameLookup);
+  const visualizationDispatch = useVisualizationDispatch();
+
+  useEffect(() => {
+    visualizationDispatch({
+      type: "update-csv-data",
+      getCsvData: async () => {
+        const keys: (keyof LedgerDatum)[] = ["tag", "name", "year", "value"];
+        return createCsv(ledger, keys);
+      },
+    });
+  }, [ledger, visualizationDispatch]);
+
   return <AnnualLedgerPropped ledger={ledger} lookup={lookup} />;
 };

--- a/src/app/src/features/eu4/features/charts/casualties/CountriesArmyCasualtiesTable.tsx
+++ b/src/app/src/features/eu4/features/charts/casualties/CountriesArmyCasualtiesTable.tsx
@@ -1,27 +1,48 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { Table } from "antd";
 import { ColumnGroupType, ColumnType } from "antd/lib/table";
 import { PlusCircleTwoTone, MinusCircleTwoTone } from "@ant-design/icons";
 import { TableLosses, useCountryCasualtyData } from "./hooks";
-import { useIsLoading } from "@/components/viz/visualization-context";
+import {
+  useIsLoading,
+  useVisualizationDispatch,
+} from "@/components/viz/visualization-context";
 import { formatInt } from "@/lib/format";
 import { ExpandableConfig } from "antd/lib/table/interface";
 import { CountriesArmyCasualtiesWarTable } from "./CountriesArmyCasualtiesWarTable";
 import { FlagAvatar } from "@/features/eu4/components/avatars";
 import { countryColumnFilter } from "../countryColumnFilter";
+import { createCsv } from "@/lib/csv";
+
+const unitTypes = [
+  ["Inf", "infantry"],
+  ["Cav", "cavalry"],
+  ["Art", "artillery"],
+  ["Total", "landTotal"],
+];
 
 export const CountriesArmyCasualtiesTable: React.FC<{}> = () => {
   const data = useCountryCasualtyData();
   const isLoading = useIsLoading();
   const numRenderer = (x: number) => formatInt(x);
   const selectFilterRef = useRef(null);
+  const visualizationDispatch = useVisualizationDispatch();
 
-  const unitTypes = [
-    ["Inf", "infantry"],
-    ["Cav", "cavalry"],
-    ["Art", "artillery"],
-    ["Total", "landTotal"],
-  ];
+  useEffect(() => {
+    visualizationDispatch({
+      type: "update-csv-data",
+      getCsvData: async () => {
+        const keys: (keyof TableLosses)[] = [
+          "tag",
+          "name",
+          ...unitTypes.map(([_, type]) => `${type}Battle` as keyof TableLosses),
+          ...unitTypes.map(([_, type]) => `${type}Attrition` as keyof TableLosses),
+          "landTotal",
+        ];
+        return createCsv(data, keys);
+      },
+    });
+  }, [data, visualizationDispatch]);
 
   const battleColumns: ColumnType<TableLosses>[] = unitTypes.map(
     ([title, type]) => ({

--- a/src/app/src/lib/csv.ts
+++ b/src/app/src/lib/csv.ts
@@ -1,0 +1,12 @@
+export function createCsv<T>(data: T[], keys: (keyof T)[]): string {
+  const header = keys.join(",");
+  let output = header + "\n";
+
+  for (let i = 0; i < data.length; i++) {
+    const datum = data[i];
+    output += keys.map((x) => datum[x]).join(",");
+    output += "\n";
+  }
+
+  return output;
+}


### PR DESCRIPTION
The visualizations and data tables in the chart view may not be in
someone's desired format, so this commit adds the ability to download
the data as a csv.

The main implementation oddity is that since the data download button
lives outside any calculations, it relies on the visualizations to set a
function to lazily compute the csv.

![image](https://user-images.githubusercontent.com/2106129/165083979-c2245c4b-a427-45ea-9c46-1d6765fa07d0.png)
