### PR TITLE
Maintain and always show table page size

### DIFF
--- a/src/app/src/features/eu4/features/charts/CountriesExpensesBaseTable.tsx
+++ b/src/app/src/features/eu4/features/charts/CountriesExpensesBaseTable.tsx
@@ -21,6 +21,7 @@ import { useAppDispatch } from "@/lib/store";
 import { FlagAvatar } from "@/features/eu4/components/avatars";
 import { selectEu4CountryFilter } from "@/features/eu4/eu4Slice";
 import { createCsv } from "@/lib/csv";
+import { useTablePagination } from "@/features/ui-controls";
 const { Text } = Typography;
 
 type CountryExpensesRecord = CountryExpenses;
@@ -42,6 +43,7 @@ export const CountriesExpensesBaseTable = ({
   const countryFilter = useSelector(selectEu4CountryFilter);
   const selectFilterRef = useRef(null);
   const visualizationDispatch = useVisualizationDispatch();
+  const tablePagination = useTablePagination();
 
   const cb = useCallback(
     async (worker: WorkerClient) => {
@@ -157,6 +159,7 @@ export const CountriesExpensesBaseTable = ({
         loading={isLoading}
         dataSource={data}
         columns={columns}
+        pagination={tablePagination}
         scroll={{ x: true }}
       />
     </div>

--- a/src/app/src/features/eu4/features/charts/CountriesIncomeTable.tsx
+++ b/src/app/src/features/eu4/features/charts/CountriesIncomeTable.tsx
@@ -24,6 +24,7 @@ import {
 import { useAppDispatch } from "@/lib/store";
 import { FlagAvatar } from "@/features/eu4/components/avatars";
 import { createCsv } from "@/lib/csv";
+import { useTablePagination } from "@/features/ui-controls";
 const { Text } = Typography;
 
 type CountryIncomeRecord = CountryIncome;
@@ -38,6 +39,7 @@ export const CountriesIncomeTable = () => {
   const countryFilter = useSelector(selectEu4CountryFilter);
   const selectFilterRef = useRef(null);
   const visualizationDispatch = useVisualizationDispatch();
+  const tablePagination = useTablePagination();
 
   const cb = useCallback(
     async (worker: WorkerClient) => {
@@ -145,6 +147,7 @@ export const CountriesIncomeTable = () => {
           loading={isLoading}
           dataSource={data}
           columns={columns}
+          pagination={tablePagination}
           scroll={{ x: true }}
         />
       </Space>

--- a/src/app/src/features/eu4/features/charts/WarTable.tsx
+++ b/src/app/src/features/eu4/features/charts/WarTable.tsx
@@ -13,6 +13,7 @@ import { selectEu4CountryFilter } from "@/features/eu4/eu4Slice";
 import { FlagAvatar } from "@/features/eu4/components/avatars";
 import { createCsv } from "@/lib/csv";
 import { useVisualizationDispatch } from "@/components/viz";
+import { useTablePagination } from "@/features/ui-controls";
 
 interface WarSideData extends WarSide {
   original_name: string;
@@ -27,6 +28,7 @@ interface WarTableData extends War {
 export const WarTable = () => {
   const [data, setData] = useState<WarTableData[]>([]);
   const filter = useSelector(selectEu4CountryFilter);
+  const tablePagination = useTablePagination();
   const visualizationDispatch = useVisualizationDispatch();
   const cb = useCallback(
     async (worker: WorkerClient) => {
@@ -269,6 +271,7 @@ export const WarTable = () => {
       scroll={{ x: true }}
       dataSource={data}
       columns={columns}
+      pagination={tablePagination}
       expandable={expandable}
     />
   );

--- a/src/app/src/features/eu4/features/charts/casualties/CountriesArmyCasualtiesTable.tsx
+++ b/src/app/src/features/eu4/features/charts/casualties/CountriesArmyCasualtiesTable.tsx
@@ -13,6 +13,7 @@ import { CountriesArmyCasualtiesWarTable } from "./CountriesArmyCasualtiesWarTab
 import { FlagAvatar } from "@/features/eu4/components/avatars";
 import { countryColumnFilter } from "../countryColumnFilter";
 import { createCsv } from "@/lib/csv";
+import { useTablePagination } from "@/features/ui-controls";
 
 const unitTypes = [
   ["Inf", "infantry"],
@@ -27,6 +28,7 @@ export const CountriesArmyCasualtiesTable = () => {
   const numRenderer = (x: number) => formatInt(x);
   const selectFilterRef = useRef(null);
   const visualizationDispatch = useVisualizationDispatch();
+  const tablePagination = useTablePagination();
 
   useEffect(() => {
     visualizationDispatch({
@@ -135,6 +137,7 @@ export const CountriesArmyCasualtiesTable = () => {
       scroll={{ x: true }}
       dataSource={data}
       columns={columns}
+      pagination={tablePagination}
       expandable={expandable}
     />
   );

--- a/src/app/src/features/eu4/features/charts/casualties/CountriesNavyCasualtiesTable.tsx
+++ b/src/app/src/features/eu4/features/charts/casualties/CountriesNavyCasualtiesTable.tsx
@@ -10,6 +10,7 @@ import { useIsLoading, useVisualizationDispatch } from "@/components/viz";
 import { formatInt } from "@/lib/format";
 import { countryColumnFilter } from "../countryColumnFilter";
 import { createCsv } from "@/lib/csv";
+import { useTablePagination } from "@/features/ui-controls";
 
 const unitTypes = [
   ["Heavy", "heavyShip"],
@@ -24,6 +25,7 @@ export const CountriesNavyCasualtiesTable = () => {
   const isLoading = useIsLoading();
   const selectFilterRef = useRef(null);
   const visualizationDispatch = useVisualizationDispatch();
+  const tablePagination = useTablePagination();
 
   useEffect(() => {
     visualizationDispatch({
@@ -135,6 +137,7 @@ export const CountriesNavyCasualtiesTable = () => {
       scroll={{ x: true }}
       dataSource={data}
       columns={columns}
+      pagination={tablePagination}
       expandable={expandable}
     />
   );

--- a/src/app/src/features/eu4/features/country-details/CountryLeaders.tsx
+++ b/src/app/src/features/eu4/features/country-details/CountryLeaders.tsx
@@ -1,4 +1,5 @@
 import { useWorkerOnSave, WorkerClient } from "@/features/engine";
+import { useTablePagination } from "@/features/ui-controls";
 import { Tag } from "antd";
 import Table, { ColumnGroupType, ColumnType } from "antd/lib/table";
 import { useCallback, useState } from "react";
@@ -9,6 +10,7 @@ export interface CountryLeadersProps {
 }
 
 export const CountryLeaders = ({ details }: CountryLeadersProps) => {
+  const tablePagination = useTablePagination();
   const [data, setData] = useState<CountryLeader[]>([]);
   const cb = useCallback(
     async (worker: WorkerClient) => {
@@ -19,13 +21,6 @@ export const CountryLeaders = ({ details }: CountryLeadersProps) => {
   );
 
   useWorkerOnSave(cb);
-
-  const [includeGenerals, setIncludeGenerals] = useState(true);
-  const [includeAdmirals, setIncludeAdmirals] = useState(true);
-  const [includeExplorers, setIncludeExplorers] = useState(true);
-  const [includeConquistadors, setIncludeConquistadors] = useState(true);
-  const [includeUnactive, setIncludeUnactive] = useState(true);
-  const [includeOnlyRulers, setIncludeOnlyRulers] = useState(false);
 
   const columns: (
     | ColumnGroupType<CountryLeader>
@@ -129,6 +124,7 @@ export const CountryLeaders = ({ details }: CountryLeadersProps) => {
       dataSource={data}
       scroll={{ x: true }}
       columns={columns}
+      pagination={tablePagination}
       title={() => "Leaders"}
     />
   );

--- a/src/app/src/features/ui-controls/index.tsx
+++ b/src/app/src/features/ui-controls/index.tsx
@@ -1,0 +1,1 @@
+export * from "./uiControlsSlice";

--- a/src/app/src/features/ui-controls/uiControlsSlice.ts
+++ b/src/app/src/features/ui-controls/uiControlsSlice.ts
@@ -1,0 +1,35 @@
+import { useAppDispatch, useAppSelector } from "@/lib/store";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { PaginationProps } from "antd";
+
+interface UiControlsState {
+  tablePageSize?: number;
+}
+
+const initialState: UiControlsState = {
+  tablePageSize: undefined,
+};
+
+const uiControlsSlice = createSlice({
+  name: "uiControls",
+  initialState: initialState,
+  reducers: {
+    pageSizeChange(state, action: PayloadAction<number>) {
+      state.tablePageSize = action.payload;
+    },
+  },
+});
+
+export function useTablePagination(): PaginationProps {
+  const dispatch = useAppDispatch();
+  const tablePageSize = useAppSelector((x) => x.uiControls.tablePageSize);
+  return {
+    defaultPageSize: tablePageSize,
+    showSizeChanger: true,
+    onShowSizeChange: (_, size) => dispatch(pageSizeChange(size)),
+  };
+}
+
+export const { pageSizeChange } = uiControlsSlice.actions;
+
+export const { reducer } = uiControlsSlice;

--- a/src/app/src/lib/store.ts
+++ b/src/app/src/lib/store.ts
@@ -9,6 +9,7 @@ import { reducer as eu4Reducer } from "@/features/eu4/eu4Slice";
 import { reducer as ck3Reducer } from "@/features/ck3/ck3Slice";
 import { reducer as hoi4Reducer } from "@/features/hoi4/hoi4Slice";
 import { reducer as imperatorReducer } from "@/features/imperator/imperatorSlice";
+import { reducer as uiControlsReducer } from "@/features/ui-controls";
 import { rtkQueryErrorLogger } from "./apiErrorMiddleware";
 
 const rootReducer = combineReducers({
@@ -19,6 +20,7 @@ const rootReducer = combineReducers({
   ck3: ck3Reducer,
   hoi4: hoi4Reducer,
   imperator: imperatorReducer,
+  uiControls: uiControlsReducer,
   [appApi.reducerPath]: appApi.reducer,
 });
 


### PR DESCRIPTION
The default behavior is to only show the page size changer when there is
more than 50 items, so if there were 49 items, one would have to page
through 5 pages to see all the items even if all 50 rows could be
displayed on the screen.

Closes #101 