### PR TITLE
Splice token gap from lookup

### DIFF
--- a/src/schemas/Cargo.toml
+++ b/src/schemas/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 
+[features]
+inline = []
+
 [dependencies]
 flatbuffers = "2"
 jomini = "0.19"

--- a/src/schemas/benches/schema_benchmark.rs
+++ b/src/schemas/benches/schema_benchmark.rs
@@ -29,42 +29,6 @@ impl<'a> jomini::binary::TokenResolver for FlatbufferResolver<'a> {
     }
 }
 
-pub struct FlatbufferResolverHalf<'a> {
-    lower: Vec<&'a str>,
-    upper: Vec<&'a str>,
-}
-
-impl<'a> FlatbufferResolverHalf<'a> {
-    pub fn from_slice(data: &'a [u8]) -> Self {
-        let xb = schemas::tokens::root_as_tokens(data).unwrap();
-        let values = xb.values().unwrap();
-        let mut lower = Vec::new();
-        let mut upper = Vec::new();
-        for (i, val) in values.iter().enumerate() {
-            if i < 10000 {
-                lower.push(val);
-            } else {
-                upper.push(val);
-            }
-        }
-        Self { lower, upper }
-    }
-}
-
-impl<'a> jomini::binary::TokenResolver for FlatbufferResolverHalf<'a> {
-    fn resolve(&self, token: u16) -> Option<&str> {
-        if token < 10000 {
-            self.lower
-                .get(usize::from(token))
-                .and_then(|x| (!x.is_empty()).then(|| *x))
-        } else {
-            self.upper
-                .get(usize::from(token))
-                .and_then(|x| (!x.is_empty()).then(|| *x))
-        }
-    }
-}
-
 pub struct FlatbufferResolverRaw<'a> {
     data: Vector<'a, ForwardsUOffset<&'a str>>,
 }
@@ -148,9 +112,9 @@ fn token_benchmark(c: &mut Criterion) {
         })
     });
 
-    group.bench_function("vec-half", |b| {
+    group.bench_function("current", |b| {
         let mut i = 0;
-        let resolver = FlatbufferResolverHalf::from_slice(data);
+        let resolver = schemas::FlatBufferResolver::from_slice(data);
 
         b.iter(|| {
             let res = resolver.resolve(arr[i % 1024]);

--- a/src/schemas/src/lib.rs
+++ b/src/schemas/src/lib.rs
@@ -6,7 +6,7 @@ mod eu4_flatbuffers;
 #[path = "../target/flatbuffers/tokens_generated.rs"]
 mod tokens_flatbuffers;
 
-mod resolver;
+pub mod resolver;
 
 pub use eu4_flatbuffers::rakaly::eu_4 as eu4;
 pub use flatbuffers;

--- a/src/schemas/src/resolver.rs
+++ b/src/schemas/src/resolver.rs
@@ -1,20 +1,63 @@
+// There is a large gap in token values where values jump from 2000 to 10000
+// (it's always 10000 for some reason). Instead of storing thousands of empty strings
+// to index into, they are instead spliced out
+const BREAKPOINT: u16 = 10000;
+
 pub struct FlatBufferResolver<'a> {
-    data: Vec<&'a str>,
+    values: Vec<&'a str>,
+
+    // The index where the data after the gap starts
+    breakpoint: u16,
 }
 
 impl<'a> FlatBufferResolver<'a> {
     pub fn from_slice(data: &'a [u8]) -> Self {
         let xb = crate::tokens::root_as_tokens(data).unwrap();
         let values = xb.values().unwrap();
-        let tokens = values.iter().collect::<Vec<_>>();
-        Self { data: tokens }
+        let values = values.iter().collect::<Vec<_>>();
+        let breakpoint = xb.breakpoint();
+        Self { values, breakpoint }
+    }
+
+    pub fn create_data(tokens: Vec<&str>) -> Vec<u8> {
+        let mut buffer = crate::flatbuffers::FlatBufferBuilder::new();
+
+        let lower_max = &tokens[..usize::from(BREAKPOINT)]
+            .iter()
+            .enumerate()
+            .fold(0, |acc, (i, x)| if x.is_empty() { acc } else { i });
+
+        let mut values = Vec::new();
+        values.extend_from_slice(&tokens[..lower_max + 1]);
+        values.extend_from_slice(&tokens[usize::from(BREAKPOINT)..]);
+
+        let offset = buffer.create_vector_of_strings(&values);
+
+        let root = crate::tokens::Tokens::create(
+            &mut buffer,
+            &crate::tokens::TokensArgs {
+                values: Some(offset),
+                breakpoint: (lower_max + 1) as u16,
+            },
+        );
+
+        buffer.finish(root, None);
+        buffer.finished_data().to_vec()
     }
 }
 
 impl<'a> jomini::binary::TokenResolver for FlatBufferResolver<'a> {
     fn resolve(&self, token: u16) -> Option<&str> {
-        self.data
-            .get(usize::from(token))
-            .and_then(|x| (!x.is_empty()).then(|| *x))
+        if token < self.breakpoint {
+            self.values
+                .get(usize::from(token))
+                .and_then(|x| (!x.is_empty()).then(|| *x))
+        } else if token >= BREAKPOINT {
+            self.values
+                .get(usize::from(token - BREAKPOINT + self.breakpoint))
+                .and_then(|x| (!x.is_empty()).then(|| *x))
+        } else {
+            None
+        }
     }
 }

--- a/src/schemas/src/tokens.fbs
+++ b/src/schemas/src/tokens.fbs
@@ -2,6 +2,7 @@ namespace Rakaly.Tokens;
 
 table Tokens {
   values:[string];
+  breakpoint:uint16;
 }
 
 root_type Tokens;


### PR DESCRIPTION
All tokens observed have some sort of large gap (8,000 or so) in token
values that picks back up at 10,000.

This commit takes advantage of this observation to splice out this gap
so that we don't store and communicate so many empty strings for the
lookup. Benchmarks confirmed that performance hit is negligble. There is
a savings of around 100 KB uncompressed per token list, which isn't bad,
but these savings tend to vanish after brotli decoding.