### PR TITLE
Optimize political map timeline calculations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 [[package]]
 name = "eu4save"
 version = "0.7.1"
-source = "git+https://github.com/rakaly/eu4save.git#3c422b29d22d8211dcb23ec4000fd7b6c53062c4"
+source = "git+https://github.com/rakaly/eu4save.git#2690351dc21a5d11f4a207b8051b12e41b220cf0"
 dependencies = [
  "jomini",
  "once_cell",

--- a/src/eu4game/src/models.rs
+++ b/src/eu4game/src/models.rs
@@ -1,4 +1,5 @@
 use eu4save::{CountryTag, ProvinceId};
+use schemas::eu4::Terrain;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GameProvince {
@@ -7,6 +8,12 @@ pub struct GameProvince {
     pub province_is_on_an_island: bool,
     pub center_x: u16,
     pub center_y: u16,
+}
+
+impl GameProvince {
+    pub fn is_habitable(&self) -> bool {
+        !matches!(self.terrain, Terrain::Wasteland | Terrain::Ocean)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/wasm-eu4/src/lib.rs
+++ b/src/wasm-eu4/src/lib.rs
@@ -1939,7 +1939,12 @@ impl SaveFileImpl {
                 .chain(std::iter::once(&(start, war.original_defender)))
                 .chain(attackers_date.iter())
                 .chain(defenders_date.iter())
-                .map(|(date, tag)| self.tag_resolver.resolve(*tag, *date))
+                .map(|(date, tag)| {
+                    self.tag_resolver
+                        .resolve(*tag, *date)
+                        .map(|x| x.current)
+                        .unwrap_or(*tag)
+                })
                 .any(|tag| tags.contains(&tag));
 
             if !filter_war {
@@ -2047,7 +2052,12 @@ impl SaveFileImpl {
                 .chain(std::iter::once(&(start, war.original_defender)))
                 .chain(attackers_date.iter())
                 .chain(defenders_date.iter())
-                .map(|(date, tag)| self.tag_resolver.resolve(*tag, *date))
+                .map(|(date, tag)| {
+                    self.tag_resolver
+                        .resolve(*tag, *date)
+                        .map(|x| x.current)
+                        .unwrap_or(*tag)
+                })
                 .any(|tag| tags.contains(&tag));
 
             if !filter_war {


### PR DESCRIPTION
There's something about the province filters that slows down the map
calculation. Since the political timeline doesn't utilize the province
filters, we can skip that, which decreases time to calculate 2-3x

I also took the time to refactor the code a bit so that it should be
more readable and re-usable when it comes time for the religion map
mode.