### PR TITLE
Fix occassional poor quality and performance of mp4 transcode

### DIFF
--- a/src/app/src/features/eu4/features/settings/Timelapse.tsx
+++ b/src/app/src/features/eu4/features/settings/Timelapse.tsx
@@ -76,15 +76,17 @@ async function transcode(webmInput: Uint8Array, isDeveloper: boolean) {
   const ffmpeg = await ffmpegModule;
   ffmpeg.FS("writeFile", "recording.webm", new Uint8Array(webmInput));
   try {
+    // prettier-ignore
     await ffmpeg.run(
-      "-i",
-      "recording.webm",
-      "-vf",
+      "-i", "recording.webm",
 
       // ref: https://stackoverflow.com/a/20848224/433785
-      "pad=ceil(iw/2)*2:ceil(ih/2)*2",
-      "-vcodec",
-      "libx264",
+      "-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+
+      // ref: https://superuser.com/q/1308355/635104
+      "-vsync", "0",
+
+      "-vcodec", "libx264",
       "recording.mp4"
     );
     const mp4Data = ffmpeg.FS("readFile", "recording.mp4");


### PR DESCRIPTION
For whatever reason, there are occassional recording runs that when
transcoding the webm to mp4 will cause ffmpeg to log errors about
duplicate frames. This effects both native and browser ffmpeg (ie: I
could take an exported webm file and see the same errors when manually
transcoding to mp4).

The transcoding process would be extremely slow, requiring minutes
whereas it would normally take seconds. The quality output would also be
horrendous and nothing like the webm.

The fix is to set vsync to passthrough as mentioned here:
https://superuser.com/questions/1308355/ffmpeg-webm-to-mp4-awful-video-quality#comment1944969_1308355

I'm not too well versed in ffmpeg flags but it seems like webm could
have a variable bit rate and that caused friction in the transcode.