### PR TITLE
Update to ffmpeg 0.11 from 0.10

### DIFF
--- a/src/app/custom.d.ts
+++ b/src/app/custom.d.ts
@@ -17,3 +17,8 @@ declare module "*.svg" {
   const content: string;
   export default content;
 }
+
+declare module "@ffmpeg/core/*" {
+  const content: string;
+  export default content;
+}

--- a/src/app/next.config.js
+++ b/src/app/next.config.js
@@ -17,6 +17,11 @@ let nextConfig = {
       type: "asset/resource",
     });
 
+    config.module.rules.push({
+      test: /@ffmpeg\/core/,
+      type: "asset/resource",
+    });
+
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/#tree-shaking-optional-code-with-nextjs
     config.plugins.push(
       new webpack.DefinePlugin({
@@ -47,7 +52,7 @@ let nextConfig = {
           {
             key: "Content-Security-Policy",
             value: "default-src 'self';" +
-              "connect-src 'self' blob: https://skanderbeg.pm/api.php https://a.pdx.tools/api/event https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/;" +
+              "connect-src 'self' blob: https://skanderbeg.pm/api.php https://a.pdx.tools/api/event;" +
               "img-src 'self' data:;" +
               "script-src 'self' 'unsafe-eval' blob: https://a.pdx.tools/js/index.js;" +
               "style-src 'self' 'unsafe-inline'"

--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/charts": "^1.4.2",
-        "@ffmpeg/ffmpeg": "^0.10.1",
+        "@ffmpeg/core": "^0.11.0",
+        "@ffmpeg/ffmpeg": "^0.11.6",
         "@prisma/client": "^4.7.1",
         "@reduxjs/toolkit": "^1.8.6",
         "@sentry/nextjs": "^7.26.0",
@@ -1608,10 +1609,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ffmpeg/core": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-9Tt/+2PMpkGPXUK8n6He9G8Y+qR6qmCPSCw9iEKZxHHOvJ9BE/r0Fccj+YgDZTlyu6rXxc9x6EqCaFBIt7qzjA=="
+    },
     "node_modules/@ffmpeg/ffmpeg": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
-      "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.11.6.tgz",
+      "integrity": "sha512-uN8J8KDjADEavPhNva6tYO9Fj0lWs9z82swF3YXnTxWMBoFLGq3LZ6FLlIldRKEzhOBKnkVfA8UnFJuvGvNxcA==",
       "dependencies": {
         "is-url": "^1.2.4",
         "node-fetch": "^2.6.1",
@@ -12690,10 +12696,15 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@ffmpeg/core": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-9Tt/+2PMpkGPXUK8n6He9G8Y+qR6qmCPSCw9iEKZxHHOvJ9BE/r0Fccj+YgDZTlyu6rXxc9x6EqCaFBIt7qzjA=="
+    },
     "@ffmpeg/ffmpeg": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
-      "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.11.6.tgz",
+      "integrity": "sha512-uN8J8KDjADEavPhNva6tYO9Fj0lWs9z82swF3YXnTxWMBoFLGq3LZ6FLlIldRKEzhOBKnkVfA8UnFJuvGvNxcA==",
       "requires": {
         "is-url": "^1.2.4",
         "node-fetch": "^2.6.1",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@ant-design/charts": "^1.4.2",
-    "@ffmpeg/ffmpeg": "^0.10.1",
+    "@ffmpeg/core": "^0.11.0",
+    "@ffmpeg/ffmpeg": "^0.11.6",
     "@prisma/client": "^4.7.1",
     "@reduxjs/toolkit": "^1.8.6",
     "@sentry/nextjs": "^7.26.0",

--- a/src/app/workers-site/index.ts
+++ b/src/app/workers-site/index.ts
@@ -198,7 +198,7 @@ function withSecurityHeaders(response: Response, pathname: string) {
   newResponse.headers.set(
     "Content-Security-Policy",
     "default-src 'self';" +
-      "connect-src 'self' blob: https://skanderbeg.pm/api.php https://a.pdx.tools/api/event https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.10.0/;" +
+      "connect-src 'self' blob: https://skanderbeg.pm/api.php https://a.pdx.tools/api/event;" +
       "img-src 'self' data:;" +
       // unsafe-eval needed for webassembly on safari
       "script-src 'self' 'unsafe-eval' blob: https://a.pdx.tools/js/index.js;" +


### PR DESCRIPTION
0.11 allows us to self host the wasm payload much easier (will need to check that we don't exceed the cloudflare file size limit on the wasm payload, as it is 8MB gzipped).

Blocked on https://github.com/ffmpegwasm/ffmpeg.wasm/issues/451