### PR TITLE
Timelapse and historical map improvements

### DIFF
--- a/src/app/src/features/engine/GameView.tsx
+++ b/src/app/src/features/engine/GameView.tsx
@@ -122,10 +122,7 @@ const FullscreenPage = ({
   }, [hasBackdrop, resetSaveAnalysis]);
 
   return (
-    <div
-      ref={ref}
-      className={`fixed inset-0 bg-white ${classes["slide-in"]}`}
-    >
+    <div ref={ref} className={`fixed inset-0 bg-white ${classes["slide-in"]}`}>
       {children}
     </div>
   );

--- a/src/app/src/features/eu4/features/map/MapTip.tsx
+++ b/src/app/src/features/eu4/features/map/MapTip.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { useEu4Map, useEu4MapMode } from "../../store";
+import { useEu4Map, useEu4MapMode, useSelectedDate } from "../../store";
 import { QuickTipPayload } from "../../types/map";
 import { getEu4Worker } from "../../worker";
 import { MapTipContents } from "./MapTipContents";
@@ -19,6 +19,7 @@ export const MapTip = () => {
   const [mapTip, setMapTip] = useState<QuickTipPayload | null>(null);
   const [provinceId, setProvinceId] = useState(0);
   const mapMode = useEu4MapMode();
+  const currentMapDate = useSelectedDate();
   const map = useEu4Map();
 
   useEffect(() => {
@@ -117,7 +118,8 @@ export const MapTip = () => {
     setTimerDisplay(false);
 
     tooltipTimer.current = setTimeout(async () => {
-      const data = await worker.eu4GetMapTooltip(provinceId, mapMode);
+      const days = currentMapDate.enabledDays ?? undefined;
+      const data = await worker.eu4GetMapTooltip(provinceId, mapMode, days);
       if (isMounted) {
         setMapTip(data);
       }
@@ -129,7 +131,7 @@ export const MapTip = () => {
         clearTimeout(tooltipTimer.current);
       }
     };
-  }, [provinceId, mapMode]);
+  }, [provinceId, mapMode, currentMapDate]);
 
   // When we are calculating (or don't want to display) the tooltip,
   // set the opacity to 0 instead of removing the display so that the width

--- a/src/app/src/features/eu4/features/map/ProvinceSelectListener.tsx
+++ b/src/app/src/features/eu4/features/map/ProvinceSelectListener.tsx
@@ -12,8 +12,17 @@ export const ProvinceSelectListener = () => {
   const [data, setData] = useState<ProvinceDetails | undefined>();
   useEffect(() => {
     map.onProvinceSelection = async (id) => {
-      setData(await getEu4Worker().eu4GetProvinceDeteails(id));
-      setDrawerVisible(true);
+      const details = await getEu4Worker().eu4GetProvinceDeteails(id);
+      if (details) {
+        map.highlightSelectedProvince();
+        map.redrawMapImage();
+        setDrawerVisible(true);
+        setData(details);
+      } else {
+        map.unhighlightSelectedProvince();
+        map.redrawMapImage();
+        setDrawerVisible(false);
+      }
     };
   }, [map]);
 

--- a/src/app/src/features/eu4/features/settings/MapSettings.tsx
+++ b/src/app/src/features/eu4/features/settings/MapSettings.tsx
@@ -15,7 +15,6 @@ import {
   useTerrainOverlay,
   useShowProvinceBorders,
   useShowCountryBorders,
-  useIsCountryBordersDisabled,
   useShowMapModeBorders,
 } from "../../store";
 
@@ -74,14 +73,12 @@ const ProvinceBordersToggleRow = () => {
 const CountryBordersToggleRow = () => {
   const data = useShowCountryBorders();
   const { setShowCountryBorders } = useEu4Actions();
-  const countryBordersDisabled = useIsCountryBordersDisabled();
 
   return (
     <ToggleRow
-      value={countryBordersDisabled ? false : data}
+      value={data}
       onChange={setShowCountryBorders}
       text="Paint country borders"
-      disabled={countryBordersDisabled}
     />
   );
 };
@@ -89,15 +86,12 @@ const CountryBordersToggleRow = () => {
 const MapModeBordersToggleRow = () => {
   const data = useShowMapModeBorders();
   const { setShowMapModeBorders } = useEu4Actions();
-  const mapMode = useEu4MapMode();
-  const disabled = mapMode == "terrain" || mapMode == "political";
 
   return (
     <ToggleRow
       value={data}
       onChange={setShowMapModeBorders}
       text="Paint map mode borders"
-      disabled={disabled}
     />
   );
 };

--- a/src/app/src/features/eu4/features/settings/TimelapseEncoder.tsx
+++ b/src/app/src/features/eu4/features/settings/TimelapseEncoder.tsx
@@ -1,29 +1,16 @@
-import { MapPayload } from "../../types/map";
-import { MapDate } from "../../types/models";
 import WebMMuxer from "webm-muxer";
 import { WebGLMap } from "@/map/map";
-import { Eu4Worker } from "../../worker";
+import { Eu4Worker, getEu4Worker } from "../../worker";
+import { Eu4Store } from "../../store";
 
-type DateInterval = "Year" | "Month" | "Week" | "Day";
-
-export async function* dates(
-  worker: Eu4Worker,
-  start: MapDate,
-  end: MapDate,
-  step: DateInterval
+export async function* mapTimelapseCursor(
+  ...args: Parameters<Eu4Worker["mapTimelapse"]>
 ) {
-  let current = start;
-  while (true) {
-    yield current;
-    const newDate = await worker.eu4IncrementDate(current.days, step);
-
-    if (current.days >= end.days) {
-      break;
-    } else if (newDate.days > end.days) {
-      current = end;
-    } else {
-      current = newDate;
-    }
+  const worker = getEu4Worker();
+  await worker.mapTimelapse(...args);
+  let item;
+  while ((item = await worker.mapTimelapseNext()) != undefined) {
+    yield item;
   }
 }
 
@@ -34,12 +21,9 @@ type EncoderConfig = VideoEncoderConfig & {
 type TimelapseEncoderOptions = {
   map: WebGLMap;
   fps: number;
-  interval: "Year" | "Month" | "Week" | "Day";
-  worker: Eu4Worker;
-  mapPayload: MapPayload;
-  startDate: MapDate;
-  endDate: MapDate;
+  frames: ReturnType<typeof mapTimelapseCursor>;
   freezeFrame: number;
+  store: Eu4Store;
 };
 
 export class TimelapseEncoder {
@@ -52,16 +36,13 @@ export class TimelapseEncoder {
 
   private constructor(
     private map: WebGLMap,
-    private worker: Eu4Worker,
     config: EncoderConfig,
     private ctx2d: CanvasRenderingContext2D,
+    private frames: ReturnType<typeof mapTimelapseCursor>,
     private fontFamily: string,
-    private mapPayload: MapPayload,
-    private startDate: MapDate,
-    private endDate: MapDate,
     private fps: number,
-    private interval: TimelapseEncoderOptions["interval"],
-    private freezeFrame: number
+    private freezeFrame: number,
+    private store: Eu4Store
   ) {
     this.muxer = new WebMMuxer({
       target: "buffer",
@@ -103,14 +84,10 @@ export class TimelapseEncoder {
     ctx2d.fillText(date, recordingCanvas.width - 10 * scale, 35 * scale);
   }
 
-  async *timelapse() {
+  async encodeTimelapse() {
     const frameDuration = 1_000_000 / this.fps; // microseconds
-    for await (const date of dates(
-      this.worker,
-      this.startDate,
-      this.endDate,
-      this.interval
-    )) {
+
+    for await (const item of this.frames) {
       if (this.error) {
         throw new Error(this.error.message);
       }
@@ -119,14 +96,9 @@ export class TimelapseEncoder {
         return;
       }
 
-      const [primary, secondary] = await this.worker.eu4MapColors({
-        ...this.mapPayload,
-        date: date.days,
-      });
-
-      this.map.updateProvinceColors(primary, secondary);
+      this.store.getState().actions.updateMap(item);
       this.map.redrawMapNow();
-      this.create2dFrame(date.text);
+      this.create2dFrame(item.date.text);
 
       const frame = new VideoFrame(this.ctx2d.canvas, {
         timestamp: this.timestamp,
@@ -141,31 +113,26 @@ export class TimelapseEncoder {
       frame.close();
       await this.encoder.flush();
       this.timestamp += frameDuration;
+    }
 
-      // For some reason the best quality freeze frame is if we encode it as
-      // many small frame
-      const isFinalFrame = date.days >= this.endDate.days;
-      if (isFinalFrame) {
-        for (
-          let t = this.timestamp;
-          t < this.timestamp + this.freezeFrame * 1_000_000;
-          t += frameDuration
-        ) {
-          const frame = new VideoFrame(this.ctx2d.canvas, {
-            timestamp: t,
-            duration: frameDuration,
-          });
+    // For some reason the best quality freeze frame is if we encode it as
+    // many small frame
+    for (
+      let t = this.timestamp;
+      t < this.timestamp + this.freezeFrame * 1_000_000;
+      t += frameDuration
+    ) {
+      const frame = new VideoFrame(this.ctx2d.canvas, {
+        timestamp: t,
+        duration: frameDuration,
+      });
 
-          this.encoder.encode(frame, {
-            keyFrame: (this.frameCount += 1) % 150 == 0,
-          });
+      this.encoder.encode(frame, {
+        keyFrame: (this.frameCount += 1) % 150 == 0,
+      });
 
-          frame.close();
-          await this.encoder.flush();
-        }
-      }
-
-      yield date;
+      frame.close();
+      await this.encoder.flush();
     }
   }
 
@@ -189,13 +156,10 @@ export class TimelapseEncoder {
 
   static async create({
     map,
+    frames,
     fps,
-    mapPayload,
-    startDate,
-    endDate,
-    worker,
-    interval,
     freezeFrame,
+    store,
   }: TimelapseEncoderOptions) {
     async function findSupportedEncoder() {
       const codecs = [
@@ -243,16 +207,13 @@ export class TimelapseEncoder {
 
     return new TimelapseEncoder(
       map,
-      worker,
       config,
       ctx2d,
+      frames,
       fontFamily,
-      mapPayload,
-      startDate,
-      endDate,
       fps,
-      interval,
-      freezeFrame
+      freezeFrame,
+      store
     );
   }
 }

--- a/src/app/src/features/eu4/store/useLoadEu4.tsx
+++ b/src/app/src/features/eu4/store/useLoadEu4.tsx
@@ -248,13 +248,12 @@ async function loadEu4Save(
   const rect = document.body.getBoundingClientRect();
   map.resize(rect.width, rect.height);
 
-  const [primary, secondary] = await runTask(dispatch, {
+  const { primary, secondary } = await runTask(dispatch, {
     fn: () =>
       worker.eu4MapColors({
         date: null,
         kind: "political",
         paintSubjectInOverlordHue: false,
-        showSecondaryColor: false,
         tagFilter: initialEu4CountryFilter,
       }),
     name: "calculate political map",
@@ -274,6 +273,7 @@ async function loadEu4Save(
     meta,
     achievements,
     countries,
+    initialPoliticalMapColors: primary,
     defaultSelectedCountry: defaultSelectedTag,
     saveInfo,
   };

--- a/src/app/src/features/eu4/types/map.ts
+++ b/src/app/src/features/eu4/types/map.ts
@@ -16,7 +16,6 @@ type MapMode =
 export interface MapPayload {
   kind: MapMode;
   date: number | null;
-  showSecondaryColor: boolean;
   paintSubjectInOverlordHue: boolean;
   tagFilter: CountryMatcher;
 }

--- a/src/map/src/map.ts
+++ b/src/map/src/map.ts
@@ -398,7 +398,12 @@ export class WebGLMap {
     this.highlightSelectedProvince();
   }
 
-  private highlightSelectedProvince() {
+  public unhighlightSelectedProvince() {
+    this.selectedProvinceColorInd = undefined;
+    this.highlightSelectedProvince();
+  }
+
+  public highlightSelectedProvince() {
     if (this.selectedProvinceColorInd !== undefined) {
       const newPrimary = this.originalPrimaryColor.slice();
       newPrimary[this.selectedProvinceColorInd * 4] = 255;
@@ -426,6 +431,9 @@ export class WebGLMap {
     } else {
       this.glResources.fillPrimaryProvinceColorsTexture(
         this.originalPrimaryColor
+      );
+      this.glResources.fillSecondaryProvinceColorsTexture(
+        this.originalSecondaryColor
       );
     }
   }
@@ -566,8 +574,6 @@ export class WebGLMap {
       const prov = this.provinceFinder.findProvinceId(pixelX, pixelY);
       if (prov && prov.colorIndex !== this.selectedProvinceColorInd) {
         this.selectedProvinceColorInd = prov.colorIndex;
-        this.highlightSelectedProvince();
-        this.redrawMapNow();
         this.onProvinceSelection?.(prov.provinceId);
       }
     }

--- a/src/wasm-eu4/src/country_details.rs
+++ b/src/wasm-eu4/src/country_details.rs
@@ -950,7 +950,7 @@ impl SaveFileImpl {
         let mut province_states: HashMap<&str, Vec<(ProvinceId, &Province)>> = HashMap::new();
         for (id, prov, state) in owned_provinces {
             let provs = province_states.entry(state).or_default();
-            provs.push((id.clone(), prov));
+            provs.push((*id, prov));
         }
 
         let mut result: Vec<_> = province_states

--- a/src/wasm-eu4/src/utils.rs
+++ b/src/wasm-eu4/src/utils.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::JsValue;
+
+pub(crate) fn to_json_value<T: serde::ser::Serialize + ?Sized>(value: &T) -> JsValue {
+    let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+    value.serialize(&serializer).unwrap()
+}


### PR DESCRIPTION
Tons of improvements. The headlining feature is political timelapse including controllers 

[ethiopia (8).webm](https://user-images.githubusercontent.com/2106129/226768101-44c2365b-455b-4333-854a-4badea76e4dd.webm)

It's not perfect and I place any imperfections on the save format 😄 

- Rebels are not shown on the map as the game does not accurately record when a province has been liberated.
- After a war, the game does not always record provinces being returned back to the owner, so we have to manually track when wars end and re-assign them
- When a list of controllers are recorded for a province on a single day, only the first controller is used, as the game lists all future tag switches as controllers which would otherwise mess with the logic (as a future tag can be an existing AI tag, so it may erroneously look like the AI took over a province)

Other improvements:

- As shown in the above video, map mode borders now work on timelapses and historical maps.
- More map settings are saved between sessions:
  - Showing province borders
  - Showing country borders
  - Showing map mode borders
- Clicking off a province onto a wasteland or sea tile will close an open province drawer (closes #12)
- Religion map mode and timelapse are consistent in that both compare the province's religion with owner's state religion  instead of the controller's state religion. 

The bulk of the code in this PR is rooted in the introduction of a timelapse cursor. The thought here is that instead of recalculating the state of the world at each date of a timelapse, we can devise a much more efficient cursor that will amortize one time initialization costs, and be able to quickly apply deltas between two dates. Hopefully this proves useful for additional timelapses.