### PR TITLE
Transition healthmap heatmap to table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "eu4save"
 version = "0.8.2"
-source = "git+https://github.com/rakaly/eu4save.git#347550e058628255be18a5c0fe804312e3c2df71"
+source = "git+https://github.com/rakaly/eu4save.git#275b2febcb40080bb6d485f8fcad9967902d0539"
 dependencies = [
  "jomini",
  "libdeflater",

--- a/src/app/src/components/viz/index.tsx
+++ b/src/app/src/components/viz/index.tsx
@@ -2,7 +2,6 @@ import dynamic from "next/dynamic";
 import React, { ComponentType } from "react";
 import type {
   LineConfig as LineConfigImpl,
-  HeatmapConfig,
   PieConfig,
   BarConfig,
   Treemap as TreemapImpl,
@@ -30,13 +29,6 @@ export const LineImpl: ComponentType<LineConfigImpl> = React.memo(
 export const Line = ({ ...props }: LineConfig) => {
   return <LineImpl {...props} />;
 };
-
-export const Heatmap: ComponentType<HeatmapConfig> = React.memo(
-  dynamic(() => import("@ant-design/plots").then((mod) => mod.Heatmap), {
-    ssr: false,
-    loading: () => <VisualizationLoader />,
-  })
-);
 
 export const Pie: ComponentType<PieConfig> = React.memo(
   dynamic(() => import("@ant-design/plots").then((mod) => mod.Pie), {
@@ -70,4 +62,4 @@ export {
 export * from "./LegendColor";
 export * from "./PieTable";
 
-export type { LineConfig, HeatmapConfig, PieConfig, BarConfig };
+export type { LineConfig, PieConfig, BarConfig };

--- a/src/app/src/features/eu4/features/charts/HealthGrid.tsx
+++ b/src/app/src/features/eu4/features/charts/HealthGrid.tsx
@@ -1,26 +1,52 @@
-import React, { useCallback, useEffect, useMemo } from "react";
-import type { HeatmapConfig } from "@ant-design/charts";
-import { formatInt } from "@/lib/format";
-import { Heatmap, useVisualizationDispatch } from "@/components/viz";
+import React, { useCallback, useEffect } from "react";
+import { formatFloat, formatInt } from "@/lib/format";
+import { useVisualizationDispatch } from "@/components/viz";
 import { useAnalysisWorker } from "@/features/eu4/worker";
 import { createCsv } from "@/lib/csv";
 import { useTagFilter } from "../../store";
+import { Table, Tooltip } from "antd";
+import { CountryHealth } from "../../types/models";
+import { FlagAvatar } from "../../components/avatars";
+import { ColumnType } from "antd/lib/table";
 
-const healthCategories = [
-  "prestige",
-  "stability",
-  "pp",
-  "development",
-  "treasury",
-  "inflation",
-  "corruption",
-  "manpower",
-  "adm tech",
-  "dip tech",
-  "mil tech",
-  "innovativeness",
-  "overextension",
-];
+// colors from bg-red-700 to bg-blue-700. But using styles as antd has too high
+// of specificity: https://stackoverflow.com/q/68656826/433785
+function colorToStyle(x: number) {
+  switch (x) {
+    case 0:
+      return { backgroundColor: "#b91c1c", color: "white" };
+    case 1:
+      return { backgroundColor: "#dc2626", color: "white" };
+    case 2:
+      return { backgroundColor: "#ef4444", color: "white" };
+    case 3:
+      return { backgroundColor: "#f87171" };
+    case 4:
+      return { backgroundColor: "#fca5a5" };
+    case 5:
+      return { backgroundColor: "#fecaca" };
+    case 6:
+      return { backgroundColor: "#fee2e2" };
+    case 7:
+      return { backgroundColor: "#fef2f2" };
+    case 8:
+      return { backgroundColor: "#eff6ff" };
+    case 9:
+      return { backgroundColor: "#dbeafe" };
+    case 10:
+      return { backgroundColor: "#bfdbfe" };
+    case 11:
+      return { backgroundColor: "#93c5fd" };
+    case 12:
+      return { backgroundColor: "#60a5fa" };
+    case 13:
+      return { backgroundColor: "#3b82f6" };
+    case 14:
+      return { backgroundColor: "#2563eb", color: "white" };
+    case 15:
+      return { backgroundColor: "#1d4ed8", color: "white" };
+  }
+}
 
 export const HealthGrid = () => {
   const countryFilter = useTagFilter();
@@ -37,67 +63,305 @@ export const HealthGrid = () => {
     visualizationDispatch({
       type: "update-csv-data",
       getCsvData: async () => {
-        const objs: Record<string, any> = {};
-        for (const group of data) {
-          objs[group.name] = {
-            ...objs[group.name],
-            [group.value_type]: group.value,
-          };
-        }
+        const columns = data.map(
+          (x) =>
+            [
+              ["tag", x.tag],
+              ["name", x.name],
+              ["income", x.coreIncome.value],
+              ["treasury_balance", x.treasuryBalance.value],
+              ["development", x.development.value],
+              ["buildings", x.buildings.value],
+              ["inflation", x.inflation.value],
+              ["general_fire", x.bestGeneral.fire],
+              ["general_shock", x.bestGeneral.shock],
+              ["general_manuever", x.bestGeneral.manuever],
+              ["general_siege", x.bestGeneral.siege],
+              ["army_tradition", x.armyTradition.value],
+              ["manpower_balance", x.manpowerBalance.value],
+              ["regiments", x.standardRegiments.value],
+              ["professionalism", x.professionalism.value],
+              ["admiral_fire", x.bestAdmiral.fire],
+              ["admiral_shock", x.bestAdmiral.shock],
+              ["admiral_manuever", x.bestAdmiral.manuever],
+              ["navy_tradition", x.navyTradition.value],
+              ["ships", x.ships.value],
+              ["stability", x.stability.value],
+              ["adm_tech", x.technology.adm],
+              ["dip_tech", x.technology.dip],
+              ["mil_tech", x.technology.mil],
+              ["ideas", x.ideas.value],
+              ["corruption", x.corruption.value],
+            ] as const
+        );
 
-        const flatten = Object.entries(objs).map(([key, values]) => ({
-          name: key,
-          ...values,
-        }));
-        return createCsv(flatten, ["name", ...healthCategories]);
+        const csvData = columns.map((x) => Object.fromEntries(x));
+        const columnNames = columns[0].map(([name, _]) => name);
+        return createCsv(csvData, columnNames);
       },
     });
   }, [data, visualizationDispatch]);
 
-  const countryCount = useMemo(() => {
-    const countSet = new Set();
-    for (let i = 0; i < data.length; i++) {
-      const element = data[i];
-      countSet.add(element.tag);
-    }
-    return countSet.size;
-  }, [data]);
-
-  const config: HeatmapConfig = {
-    data,
-    autoFit: true,
-    xField: "value_type",
-    yField: "name",
-    colorField: "color",
-    color: ["#0d5fbb", "#a2a2a5", "#aa3523"].reverse(),
-    interactions: [{ type: "element-active" }],
-    legend: false,
-    label: false,
-    tooltip: {
-      customContent: (title, data) => {
-        const v = data[0];
-        if (!v) {
-          return "<div></div>";
-        }
-
-        return `<div style="margin: 12px">${v.data.name} - ${
-          v.data.value_type
-        }: ${formatInt(v.data.value)}</div>`;
-      },
+  const columns: ColumnType<CountryHealth>[] = [
+    {
+      title: "Country",
+      dataIndex: "name",
+      className: "no-break",
+      fixed: "left",
+      width: 175,
+      render: (_name: string, x: CountryHealth) => (
+        <FlagAvatar tag={x.tag} name={x.name} size="large" />
+      ),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.name.localeCompare(b.name),
     },
-    meta: {
-      value_type: {
-        type: "cat",
-        values: healthCategories,
-      },
-      name: {},
-      color: {
-        min: -100,
-        max: 100,
-      },
-      value: {},
+    {
+      title: () => (
+        <Tooltip title="Tax + production + trade + gold">Income</Tooltip>
+      ),
+      showSorterTooltip: false,
+      dataIndex: "coreIncome",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.coreIncome.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.coreIncome.value - b.coreIncome.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.coreIncome.color),
+      }),
     },
-  };
+    {
+      title: <Tooltip title="Current treasury minus loans">Treasury</Tooltip>,
+      showSorterTooltip: false,
+      dataIndex: "treasuryBalance",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.treasuryBalance.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.treasuryBalance.value - b.treasuryBalance.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.treasuryBalance.color),
+      }),
+    },
+    {
+      title: (
+        <Tooltip title="Autonomy adjusted development">Development</Tooltip>
+      ),
+      showSorterTooltip: false,
+      dataIndex: "development",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.development.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.development.value - b.development.value,
+      defaultSortOrder: "descend",
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.development.color),
+      }),
+    },
+    {
+      title: "Buildings",
+      dataIndex: "buildings",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.buildings.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.buildings.value - b.buildings.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.buildings.color),
+      }),
+    },
+    {
+      title: "Inflation",
+      dataIndex: "inflation",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatFloat(record.inflation.value, 2),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.inflation.value - b.inflation.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.inflation.color),
+      }),
+    },
+    {
+      title: <Tooltip title="General with most pips">Generals</Tooltip>,
+      showSorterTooltip: false,
+      dataIndex: "bestGeneral",
+      className: "no-break",
+      align: "right",
+      render: (_, record) =>
+        record.bestGeneral.value === 0
+          ? "---"
+          : `(${record.bestGeneral.fire} / ${record.bestGeneral.shock} / ${record.bestGeneral.manuever} / ${record.bestGeneral.siege})`,
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.bestGeneral.value - b.bestGeneral.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.bestGeneral.color),
+      }),
+    },
+    {
+      title: <Tooltip title="Army Tradition">AT</Tooltip>,
+      showSorterTooltip: false,
+      dataIndex: "armyTradition",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatFloat(record.armyTradition.value, 2),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.armyTradition.value - b.armyTradition.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.armyTradition.color),
+      }),
+    },
+    {
+      title: (
+        <Tooltip title="Manpower leftover after reinforcing all units">
+          Manpower
+        </Tooltip>
+      ),
+      showSorterTooltip: false,
+      dataIndex: "manpowerBalance",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.manpowerBalance.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.manpowerBalance.value - b.manpowerBalance.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.manpowerBalance.color),
+      }),
+    },
+    {
+      title: (
+        <Tooltip title="Regiments (excludes mercenaries)">Regiments</Tooltip>
+      ),
+      showSorterTooltip: false,
+      dataIndex: "standardRegiments",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.standardRegiments.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.standardRegiments.value - b.standardRegiments.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.standardRegiments.color),
+      }),
+    },
+    {
+      title: <Tooltip title="Professionalism">Prof</Tooltip>,
+      showSorterTooltip: false,
+      dataIndex: "professionalism",
+      className: "no-break",
+      align: "right",
+      render: (_, record) =>
+        formatInt(record.professionalism.value * 100) + "%",
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.professionalism.value - b.professionalism.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.professionalism.color),
+      }),
+    },
+    {
+      title: (
+        <Tooltip title="Admiral with the most pips (excludes siege pip)">
+          Admirals
+        </Tooltip>
+      ),
+      showSorterTooltip: false,
+      dataIndex: "bestAdmiral",
+      className: "no-break",
+      align: "right",
+      render: (_, record) =>
+        record.bestAdmiral.value === 0
+          ? "---"
+          : `(${record.bestAdmiral.fire} / ${record.bestAdmiral.shock} / ${record.bestAdmiral.manuever})`,
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.bestAdmiral.value - b.bestAdmiral.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.bestAdmiral.color),
+      }),
+    },
+    {
+      title: <Tooltip title="Navy Tradition">NT</Tooltip>,
+      showSorterTooltip: false,
+      dataIndex: "navyTradition",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatFloat(record.navyTradition.value, 2),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.navyTradition.value - b.navyTradition.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.navyTradition.color),
+      }),
+    },
+    {
+      title: "Ships",
+      dataIndex: "boats",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.ships.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.ships.value - b.ships.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.ships.color),
+      }),
+    },
+    {
+      title: "Stability",
+      dataIndex: "stability",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.stability.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.stability.value - b.stability.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.stability.color),
+      }),
+    },
+    {
+      title: "Technology",
+      dataIndex: "technology",
+      className: "no-break",
+      align: "right",
+      render: (_, record) =>
+        `(${record.technology.adm} / ${record.technology.dip} / ${record.technology.mil})`,
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.technology.value - b.technology.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.technology.color),
+      }),
+    },
+    {
+      title: "Ideas",
+      dataIndex: "ideas",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatInt(record.ideas.value),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.ideas.value - b.ideas.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.ideas.color),
+      }),
+    },
+    {
+      title: "Corruption",
+      dataIndex: "corruption",
+      className: "no-break",
+      align: "right",
+      render: (_, record) => formatFloat(record.corruption.value, 2),
+      sorter: (a: CountryHealth, b: CountryHealth) =>
+        a.corruption.value - b.corruption.value,
+      onCell: (record: CountryHealth) => ({
+        style: colorToStyle(record.corruption.color),
+      }),
+    },
+  ];
 
-  return <Heatmap style={{ height: 75 + countryCount * 45 }} {...config} />;
+  return (
+    <Table
+      rowKey="tag"
+      size="small"
+      columns={columns}
+      scroll={{ x: true }}
+      dataSource={data}
+      pagination={false}
+    />
+  );
 };

--- a/src/app/src/features/eu4/features/charts/Help.tsx
+++ b/src/app/src/features/eu4/features/charts/Help.tsx
@@ -85,12 +85,12 @@ export const Help = ({ module }: HelpProps) => {
         <>
           <p>
             The health grid depicts multiple facets of a nation in a single
-            view. Since each facet has a different range of values: (eg:
-            prestige: [-100, 100], power projection: [0, 100], treasury: (-inf,
-            inf), corruption: [0, 100]) and different interpretation of the
-            ranges: (eg: a prestige of 100 is good while a corruption of 100 is
-            horrible), this visualization abstracts away the concrete values in
-            favor of a color representing good (blue) or bad (red).
+            view. Since each facet has a different range of values: (eg: income
+            [0, inf) treasury: (-inf, inf), corruption: [0, 100]) and different
+            interpretation of the ranges: (eg: professionalism of 100 is good
+            while a corruption of 100 is horrible), this visualization abstracts
+            away the concrete values in favor of a color representing good
+            (blue) or bad (red).
           </p>
           <p>
             Several of the facets are relative to other nations in the health
@@ -106,46 +106,6 @@ export const Help = ({ module }: HelpProps) => {
             major war breaks out plunging many nations into a deficient, then a
             small deficient won't be colored so harshly.
           </p>
-          <p>Below are definitions of some of the fields</p>
-          <dl>
-            <dt>pp</dt>
-            <dd>"pp" is short for power projection</dd>
-
-            <dt>treasury</dt>
-            <dd>
-              Treasury is calculated by taking the countries current balance and
-              subtracting any outstanding debt. Treasury color is relative to
-              other countries in the grid
-            </dd>
-
-            <dt>inflation</dt>
-            <dd>
-              Inflation is considered good to neutral until 15 when it starts
-              turning bad (capped at 30)
-            </dd>
-
-            <dt>corruption</dt>
-            <dd>
-              Corruption is considered good to neutral until 10 when it starts
-              turning bad (capped at 20)
-            </dd>
-
-            <dt>manpower</dt>
-            <dd>
-              Manpower is calculated by taking the countries current manpower
-              reserves and subtracting men needed for reinforcements. Manpower
-              color is relative to other countries in the grid
-            </dd>
-
-            <dt>adm / dip / mil tech</dt>
-            <dd>
-              Administration (adm), Diplomatic (dip), and Military (mil) tech
-              are calculated relative to the other countries in the grid. A
-              country's tech is considered good to neutral while it is less than
-              3 techs behind the leader. More than 3 techs behind is considered
-              bad (capped at 6 behind)
-            </dd>
-          </dl>
         </>
       );
     }

--- a/src/app/src/features/eu4/types/models.ts
+++ b/src/app/src/features/eu4/types/models.ts
@@ -73,15 +73,49 @@ export interface LedgerDatum {
 }
 
 export interface HealthData {
-  data: HealthDatum[];
+  data: CountryHealth[];
+}
+
+export interface CountryHealth {
+  tag: string;
+  name: string;
+  coreIncome: HealthDatum;
+  treasuryBalance: HealthDatum;
+  development: HealthDatum;
+  buildings: HealthDatum;
+  inflation: HealthDatum;
+  bestGeneral: LeaderHealth;
+  armyTradition: HealthDatum;
+  manpowerBalance: HealthDatum;
+  standardRegiments: HealthDatum;
+  professionalism: HealthDatum;
+  bestAdmiral: LeaderHealth;
+  navyTradition: HealthDatum;
+  ships: HealthDatum;
+  stability: HealthDatum;
+  technology: {
+    color: number;
+    value: number;
+    adm: number;
+    dip: number;
+    mil: number;
+  };
+  ideas: HealthDatum;
+  corruption: HealthDatum;
+}
+
+export interface LeaderHealth {
+  color: number;
+  value: number;
+  fire: number;
+  shock: number;
+  manuever: number;
+  siege: number;
 }
 
 export interface HealthDatum {
-  tag: string;
-  name: string;
   color: number;
   value: number;
-  value_type: string;
 }
 
 export interface IronmanAchievements {

--- a/src/app/src/features/eu4/worker/module.ts
+++ b/src/app/src/features/eu4/worker/module.ts
@@ -236,8 +236,7 @@ export function eu4GetAnnualInflationData(
 }
 
 export function eu4GetHealth(filter: CountryMatcher): HealthData {
-  const data = wasm.save.get_health(filter) as HealthData;
-  return data;
+  return wasm.save.get_health(filter) as HealthData;
 }
 
 export function eu4GetCountriesIncome(


### PR DESCRIPTION
- Table allows one to sort columns and see the raw values without hovering over the cells
- Added more signals of country health:
  - Income from tax + production + trade + gold
  - Number of buildings
  - Best generals / admirals
  - Army tradition / Navy tradition / Professionalism
  - Number of regiments / ships
  - Number of completed ideas
- Removed weak signals of country health:
  - prestige
  - power projection
  - overextension
  - innovativeness

Closes #103, as this is now serves the purpose of a global table
Closes #102, as the table shows regiments, professionalism, tradition, and best generals (in addition to manpower)

![image](https://user-images.githubusercontent.com/2106129/229139136-34e8d6bc-72e2-4796-956f-5eb64d04d8a4.png)
