### PR TITLE
Improve token space efficiency with improved format

### DIFF
--- a/src/schemas/benches/schema_benchmark.rs
+++ b/src/schemas/benches/schema_benchmark.rs
@@ -8,11 +8,11 @@ use flatbuffers::{ForwardsUOffset, Vector};
 use jomini::binary::TokenResolver;
 use rand::{thread_rng, Rng};
 
-pub struct FlatbufferResolver<'a> {
+pub struct FlatResolver<'a> {
     data: Vec<&'a str>,
 }
 
-impl<'a> FlatbufferResolver<'a> {
+impl<'a> FlatResolver<'a> {
     pub fn from_slice(data: &'a [u8]) -> Self {
         let xb = schemas::tokens::root_as_tokens(data).unwrap();
         let values = xb.values().unwrap();
@@ -21,7 +21,7 @@ impl<'a> FlatbufferResolver<'a> {
     }
 }
 
-impl<'a> jomini::binary::TokenResolver for FlatbufferResolver<'a> {
+impl<'a> jomini::binary::TokenResolver for FlatResolver<'a> {
     fn resolve(&self, token: u16) -> Option<&str> {
         self.data
             .get(usize::from(token))
@@ -29,11 +29,11 @@ impl<'a> jomini::binary::TokenResolver for FlatbufferResolver<'a> {
     }
 }
 
-pub struct FlatbufferResolverRaw<'a> {
+pub struct FlatResolverRaw<'a> {
     data: Vector<'a, ForwardsUOffset<&'a str>>,
 }
 
-impl<'a> FlatbufferResolverRaw<'a> {
+impl<'a> FlatResolverRaw<'a> {
     pub fn from_slice(data: &'a [u8]) -> Self {
         let xb = schemas::tokens::root_as_tokens(data).unwrap();
         let values = xb.values().unwrap();
@@ -41,7 +41,7 @@ impl<'a> FlatbufferResolverRaw<'a> {
     }
 }
 
-impl<'a> jomini::binary::TokenResolver for FlatbufferResolverRaw<'a> {
+impl<'a> jomini::binary::TokenResolver for FlatResolverRaw<'a> {
     fn resolve(&self, token: u16) -> Option<&str> {
         let s = self.data.get(usize::from(token));
 
@@ -103,7 +103,7 @@ fn token_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("resolve");
     group.bench_function("vec", |b| {
         let mut i = 0;
-        let resolver = FlatbufferResolver::from_slice(data);
+        let resolver = FlatResolver::from_slice(data);
 
         b.iter(|| {
             let res = resolver.resolve(arr[i % 1024]);
@@ -114,7 +114,7 @@ fn token_benchmark(c: &mut Criterion) {
 
     group.bench_function("current", |b| {
         let mut i = 0;
-        let resolver = schemas::FlatBufferResolver::from_slice(data);
+        let resolver = schemas::FlatResolver::from_slice(data);
 
         b.iter(|| {
             let res = resolver.resolve(arr[i % 1024]);
@@ -125,7 +125,7 @@ fn token_benchmark(c: &mut Criterion) {
 
     group.bench_function("raw", |b| {
         let mut i = 0;
-        let resolver = FlatbufferResolverRaw::from_slice(data);
+        let resolver = FlatResolverRaw::from_slice(data);
 
         b.iter(|| {
             let res = resolver.resolve(arr[i % 1024]);
@@ -171,7 +171,7 @@ fn token_creation_benchmark(c: &mut Criterion) {
     let data = include_bytes!("../../../assets/tokens/eu4-raw.bin");
 
     c.bench_function("creation", |b| {
-        b.iter(|| FlatbufferResolver::from_slice(data))
+        b.iter(|| FlatResolver::from_slice(data))
     });
 }
 

--- a/src/schemas/build.rs
+++ b/src/schemas/build.rs
@@ -8,9 +8,8 @@ use std::{
 fn main() {
     if std::env::var("XARGO_HOME").is_err() {
         println!("cargo:rerun-if-changed=src/eu4.fbs");
-        println!("cargo:rerun-if-changed=src/tokens.fbs");
         flatc_rust::run(flatc_rust::Args {
-            inputs: &[Path::new("src/eu4.fbs"), Path::new("src/tokens.fbs")],
+            inputs: &[Path::new("src/eu4.fbs")],
             out_dir: Path::new("target/flatbuffers/"),
             ..Default::default()
         })
@@ -37,7 +36,7 @@ fn main() {
             r#"
 #[cfg(feature = "inline")]
 pub struct {pascal}FlatBufferTokens {{
-    resolver: FlatBufferResolver<'static>,
+    resolver: FlatResolver<'static>,
 }}
 
 #[cfg(feature = "inline")]
@@ -46,14 +45,14 @@ impl {pascal}FlatBufferTokens {{
     pub fn new() -> Self {{
         let data = include_bytes!("{token_path}");
         Self {{
-            resolver: FlatBufferResolver::from_slice(data),
+            resolver: FlatResolver::from_slice(data),
         }}
     }}
 
     #[cfg(not({game}_tokens))]
     pub fn new() -> Self {{
         Self {{
-            resolver: FlatBufferResolver {{
+            resolver: FlatResolver {{
                 values: Vec::new(),
                 breakpoint: 0,
             }},

--- a/src/schemas/src/lib.rs
+++ b/src/schemas/src/lib.rs
@@ -10,5 +10,5 @@ pub mod resolver;
 
 pub use eu4_flatbuffers::rakaly::eu_4 as eu4;
 pub use flatbuffers;
-pub use resolver::FlatBufferResolver;
+pub use resolver::{FlatResolver, BREAKPOINT};
 pub use tokens_flatbuffers::rakaly::tokens;

--- a/src/schemas/src/resolver.rs
+++ b/src/schemas/src/resolver.rs
@@ -1,60 +1,46 @@
 // There is a large gap in token values where values jump from 2000 to 10000
 // (it's always 10000 for some reason). Instead of storing thousands of empty strings
 // to index into, they are instead spliced out
-const BREAKPOINT: u16 = 10000;
+pub const BREAKPOINT: u16 = 10000;
 
-pub struct FlatBufferResolver<'a> {
+pub struct FlatResolver<'a> {
     values: Vec<&'a str>,
 
     // The index where the data after the gap starts
     breakpoint: u16,
 }
 
-impl<'a> FlatBufferResolver<'a> {
+impl<'a> FlatResolver<'a> {
     pub fn from_slice(data: &'a [u8]) -> Self {
-        if data.is_empty() {
-            return FlatBufferResolver {
+        if data.len() < 4 {
+            return FlatResolver {
                 values: Vec::new(),
                 breakpoint: 0,
             };
         }
 
-        let xb = crate::tokens::root_as_tokens(data).unwrap();
-        let values = xb.values().unwrap();
-        let values = values.iter().collect::<Vec<_>>();
-        let breakpoint = xb.breakpoint();
+        let total_tokens = usize::from(u16::from_le_bytes([data[0], data[1]]));
+        let breakpoint = u16::from_le_bytes([data[2], data[3]]);
+        let mut values = vec![""; total_tokens];
+        let mut data = &data[4..];
+        for i in 0..total_tokens {
+            if let Some((&len, rest)) = data.split_first() {
+                let len = usize::from(len);
+                if len != 0 && rest.len() >= len {
+                    let (s, rest) = rest.split_at(len);
+                    values[i] = unsafe { std::str::from_utf8_unchecked(s) };
+                    data = rest;
+                } else {
+                    data = rest;
+                }
+            }
+        }
+
         Self { values, breakpoint }
-    }
-
-    pub fn create_data(tokens: Vec<&str>) -> Vec<u8> {
-        let mut buffer = crate::flatbuffers::FlatBufferBuilder::new();
-
-        let lower_max = &tokens[..usize::from(BREAKPOINT)]
-            .iter()
-            .enumerate()
-            .fold(0, |acc, (i, x)| if x.is_empty() { acc } else { i });
-
-        let mut values = Vec::new();
-        values.extend_from_slice(&tokens[..lower_max + 1]);
-        values.extend_from_slice(&tokens[usize::from(BREAKPOINT)..]);
-
-        let softs: Vec<_> = values.iter().map(|x| buffer.create_string(x)).collect();
-        let offset = buffer.create_vector(&softs);
-
-        let root = crate::tokens::Tokens::create(
-            &mut buffer,
-            &crate::tokens::TokensArgs {
-                values: Some(offset),
-                breakpoint: (lower_max + 1) as u16,
-            },
-        );
-
-        buffer.finish(root, None);
-        buffer.finished_data().to_vec()
     }
 }
 
-impl<'a> jomini::binary::TokenResolver for FlatBufferResolver<'a> {
+impl<'a> jomini::binary::TokenResolver for FlatResolver<'a> {
     fn resolve(&self, token: u16) -> Option<&str> {
         if token < self.breakpoint {
             self.values

--- a/src/schemas/src/tokens.fbs
+++ b/src/schemas/src/tokens.fbs
@@ -1,8 +1,0 @@
-namespace Rakaly.Tokens;
-
-table Tokens {
-  values:[string];
-  breakpoint:uint16;
-}
-
-root_type Tokens;

--- a/src/wasm-eu4/src/tokens.rs
+++ b/src/wasm-eu4/src/tokens.rs
@@ -1,10 +1,10 @@
-use schemas::FlatBufferResolver;
+use schemas::FlatResolver;
 use wasm_bindgen::prelude::*;
 
 static mut TOKEN_DATA: Option<Vec<u8>> = None;
-static mut TOKEN_LOOKUP: Option<FlatBufferResolver<'static>> = None;
+static mut TOKEN_LOOKUP: Option<FlatResolver<'static>> = None;
 
-pub(crate) fn get_tokens() -> &'static FlatBufferResolver<'static> {
+pub(crate) fn get_tokens() -> &'static FlatResolver<'static> {
     let raw = unsafe { &TOKEN_LOOKUP };
     raw.as_ref().unwrap()
 }
@@ -12,7 +12,7 @@ pub(crate) fn get_tokens() -> &'static FlatBufferResolver<'static> {
 #[wasm_bindgen]
 pub fn set_tokens(data: Vec<u8>) {
     let sl: &'static [u8] = unsafe { std::mem::transmute(data.as_slice()) };
-    let resolver = FlatBufferResolver::from_slice(sl);
+    let resolver = FlatResolver::from_slice(sl);
     unsafe {
         TOKEN_DATA = Some(data);
         TOKEN_LOOKUP = Some(resolver)


### PR DESCRIPTION
The flatbuffer token file is often bigger than the plaintext equivalent as it must handle large strings and infrastructure to support random access. We immediately iterate through the flatbuffer tokens to transform them into an in-memory structure that has faster random access, so we aren't using flatbuffer benefits.

The new format is just length prefixed strings back to back. Cuts down on file size by about 30% with zero runtime impact.