### PR TITLE
Remove dependence on content-encoding header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,21 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,27 +560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "brotli"
-version = "3.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -1931,7 +1895,6 @@ dependencies = [
  "attohttpc",
  "aws-config",
  "aws-sdk-s3",
- "brotli",
  "chrono",
  "clap 4.2.5",
  "csv",
@@ -3003,6 +2966,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
+ "zstd",
 ]
 
 [[package]]
@@ -3032,6 +2996,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-test",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -3045,6 +3010,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
+ "zstd",
 ]
 
 [[package]]
@@ -3058,6 +3024,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
+ "zstd",
 ]
 
 [[package]]
@@ -3071,6 +3038,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "vic3save",
  "wasm-bindgen",
+ "zstd",
 ]
 
 [[package]]

--- a/justfile
+++ b/justfile
@@ -47,7 +47,10 @@ staging: build-napi build-app prep-dev-app
     "PORT=3001 node_modules/.bin/next start" \
     "wrangler dev --port 3003 --local --local-upstream localhost:3001 --var AWS_S3_HOST:localhost --var AWS_S3_PORT:$S3_PORT --var AWS_S3_BUCKET:$S3_BUCKET --var AWS_DEFAULT_REGION:$S3_REGION --var AWS_ACCESS_KEY_ID:$S3_ACCESS_KEY --var AWS_SECRET_ACCESS_KEY:$S3_SECRET_KEY"
 
-test: (cargo "test" "--workspace" "--exclude" "pdx" "--exclude" "wasm-eu4") (cargo "test" "-p" "pdx" "--all-features") (cargo "test" "-p" "wasm-eu4") test-app
+test: (cargo "test" "--workspace" "--exclude" "pdx" "--exclude" "wasm-*") test-wasm (cargo "test" "-p" "pdx" "--all-features") test-app
+
+# Disable zstd fat-lto which cause linking issues for tests
+test-wasm: (cargo "test" "--no-default-features" "--features" "miniz" "-p" "wasm-*")
 
 setup:
   #!/usr/bin/env bash

--- a/src/app/next.config.js
+++ b/src/app/next.config.js
@@ -56,15 +56,6 @@ let nextConfig = {
           }
         ],
       },
-      {
-        source: "/:path*.bin",
-        headers: [
-          {
-            key: "Content-Encoding",
-            value: "br",
-          },
-        ],
-      },
     ];
   },
   async rewrites() {

--- a/src/app/workers-site/index.ts
+++ b/src/app/workers-site/index.ts
@@ -140,6 +140,7 @@ function calcCacheControl(event: FetchEvent) {
     "bin",
     "frag",
     "vert",
+    "bin",
   ];
   const isCacheable = extension && cacheable.indexOf(extension) !== -1;
   return isCacheable ? assetCacheControl : undefined;
@@ -213,22 +214,12 @@ async function handleEvent(event: FetchEvent) {
   }
 
   const cacheControl = calcCacheControl(event);
-  let resp = await getAssetFromKV(event, {
+  const resp = await getAssetFromKV(event, {
     mapRequestToAsset: assetRequest,
     cacheControl,
   });
-  if (event.request.url.endsWith(".bin")) {
-    // https://stackoverflow.com/a/64849685/433785
-    resp = new Response(resp.body, {
-      status: resp.status,
-      headers: resp.headers,
-      encodeBody: "manual",
-    });
-    resp.headers.set("Content-Encoding", "br");
-    return resp;
-  } else {
-    return withSecurityHeaders(resp, parsedUrl.pathname);
-  }
+
+  return withSecurityHeaders(resp, parsedUrl.pathname);
 }
 
 function isDocsUrl(path: string) {

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -9,9 +9,9 @@ admin = ["create_bundle", "fetch_assets", "tokenize", "dep:applib", "dep:eu4game
 fun = ["compile_assets", "dep:applib", "dep:eu4game", "dep:eu4save", "dep:flate2"]
 
 create_bundle = ["dep:zstd"]
-compile_assets = ["dep:attohttpc", "dep:brotli", "dep:eu4save", "dep:jomini", "dep:oxipng", "dep:schemas", "schemas?/inline", "dep:zstd"]
+compile_assets = ["dep:attohttpc", "dep:eu4save", "dep:jomini", "dep:oxipng", "dep:schemas", "schemas?/inline", "dep:zstd"]
 fetch_assets = ["dep:aws-config", "dep:aws-sdk-s3", "dep:tokio", "dep:tokio-stream"]
-tokenize = ["dep:brotli", "dep:schemas"]
+tokenize = ["dep:zstd", "dep:schemas"]
 
 [dependencies]
 anyhow = "1.0"
@@ -19,7 +19,6 @@ applib = { path = "../applib", optional = true }
 attohttpc = { version = "0.25", features = ["json"], optional = true }
 aws-config = { version = "0.55.1", optional = true }
 aws-sdk-s3 = { version = "0.26.0", optional = true }
-brotli = { version = "3.3", optional = true }
 chrono = "0.4"
 clap = { version = "4.1", features = ["derive", "env"] }
 csv = { version = "1.1" }

--- a/src/cli/src/cmd/tokenize.rs
+++ b/src/cli/src/cmd/tokenize.rs
@@ -1,4 +1,4 @@
-use crate::brotli_tee::BrotliTee;
+use crate::zstd_tee::ZstdTee;
 use anyhow::Context;
 use clap::Args;
 use log::{debug, info};
@@ -69,9 +69,11 @@ where
     std::fs::create_dir_all(&out_dir).context("unable to create token directory")?;
 
     let out = out_dir.join(name);
-    let writer = BrotliTee::create(out)?;
+    let mut writer = ZstdTee::create(out)?;
 
-    tokenize(reader, writer, name)
+    tokenize(reader, &mut writer, name)?;
+    writer.flush()?;
+    Ok(())
 }
 
 fn tokenize<R, W>(reader: R, mut top_writer: W, name: &str) -> anyhow::Result<()>

--- a/src/cli/src/cmd/transcode.rs
+++ b/src/cli/src/cmd/transcode.rs
@@ -83,7 +83,7 @@ impl TranscodeArgs {
                 }
 
                 out_zip.finish().unwrap().into_inner()
-            } else if inflated.get(..4) == Some(&[0x28, 0xb5, 0x2f, 0xfd])  {
+            } else if inflated.get(..4) == Some(&[0x28, 0xb5, 0x2f, 0xfd]) {
                 continue;
             } else {
                 zstd::bulk::compress(&inflated, 7).context("zstd failure")?

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -38,15 +38,15 @@ mod smallest_province;
 
 /* Shared modules */
 
-#[cfg(any(feature = "tokenize", feature = "compile_assets"))]
-#[path = "storage/brotli_tee.rs"]
-mod brotli_tee;
 #[allow(dead_code)]
 #[cfg(any(feature = "compile_assets", feature = "fun"))]
 mod rawbmp;
 #[cfg(any(feature = "admin", feature = "fun"))]
 #[path = "storage/remote_parse.rs"]
 mod remote_parse;
+#[cfg(any(feature = "tokenize", feature = "compile_assets"))]
+#[path = "storage/zstd_tee.rs"]
+mod zstd_tee;
 
 use clap::{Parser, Subcommand};
 use cli::InfoLevel;

--- a/src/eu4game/Cargo.toml
+++ b/src/eu4game/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 default = ["embedded", "miniz"]
 miniz = ["eu4save/miniz"]
 libdeflate = ["eu4save/libdeflate"]
-zstd-fat-lto = ["zstd/fat-lto"]
 embedded = []
 
 [dependencies]

--- a/src/schemas/benches/schema_benchmark.rs
+++ b/src/schemas/benches/schema_benchmark.rs
@@ -170,9 +170,7 @@ fn token_benchmark(c: &mut Criterion) {
 fn token_creation_benchmark(c: &mut Criterion) {
     let data = include_bytes!("../../../assets/tokens/eu4-raw.bin");
 
-    c.bench_function("creation", |b| {
-        b.iter(|| FlatResolver::from_slice(data))
-    });
+    c.bench_function("creation", |b| b.iter(|| FlatResolver::from_slice(data)));
 }
 
 criterion_group!(benches, token_benchmark, token_creation_benchmark);

--- a/src/wasm-ck3/Cargo.toml
+++ b/src/wasm-ck3/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["miniz"]
+default = ["miniz", "zstd/fat-lto"]
 miniz = ["ck3save/miniz"]
 libdeflate = ["ck3save/libdeflate"]
 
@@ -21,6 +21,7 @@ serde-wasm-bindgen = "0.5"
 serde = { version = "1", features = ["derive"] }
 ck3save = { git = "https://github.com/rakaly/ck3save.git" }
 js-sys = "0.3"
+zstd = { version = "0.12.3", default-features = false }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-compress/Cargo.toml
+++ b/src/wasm-compress/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = { version = "0.2" }
 zip_next = { git = "https://github.com/nickbabcock/zip-rs.git", branch = "disable-default-zstd2", default-features = false, features = ["deflate", "zstd"] }
-zstd = { version = "0.12", default-features = false }
+zstd = { version = "0.12.3", default-features = false }
 js-sys = "0.3"
 
 [package.metadata.wasm-pack.profile.release]

--- a/src/wasm-eu4/Cargo.toml
+++ b/src/wasm-eu4/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["miniz"]
+default = ["miniz", "zstd/fat-lto"]
 miniz = ["eu4save/miniz", "eu4game/miniz"]
 libdeflate = ["eu4save/libdeflate", "eu4game/libdeflate"]
 
@@ -21,11 +21,12 @@ wasm-bindgen = { version = "0.2" }
 serde-wasm-bindgen = "0.5"
 serde = { version = "1", features = ["derive"] }
 eu4save = { git = "https://github.com/rakaly/eu4save.git", default-features = false, features = ["zstd"] }
-eu4game = { path = "../eu4game", default-features = false, features = ["zstd-fat-lto"] }
+eu4game = { path = "../eu4game", default-features = false }
 schemas = { path = "../schemas" }
 tarsave = { path = "../tarsave" }
 tar = "0.4"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
+zstd = { version = "0.12.3", default-features = false }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/src/wasm-eu4/src/lib.rs
+++ b/src/wasm-eu4/src/lib.rs
@@ -3246,6 +3246,8 @@ pub fn _initial_save(
     let save = eu4game::shared::parse_save_raw(&save_data, &mut zip_data)?;
     let save: Eu4RemoteFile<'static> = unsafe { std::mem::transmute(save) };
 
+    let game_data = zstd::bulk::decompress(&game_data, 1024 * 1024).unwrap();
+
     // Cast away the lifetime so that we can store it in a wasm-bindgen compatible struct
     let game = Game::from_flatbuffer(&game_data);
     let game: Game<'static> = unsafe { std::mem::transmute(game) };

--- a/src/wasm-eu4/src/tokens.rs
+++ b/src/wasm-eu4/src/tokens.rs
@@ -11,10 +11,11 @@ pub(crate) fn get_tokens() -> &'static FlatResolver<'static> {
 
 #[wasm_bindgen]
 pub fn set_tokens(data: Vec<u8>) {
-    let sl: &'static [u8] = unsafe { std::mem::transmute(data.as_slice()) };
+    let tokens = zstd::bulk::decompress(&data, 1024 * 1024).unwrap_or_default();
+    let sl: &'static [u8] = unsafe { std::mem::transmute(tokens.as_slice()) };
     let resolver = FlatResolver::from_slice(sl);
     unsafe {
-        TOKEN_DATA = Some(data);
+        TOKEN_DATA = Some(tokens);
         TOKEN_LOOKUP = Some(resolver)
     }
 }

--- a/src/wasm-hoi4/Cargo.toml
+++ b/src/wasm-hoi4/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["zstd/fat-lto"]
+
 [dependencies]
 jomini = "0.21"
 schemas = { path = "../schemas" }
@@ -15,6 +18,7 @@ serde-wasm-bindgen = "0.5"
 serde = { version = "1", features = ["derive"] }
 hoi4save = { git = "https://github.com/rakaly/hoi4save.git" }
 js-sys = "0.3"
+zstd = { version = "0.12.3", default-features = false }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-imperator/Cargo.toml
+++ b/src/wasm-imperator/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["miniz"]
+default = ["miniz", "zstd/fat-lto"]
 miniz = ["imperator-save/miniz"]
 libdeflate = ["imperator-save/libdeflate"]
 
@@ -20,6 +20,7 @@ serde-wasm-bindgen = "0.5"
 serde = { version = "1", features = ["derive"] }
 imperator-save = { git = "https://github.com/rakaly/imperator-save.git" }
 js-sys = "0.3"
+zstd = { version = "0.12.3", default-features = false }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-vic3/Cargo.toml
+++ b/src/wasm-vic3/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["miniz"]
+default = ["miniz", "zstd/fat-lto"]
 miniz = ["vic3save/miniz"]
 libdeflate = ["vic3save/libdeflate"]
 
@@ -20,6 +20,7 @@ serde-wasm-bindgen = "0.5"
 serde = { version = "1", features = ["derive"] }
 vic3save = { path = "../vic3save" }
 js-sys = "0.3"
+zstd = { version = "0.12.3", default-features = false }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false


### PR DESCRIPTION
To save on space, pdx.tools stores some binary assets (game data, tokens, map info) precompressed with brotli. This required that these assets be served with the `Content-Encoding: br` header. How to configure this behavior is different per platform (ie: next.js vs cloudflare workers), and some platforms don't allow this configuration at all (cloudflare pages).

So this commit instead stores some assets where compression hardly helps uncompressed (map info). Other content that is destined only to be consumed via Wasm is now stored as zstd compressed and decoded in Wasm.