### PR TITLE
Group user saves by playthrough name

### DIFF
--- a/src/app/src/features/account/UserPage.tsx
+++ b/src/app/src/features/account/UserPage.tsx
@@ -31,7 +31,7 @@ export const UserPage = ({ userId }: UserRouteProps) => {
           <TimeAgo date={user.user_info.created_on} />
         </div>
 
-        <UserSaveTable isPrivileged={isPrivileged} records={user.saves} />
+        <UserSaveTable isPrivileged={isPrivileged} saves={user.saves} />
       </div>
     </div>
   );

--- a/src/app/src/lib/groupBy.ts
+++ b/src/app/src/lib/groupBy.ts
@@ -1,0 +1,9 @@
+export function groupBy<T, K>(items: T[], fn: (arg0: T) => K): Map<K, T[]> {
+  const result: Map<K, T[]> = new Map();
+  for (const item of items) {
+    const key = fn(item);
+    const existing = result.get(key);
+    result.set(key, [...(existing ?? []), item]);
+  }
+  return result;
+}

--- a/src/app/src/server-lib/db/index.ts
+++ b/src/app/src/server-lib/db/index.ts
@@ -38,7 +38,7 @@ export const toApiSaveUser = (save: Save, user: User) => {
     ironman: save.ironman,
     multiplayer: save.multiplayer || false,
     patch: `${save.saveVersionFirst}.${save.saveVersionSecond}.${save.saveVersionThird}.${save.saveVersionFourth}`,
-    dlc: save.dlc,
+    playthrough_id: save.playthroughId,
     achievements: save.achieveIds,
     weighted_score: weightedScore,
     game_difficulty: dbDifficulty(save.gameDifficulty),


### PR DESCRIPTION
This should make it easier to see the progression of multiple concurrent campaigns. If a playthrough group has a singular, unique filename, that filename is used as the playthrough name, otherwise a randomly generated one is used.

See underlined row for example

![image](https://github.com/pdx-tools/pdx-tools/assets/2106129/3164da95-9013-470f-b4a8-3d8b2f7b56ce)
