### PR TITLE
Add country dev push institution module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,7 +1165,7 @@ dependencies = [
 [[package]]
 name = "eu4save"
 version = "0.8.2"
-source = "git+https://github.com/rakaly/eu4save.git#f041531f78f0587698c516421063b12a84246621"
+source = "git+https://github.com/rakaly/eu4save.git#dfb0e4b745ebc537957b863ab78180bb2422d5d2"
 dependencies = [
  "flate2",
  "jomini",
@@ -3308,6 +3308,7 @@ dependencies = [
  "once_cell",
  "schemas",
  "serde",
+ "serde-wasm-bindgen",
  "tsify",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/src/app/src/components/DataTable.tsx
+++ b/src/app/src/components/DataTable.tsx
@@ -21,6 +21,7 @@ interface DataTableProps<TData> {
   pagination?: boolean;
   summary?: React.ReactNode;
   initialSorting?: SortingState;
+  className?: string;
 }
 
 export function DataTable<TData extends Object & Partial<{ rowSpan: number }>>({
@@ -29,6 +30,7 @@ export function DataTable<TData extends Object & Partial<{ rowSpan: number }>>({
   pagination,
   summary,
   initialSorting = [],
+  className,
 }: DataTableProps<TData>) {
   const [sorting, setSorting] = useState<SortingState>(initialSorting);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -56,7 +58,7 @@ export function DataTable<TData extends Object & Partial<{ rowSpan: number }>>({
 
   const rows = table.getRowModel().rows;
   return (
-    <div className="flex flex-col gap-2 rounded-md">
+    <div className={cx("flex flex-col gap-2 rounded-md", className)}>
       <Table>
         <Table.Header>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/src/app/src/components/Input.tsx
+++ b/src/app/src/components/Input.tsx
@@ -10,7 +10,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cx(
-          "placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border border-solid border-gray-400 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-muted-foreground focus-visible:ring-ring flex rounded-md border border-solid border-gray-400 bg-white text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/src/app/src/features/eu4/features/country-details/CountryInstitution.tsx
+++ b/src/app/src/features/eu4/features/country-details/CountryInstitution.tsx
@@ -1,0 +1,266 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { CountryDetails } from "../../types/models";
+import { Eu4Worker, useEu4Worker } from "../../worker";
+import { Alert } from "@/components/Alert";
+import { formatFloat, formatInt } from "@/lib/format";
+import { cx } from "class-variance-authority";
+import { InstitutionCost } from "../../../../../../wasm-eu4/pkg/wasm_eu4";
+import { createColumnHelper } from "@tanstack/react-table";
+import { Table } from "@/components/Table";
+import { DataTable } from "@/components/DataTable";
+import { create } from "zustand";
+import { IconButton } from "@/components/IconButton";
+import { XMarkIcon } from "@heroicons/react/16/solid";
+import { useThrottle } from "@/hooks/useThrottle";
+import { Divider } from "@/components/Divider";
+import { Input } from "@/components/Input";
+import { Tooltip } from "@/components/Tooltip";
+
+function ProvinceModifier(props: InstitutionCost) {
+  const actions = useInstitutionActions();
+  const override = useProvinceModifierOverride(props.province_id);
+  const value = Math.round((override ?? props.dev_cost_modifier) * 100);
+
+  const changeCb = (
+    e: React.FocusEvent<HTMLInputElement> | React.ChangeEvent<HTMLInputElement>
+  ) => {
+    actions.overrideModifier(
+      props.province_id,
+      Number(e.currentTarget.value) / 100
+    );
+  };
+
+  return (
+    <div className="flex">
+      <Input
+        className="w-14 text-right border-gray-400/25 mr-1"
+        type="number"
+        value={value}
+        onFocus={changeCb}
+        onChange={changeCb}
+      />
+      %
+      {override !== undefined ? (
+        <IconButton
+          className="pl-2"
+          variant="ghost"
+          shape="none"
+          onClick={() => actions.clearOverride(props.province_id)}
+          tooltip={"Reset modified dev cost modifier"}
+          icon={
+            <XMarkIcon className="h-4 w-4 hover:opacity-100 transition-opacity opacity-50" />
+          }
+        />
+      ) : null}
+    </div>
+  );
+}
+
+const columnHelper = createColumnHelper<InstitutionCost>();
+const columns = [
+  columnHelper.accessor("name", {
+    header: ({ column }) => (
+      <Table.ColumnHeader column={column} title="Province" />
+    ),
+    cell: ({ row }) => (
+      <div>
+        {row.original.name} ({row.original.province_id})
+      </div>
+    ),
+  }),
+
+  columnHelper.accessor("current_institution_progress", {
+    header: ({ column }) => (
+      <Table.ColumnHeader column={column} title="Progress" />
+    ),
+    cell: (info) => (
+      <div className="text-right">{formatFloat(info.getValue(), 3)}%</div>
+    ),
+  }),
+
+  columnHelper.accessor("mana_cost", {
+    header: ({ column }) => (
+      <Table.ColumnHeader column={column} title="Mana cost" />
+    ),
+    cell: (info) => (
+      <div className="text-right">{formatInt(info.getValue())}</div>
+    ),
+  }),
+
+  columnHelper.accessor("current_dev", {
+    header: ({ column }) => (
+      <Table.ColumnHeader column={column} title="Current dev" />
+    ),
+    cell: (info) => (
+      <div className="text-right">{formatInt(info.getValue())}</div>
+    ),
+  }),
+
+  columnHelper.accessor("dev_cost_modifier", {
+    header: ({ column }) => (
+      <Tooltip>
+        <Tooltip.Trigger asChild>
+          <Table.ColumnHeader column={column} title="Dev modifier" />
+        </Tooltip.Trigger>
+        <Tooltip.Content className="max-w-72">
+          The calculated development cost modifier from province specific and
+          country-wide sources. Can be edited for exactness.
+        </Tooltip.Content>
+      </Tooltip>
+    ),
+    cell: (info) => <ProvinceModifier {...info.row.original} />,
+  }),
+
+  columnHelper.accessor("final_dev", {
+    header: ({ column }) => (
+      <Table.ColumnHeader column={column} title="Final dev" />
+    ),
+    cell: (info) => (
+      <div className="text-right">{formatInt(info.getValue())}</div>
+    ),
+  }),
+
+  columnHelper.accessor("exploit_at", {
+    header: ({ column }) => (
+      <Table.ColumnHeader column={column} title="Exploit at" />
+    ),
+    cell: (info) => {
+      const value = info.getValue();
+      return (
+        <div className="text-right">
+          {value === undefined ? "---" : formatInt(value)}
+        </div>
+      );
+    },
+  }),
+
+  columnHelper.accessor("additional_expand_infrastructure", {
+    header: ({ column }) => (
+      <Table.ColumnHeader
+        className="w-28"
+        column={column}
+        title="Additional expand infra."
+      />
+    ),
+    cell: (info) => (
+      <div className="text-right">{formatInt(info.getValue())}</div>
+    ),
+  }),
+];
+
+type CountryInstitutionState = {
+  overrides: Map<number, number>;
+  actions: {
+    overrideModifier: (id: number, modifier: number) => void;
+    clearOverride: (id: number) => void;
+  };
+};
+
+const useInstitutionStore = create<CountryInstitutionState>()((set, get) => ({
+  overrides: new Map(),
+  actions: {
+    overrideModifier: function (id: number, modifier: number): void {
+      set({ overrides: new Map(get().overrides).set(id, modifier) });
+    },
+    clearOverride: function (id: number): void {
+      const newMap = new Map(get().overrides);
+      newMap.delete(id);
+      set({ overrides: newMap });
+    },
+  },
+}));
+
+const useInstitutionActions = () => useInstitutionStore((x) => x.actions);
+const useProvinceModifierOverride = (id: number) =>
+  useInstitutionStore((x) => x.overrides.get(id));
+
+export const CountryInstitution = ({
+  details,
+}: {
+  details: CountryDetails;
+}) => {
+  const [modifier, setModifier] = useState(0);
+  const [expandCost, setExpandCost] = useState(50);
+  const overrides = useInstitutionStore((x) => x.overrides);
+  const institutionPush = useThrottle(
+    useCallback(
+      (worker: Eu4Worker) =>
+        worker.eu4GetCountryInstitutionPush(
+          details.tag,
+          modifier / 100,
+          expandCost,
+          overrides
+        ),
+      [details.tag, modifier, expandCost, overrides]
+    ),
+    150
+  );
+
+  const { data, error } = useEu4Worker(institutionPush);
+
+  if (error) {
+    return <Alert.Error msg={error} />;
+  }
+
+  if (data === undefined) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div
+        className={cx(
+          data.institutions_embraced == data.institutions_available &&
+            "font-semibold text-green-600"
+        )}
+      >
+        {formatInt(data.institutions_embraced)}/
+        {formatInt(data.institutions_available)} institutions embraced
+      </div>
+      <Divider>Dev Push Institution</Divider>
+      <div className="space-y-1">
+        <Tooltip>
+          <Tooltip.Trigger>
+            <div>
+              <label className="w-96 inline-flex justify-between mr-1">
+                Country-wide development cost modifier:
+                <Input
+                  className="px-2 py-1 w-14 text-right"
+                  type="number"
+                  min="-200"
+                  max="200"
+                  value={modifier}
+                  onChange={(e) => setModifier(Number(e.currentTarget.value))}
+                />
+              </label>
+              %
+            </div>
+          </Tooltip.Trigger>
+          <Tooltip.Content className="max-w-72">
+            The development cost modifier that all provinces share (eg:
+            renaissance)
+          </Tooltip.Content>
+        </Tooltip>
+        <div>
+          <label className="w-96 inline-flex justify-between">
+            Expand infrastructure mana cost:
+            <Input
+              className="px-2 py-1 w-14 text-right"
+              type="number"
+              min="0"
+              max="200"
+              value={expandCost}
+              onChange={(e) => setExpandCost(Number(e.currentTarget.value))}
+            />
+          </label>
+        </div>
+      </div>
+      <DataTable
+        className="pt-6"
+        data={data.dev_push}
+        columns={columns}
+        pagination={true}
+      />
+    </div>
+  );
+};

--- a/src/app/src/features/eu4/features/country-details/CountrySideBarButton.tsx
+++ b/src/app/src/features/eu4/features/country-details/CountrySideBarButton.tsx
@@ -42,6 +42,8 @@ import { MenuFoldIcon } from "@/components/icons/MenuFoldIcon";
 import { CountrySelect } from "../../components/CountrySelect";
 import { emitEvent } from "@/lib/plausible";
 import { CountryHistory } from "./CountryHistory";
+import { CountryInstitution } from "./CountryInstitution";
+import { useIsDeveloper } from "@/features/account";
 
 export const CountrySideBarButton = ({
   children,
@@ -68,6 +70,7 @@ const CountryDetailsContent = () => {
   const [expanded, setExpanded] = useState(false);
   const selectedTag = useSelectedTag();
   const sideBarContainerRef = useSideBarContainerRef();
+  const isDeveloper = useIsDeveloper();
 
   const {
     data: [country, rulers, advisors] = [undefined, [], undefined],
@@ -91,7 +94,7 @@ const CountryDetailsContent = () => {
       onInteractOutside={(e) => e.preventDefault()}
       className={cx(
         "flex flex-col bg-white pt-4 transition-[width] duration-200",
-        expanded ? "w-full" : "w-[880px] max-w-full",
+        expanded ? "w-full" : "w-[970px] max-w-full",
       )}
     >
       <Sheet.Header className="px-4">
@@ -169,6 +172,9 @@ const CountryDetailsContent = () => {
         <Tabs.List className="mt-3 w-full max-w-full overflow-x-auto border-0 px-4 shadow-md">
           <Tabs.Trigger value="General">General</Tabs.Trigger>
           <Tabs.Trigger value="History">History</Tabs.Trigger>
+          {isDeveloper && (
+            <Tabs.Trigger value="Institution">Institution</Tabs.Trigger>
+          )}
           <Tabs.Trigger value="Advisors">Advisors</Tabs.Trigger>
           <Tabs.Trigger value="Rulers">Rulers</Tabs.Trigger>
           <Tabs.Trigger value="Leaders">Leaders</Tabs.Trigger>
@@ -192,6 +198,14 @@ const CountryDetailsContent = () => {
         <Tabs.Content value="History" className=" flex-1 basis-0 relative">
           {country && <CountryHistory details={country} />}
         </Tabs.Content>
+        {isDeveloper && (
+          <Tabs.Content
+            value="Institution"
+            className=" flex-1 basis-0 px-4 py-6"
+          >
+            {country && <CountryInstitution details={country} />}
+          </Tabs.Content>
+        )}
         <Tabs.Content value="Advisors" className=" flex-1 basis-0 px-4 py-6">
           <div>
             Radical reforms completed: {advisors?.radicalReforms || "no"}

--- a/src/app/src/features/eu4/worker/module.ts
+++ b/src/app/src/features/eu4/worker/module.ts
@@ -25,6 +25,7 @@ import { wasm } from "./common";
 import { TimelapseIter } from "../../../../../wasm-eu4/pkg/wasm_eu4";
 import { timeSync, timeit } from "@/lib/timeit";
 import { logMs } from "@/lib/log";
+import exp from "constants";
 export * from "./init";
 
 export const getRawData = wasm.viewData;
@@ -146,6 +147,24 @@ export function eu4GetCountryProvinceReligion(tag: string) {
 export function eu4GetCountryHistory(tag: string) {
   const timed = timeSync(() => wasm.save.get_country_history(tag));
   logMs(timed, "country history calculation");
+  return timed.data;
+}
+
+export function eu4GetCountryInstitutionPush(
+  tag: string,
+  countryDevelopmentModifier: number,
+  expandInfrastructureCost: number,
+  overrides: Map<number, number>,
+) {
+  const timed = timeSync(() =>
+    wasm.save.get_country_institutions(
+      tag,
+      countryDevelopmentModifier,
+      expandInfrastructureCost,
+      overrides,
+    ),
+  );
+  logMs(timed, "country institution push calculation");
   return timed.data;
 }
 

--- a/src/app/src/features/skanderbeg/SkanderbegPage.tsx
+++ b/src/app/src/features/skanderbeg/SkanderbegPage.tsx
@@ -39,7 +39,11 @@ export const SkanderbegPage = () => {
               );
             }}
           >
-            <Input name="id" placeholder="Skanderbeg URL or id" />
+            <Input
+              name="id"
+              placeholder="Skanderbeg URL or id"
+              className="h-10 px-3 py-2"
+            />
             <Button type="submit" variant="primary">
               Analyze
             </Button>

--- a/src/app/src/hooks/useThrottle.tsx
+++ b/src/app/src/hooks/useThrottle.tsx
@@ -1,0 +1,24 @@
+import { throttle } from "map";
+import { useEffect, useReducer, useRef } from "react";
+import { useIsMounted } from "./useIsMounted";
+
+export function useThrottle<T>(value: T, interval: number) {
+  // Easier to use refs when value could be a function
+  const throttledValue = useRef(value);
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
+
+  const mounted = useIsMounted();
+  const cb = (x: T) => {
+    if (mounted()) {
+      throttledValue.current = x;
+      forceUpdate();
+    }
+  };
+
+  const setter = useRef(throttle(cb, interval));
+  useEffect(() => {
+    setter.current(value);
+  }, [value]);
+
+  return throttledValue.current;
+}

--- a/src/cli/src/cmd/compile_assets/mapper.rs
+++ b/src/cli/src/cmd/compile_assets/mapper.rs
@@ -16,6 +16,8 @@ pub struct Terrain {
 pub struct TerrainCategory {
     #[serde(default)]
     pub terrain_override: Vec<u16>,
+    #[serde(default)]
+    pub local_development_cost: f32,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/eu4game/src/ext.rs
+++ b/src/eu4game/src/ext.rs
@@ -1,0 +1,20 @@
+use eu4save::{models::Province, Eu4Date};
+
+pub trait ProvinceExt {
+    fn recently_exploited(&self, at: Eu4Date) -> bool;
+    fn exploitable(&self, at: Eu4Date) -> bool;
+}
+
+impl ProvinceExt for Province {
+    fn recently_exploited(&self, at: Eu4Date) -> bool {
+        self.exploit_date
+            .map_or(false, |x| x.add_days(365 * 20) > at)
+    }
+
+    fn exploitable(&self, at: Eu4Date) -> bool {
+        // Can't exploit production of inland provinces, but this hasn't been setup,
+        // so just rely on either tax or manpower being above 2.
+        let has_dev = self.base_tax >= 2.0 || self.base_manpower >= 2.0;
+        has_dev && !self.recently_exploited(at)
+    }
+}

--- a/src/eu4game/src/game.rs
+++ b/src/eu4game/src/game.rs
@@ -1,7 +1,10 @@
 use crate::GameProvince;
 pub use eu4game_data::LATEST_MINOR;
 use eu4save::{CountryTag, ProvinceId};
-use schemas::flatbuffers::{Follow, Vector};
+use schemas::{
+    eu4::Terrain,
+    flatbuffers::{Follow, Vector},
+};
 use std::{cmp::Ordering, collections::HashMap};
 
 #[derive(Debug)]
@@ -46,6 +49,12 @@ pub enum NavalUnitKind {
     LightShip,
     Galley,
     Transport,
+}
+
+#[derive(Debug)]
+pub struct TerrainInfo {
+    pub terrain: Terrain,
+    pub local_development_cost: f32,
 }
 
 #[derive(Debug)]
@@ -341,6 +350,17 @@ impl<'a> Game<'a> {
                 _ => NavalUnitKind::Transport,
             },
         })
+    }
+
+    pub fn terrain_infos(&self) -> impl Iterator<Item = TerrainInfo> + 'a {
+        self.data.terrain().unwrap().iter().map(|x| TerrainInfo {
+            terrain: x.id(),
+            local_development_cost: x.local_development_cost(),
+        })
+    }
+
+    pub fn terrain_info(&self, terrain: schemas::eu4::Terrain) -> Option<TerrainInfo> {
+        self.terrain_infos().find(|x| x.terrain == terrain)
     }
 }
 

--- a/src/eu4game/src/lib.rs
+++ b/src/eu4game/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod achievements;
 mod errors;
+mod ext;
 pub mod game;
 mod models;
 mod save_game_query;
 pub mod shared;
 
 pub use errors::*;
+pub use ext::*;
 pub use models::*;
 pub use save_game_query::*;

--- a/src/schemas/src/eu4.fbs
+++ b/src/schemas/src/eu4.fbs
@@ -31,6 +31,11 @@ struct Rgb {
   b:uint8;
 }
 
+table TerrainInfo {
+  id:Terrain;
+  local_development_cost:float32;
+}
+
 table Country {
   tag:string (key);
   name:string;
@@ -126,6 +131,7 @@ table Game {
   religions:[Religion];
   land_units:[LandUnit];
   naval_units:[NavalUnit];
+  terrain:[TerrainInfo];
 }
 
 root_type Game;

--- a/src/wasm-eu4/Cargo.toml
+++ b/src/wasm-eu4/Cargo.toml
@@ -19,6 +19,7 @@ js-sys = "0.3"
 once_cell = "1.13"
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.5"
 eu4save = { git = "https://github.com/rakaly/eu4save.git", default-features = false, features = ["zstd", "tsify"] }
 eu4game = { path = "../eu4game", default-features = false }
 schemas = { path = "../schemas" }

--- a/src/wasm-eu4/src/lib.rs
+++ b/src/wasm-eu4/src/lib.rs
@@ -6,7 +6,7 @@ use crate::{
         PlayerHistories, RunningMonarchs, SingleCountryWarCasualtiesList, StaticMap, StringList,
         Wars,
     },
-    savefile::CountryHistory,
+    savefile::{CountryHistory, CountryInstitution},
 };
 use eu4game::{game::Game, shared::Eu4Parser};
 use eu4save::{
@@ -191,6 +191,21 @@ impl SaveFile {
 
     pub fn get_country_history(&self, tag: &str) -> CountryHistory {
         self.0.country_history(tag)
+    }
+
+    pub fn get_country_institutions(
+        &self,
+        tag: &str,
+        country_development_modifier: f64,
+        expand_infrastructure_cost: i32,
+        overrides: JsValue,
+    ) -> CountryInstitution {
+        self.0.institution_provinces(
+            tag,
+            country_development_modifier,
+            expand_infrastructure_cost,
+            overrides,
+        )
     }
 
     pub fn get_country_province_religion(&self, tag: &str) -> CountryReligions {

--- a/src/wasm-eu4/src/savefile/country_details.rs
+++ b/src/wasm-eu4/src/savefile/country_details.rs
@@ -10,7 +10,7 @@ use crate::savefile::{
     hex_color, BattleGroundProvince, CountryHistoryYear, CountryReligion, CultureTolerance,
     MonarchStats, RebelReligion, WarEnd, WarStart,
 };
-use eu4game::SaveGameQuery;
+use eu4game::{ProvinceExt, SaveGameQuery};
 use eu4save::{
     models::{Country, CountryEvent, Leader, LeaderKind, Province},
     query::{NationEvents, ProvinceOwnerChange, SaveCountry},
@@ -665,18 +665,7 @@ impl SaveFileImpl {
             let entry = province_counts.entry(religion).or_default();
             entry.count += 1;
             entry.development += prov.base_manpower + prov.base_production + prov.base_tax;
-
-            // Can't exploit production of inland provinces, but this hasn't been setup,
-            // so just rely on either tax or manpower being above 2.
-            let exploited_recently = prov.exploit_date.map_or(false, |x| {
-                x.add_days(365 * 20) > self.query.save().meta.date
-            });
-            entry.exploitable +=
-                if (prov.base_tax >= 2.0 || prov.base_manpower >= 2.0) && !exploited_recently {
-                    1
-                } else {
-                    0
-                }
+            entry.exploitable += prov.exploitable(self.query.save().meta.date) as usize;
         }
 
         let mut total_provinces = 0;

--- a/src/wasm-eu4/src/savefile/institution.rs
+++ b/src/wasm-eu4/src/savefile/institution.rs
@@ -1,0 +1,818 @@
+use super::{CountryInstitution, InstitutionCost, SaveFileImpl};
+use eu4game::ProvinceExt;
+use eu4save::{models::Province, CountryTag, ProvinceId};
+use std::{collections::HashMap, ops};
+use wasm_bindgen::JsValue;
+
+const MIN_INSITUTION_POINTS: i32 = 601;
+
+// province institution is out of 100 but points are out of 601
+const INSTITUTION_SCALING: f64 = MIN_INSITUTION_POINTS as f64 / 100.0;
+
+// Compute the province development that would cause an institution to spawn
+// there, given the starting development and current progress.
+fn end_dev(start_dev: i32, institution_progress: f64) -> i32 {
+    let dev = start_dev as f64;
+
+    // Add all numbers: x+1, x+2, ..., x+y until it surpasses 601.
+    // Equation: (x+y)*(x+y+1)/2 - x*(x+1)/2 > 601
+    // Replace x by start_dev and solve for y.
+    // y = (sqrt(4 x^2 + 4 x + 4809) - 2 x - 1) / 2
+    // https://www.wolframalpha.com/input?i=%28x%2By%29*%28x%2By%2B1%29%2F2+-+x%28x%2B1%29%2F2+%3E+601
+    let progress_offset = 8.0 * INSTITUTION_SCALING * institution_progress;
+    let radicand = 4.0 * dev * dev + 4.0 * dev - progress_offset + 4809.0;
+    let y = (f64::sqrt(radicand) - 2.0 * dev - 1.0) * 0.5;
+    (dev + f64::ceil(y)) as i32
+}
+
+// Compute the dev you should exploit at to minimize overflow in institution
+// points, given the starting dev of the province and current progress.
+fn exploit_at(start_dev: i32, institution_progress: f64) -> i32 {
+    let progress_points = (INSTITUTION_SCALING * institution_progress).round() as i32;
+    let final_dev = end_dev(start_dev, institution_progress);
+    let institution_points = final_dev * (final_dev + 1) / 2 - start_dev * (start_dev + 1) / 2;
+    let extra_points = institution_points + progress_points - MIN_INSITUTION_POINTS;
+    start_dev.max(final_dev - extra_points)
+}
+
+// Returns the base dev cost modifier (as a percent) given a current dev.
+//  - [0-9] there is no increase per dev click
+//  - [10-19]: each dev click increases dev cost by 3% (eg: f(11) -> 6%)
+//  - [20-29]: each dev click increases dev cost by 6% (eg: f(21) -> 42%)
+//  - etc with each 10 development increasing dev click cost by another 3%
+fn base_dev_cost_modifier(dev: i32) -> Modifier {
+    // Gaussian summation trick:
+    let whole = (dev / 10) * 5 * ((dev - 10).max(0) / 10 * 3);
+
+    // the remnants of the latest block
+    let partial = ((dev % 10) + 1) * (dev / 10) * 3;
+    Modifier::from_percent(whole + partial)
+}
+
+/// Returns the mana cost of increasing a province development by one given:
+/// - The current development of the province
+/// - The development cost modifier
+/// - The development efficiency modifier
+fn dev_cost(
+    dev: i32,
+    variables: ProvinceVariables,
+    province: ProvinceModifiers,
+    country: CountryModifiers,
+) -> i32 {
+    let dev_efficiency = province.dev_efficiency + country.dev_efficiency;
+    let dev_base_cost = (50.0 * (1.0 - dev_efficiency.0)).floor();
+
+    let base_cost_modifier = base_dev_cost_modifier(dev);
+    let expand_infrastructure_modifier = country
+        .expand_infrastructure_dev_cost_modifier
+        .mul(variables.expand_infrastructure_times);
+    let final_dev_cost_increase =
+        base_cost_modifier + province.dev_cost_modifier + expand_infrastructure_modifier;
+    let dev_cost_modifier = (1.0 + final_dev_cost_increase.0).max(0.1);
+
+    (dev_base_cost * dev_cost_modifier).floor().min(999.0) as i32
+}
+
+#[derive(Debug, PartialEq, Clone, Copy, Eq, PartialOrd, Ord)]
+struct ProvinceDevStrategy {
+    mana_cost: i32,
+    additional_expand_infrastructure: i32,
+    exploit_at: Option<i32>,
+    final_dev: i32,
+}
+
+fn institution_cost_engine(prov: InstitutionEngine) -> ProvinceDevStrategy {
+    if prov.institution_progress >= 100.0 {
+        let exploit_at = match prov.exploitable {
+            Exploit::At(x) => Some(x),
+            _ => None,
+        };
+
+        let additional_expand_infrastructure =
+            prov.current_expand_infrastructure - prov.original_expand_infrastructure;
+
+        return ProvinceDevStrategy {
+            mana_cost: prov.mana_cost,
+            final_dev: prov.dev,
+            additional_expand_infrastructure,
+            exploit_at,
+        };
+    }
+
+    let base = institution_cost_engine(prov.dev_click());
+    let mut optimal = base;
+
+    let expand_step = prov.dev % 15 == 0;
+    let available_expands = (prov.dev / 15) - prov.current_expand_infrastructure;
+    if expand_step && available_expands == 1 {
+        optimal = optimal.min(institution_cost_engine(prov.expand_infrastructure()))
+    }
+
+    if matches!(prov.exploitable, Exploit::Available) {
+        let right_after_expand = expand_step && available_expands == 0;
+        let optimal_exploit = exploit_at(prov.dev, f64::from(prov.institution_progress));
+        if right_after_expand || prov.dev == optimal_exploit {
+            optimal = optimal.min(institution_cost_engine(prov.exploit()))
+        }
+    }
+
+    optimal
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Exploit {
+    Available,
+    Unavailable,
+    At(i32),
+}
+
+struct InstitutionEngine {
+    // Mana cost spent developing the institution.
+    mana_cost: i32,
+
+    // Current development of the province.
+    dev: i32,
+    institution_progress: f64,
+    current_expand_infrastructure: i32,
+    exploitable: Exploit,
+
+    original_expand_infrastructure: i32,
+    prov_modifiers: ProvinceModifiers,
+    country_modifiers: CountryModifiers,
+}
+
+impl InstitutionEngine {
+    fn dev_click(&self) -> Self {
+        let variables = ProvinceVariables {
+            expand_infrastructure_times: self.current_expand_infrastructure,
+        };
+
+        let dev_cost = dev_cost(
+            self.dev,
+            variables,
+            self.prov_modifiers,
+            self.country_modifiers,
+        );
+        let new_dev = self.dev + 1;
+        let new_institution_progress =
+            self.institution_progress + (new_dev as f64) / INSTITUTION_SCALING;
+
+        Self {
+            mana_cost: self.mana_cost + dev_cost,
+            dev: new_dev,
+            institution_progress: new_institution_progress,
+            ..*self
+        }
+    }
+
+    fn exploit(&self) -> Self {
+        Self {
+            dev: self.dev - 1,
+            exploitable: Exploit::At(self.dev),
+            ..*self
+        }
+    }
+
+    fn expand_infrastructure(&self) -> Self {
+        Self {
+            mana_cost: self.mana_cost + self.country_modifiers.expand_infrastructure_cost,
+            current_expand_infrastructure: self.current_expand_infrastructure + 1,
+            ..*self
+        }
+    }
+}
+
+fn institution_cost(
+    stats: ProvinceStats,
+    province: ProvinceModifiers,
+    country: CountryModifiers,
+) -> ProvinceDevStrategy {
+    let exploitable = if stats.exploitable {
+        Exploit::Available
+    } else {
+        Exploit::Unavailable
+    };
+
+    let engine = InstitutionEngine {
+        mana_cost: 0,
+        dev: stats.dev,
+        original_expand_infrastructure: stats.current_expand_infrastructure,
+        current_expand_infrastructure: stats.current_expand_infrastructure,
+        exploitable,
+        institution_progress: f64::from(stats.institution_progress),
+        prov_modifiers: province,
+        country_modifiers: country,
+    };
+
+    institution_cost_engine(engine)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
+struct Modifier(f64);
+
+impl ops::Add for Modifier {
+    type Output = Self;
+
+    #[must_use]
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Modifier {
+    #[must_use]
+    pub fn from_percent(percent: i32) -> Self {
+        Self(percent as f64 / 100.0)
+    }
+
+    #[must_use]
+    pub fn mul(self, times: i32) -> Self {
+        Self(times as f64 * self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Default)]
+struct DevEfficiency(f64);
+
+impl ops::Add for DevEfficiency {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CountryModifiers {
+    // Mana cost of clicking the expand infrastructure button.
+    expand_infrastructure_cost: i32,
+
+    expand_infrastructure_dev_cost_modifier: Modifier,
+
+    // Country-wide dev efficiency for all owned provinces (eg: admin tech 17)
+    dev_efficiency: DevEfficiency,
+}
+
+impl Default for CountryModifiers {
+    fn default() -> Self {
+        Self {
+            expand_infrastructure_cost: 50,
+            expand_infrastructure_dev_cost_modifier: Modifier::from_percent(-15),
+            dev_efficiency: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ProvinceVariables {
+    // Number of times province infrastructure has been expanded
+    expand_infrastructure_times: i32,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ProvinceModifiers {
+    // Province specific dev efficiency (eg: monument dev efficiency for state)
+    dev_efficiency: DevEfficiency,
+
+    // Province specific dev cost modifier
+    dev_cost_modifier: Modifier,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ProvinceStats {
+    dev: i32,
+    institution_progress: f32,
+    current_expand_infrastructure: i32,
+    exploitable: bool,
+}
+
+#[derive(Debug)]
+struct ProvinceInstitution<'a> {
+    results: ProvinceDevStrategy,
+    province: &'a Province,
+    current_institution_progress: f32,
+    province_id: ProvinceId,
+    dev: i32,
+    dev_cost_modifier: Modifier,
+}
+
+impl SaveFileImpl {
+    pub fn institution_provinces(
+        &self,
+        tag: &str,
+        country_wide_dev_cost_modifier: f64,
+        expand_infrastructure_cost: i32,
+        overrides: JsValue,
+    ) -> CountryInstitution {
+        let overrides: HashMap<ProvinceId, f64> =
+            serde_wasm_bindgen::from_value(overrides).unwrap();
+        let tag = tag.parse::<CountryTag>().unwrap();
+        let country = self.query.country(&tag).unwrap();
+        let state_lookup = self.game.province_area_lookup();
+
+        let institutions = &self.query.save().game.institutions;
+        let institutions_spawned = institutions
+            .iter()
+            .position(|&x| x == 0)
+            .unwrap_or(institutions.len() - 1);
+        let institutions_embraced = country
+            .institutions
+            .iter()
+            .position(|&x| x == 0)
+            .unwrap_or(country.institutions.len() - 1);
+
+        let max_institution_index = (institutions_spawned - 1).max(0);
+
+        let dev_efficiency = match country.technology.adm_tech {
+            ..=16 => 0.0,
+            17..=22 => 0.1,
+            23..=26 => 0.2,
+            27.. => 0.3,
+        };
+
+        let country_modifers = CountryModifiers {
+            dev_efficiency: DevEfficiency(dev_efficiency),
+            expand_infrastructure_cost,
+            expand_infrastructure_dev_cost_modifier: Modifier(-0.15),
+        };
+
+        let provinces = self
+            .query
+            .save()
+            .game
+            .provinces
+            .iter()
+            .filter(|(_, prov)| prov.owner.is_some_and(|owner| owner == tag));
+
+        let mut costs = Vec::new();
+
+        for (id, save) in provinces {
+            let Some(game) = self.game.get_province(id) else {
+                continue;
+            };
+
+            let current_institution_progress = save
+                .institutions
+                .get(max_institution_index)
+                .copied()
+                .unwrap_or_default();
+
+            if current_institution_progress >= 100.0 {
+                continue;
+            }
+
+            let terrain_local_dev = self
+                .game
+                .terrain_info(game.terrain)
+                .map(|x| x.local_development_cost)
+                .unwrap_or_default();
+
+            let cot_dev = match save.center_of_trade {
+                2 => -0.05,
+                3.. => -0.10,
+                _ => 0.0,
+            };
+
+            let trade_goods_modifier = save
+                .trade_goods
+                .as_ref()
+                .filter(|x| matches!(x.as_str(), "cotton" | "cloth"))
+                .map(|_| -0.1)
+                .unwrap_or_default();
+
+            // let climate_dev =
+
+            let capital_modifier = if country.capital == *id {
+                -(((country.raw_development / 100.0) * 0.05).min(0.5)) as f64
+            } else {
+                0.0
+            };
+
+            let prosperity_modifier = state_lookup
+                .get(id)
+                .and_then(|state| self.query.save().game.map_area_data.get(*state))
+                .and_then(|x| x.state.as_ref())
+                .and_then(|x| x.country_states.iter().find(|c| c.country == tag))
+                .filter(|x| x.prosperity >= 100.0)
+                .map(|_| -0.1)
+                .unwrap_or_default();
+
+            let dev_cost_modifier = f64::from(terrain_local_dev)
+                + cot_dev
+                + capital_modifier
+                + prosperity_modifier
+                + trade_goods_modifier
+                + country_wide_dev_cost_modifier;
+
+            // Avoid situations where "-0.15000000000000002" (which does
+            // influence results), we convert to percent and remove the decimal.
+            let dev_cost_modifier = f64::trunc(dev_cost_modifier * 100.0) / 100.0;
+
+            let dev_cost_modifier = overrides.get(id).copied().unwrap_or(dev_cost_modifier);
+
+            let province_modifiers = ProvinceModifiers {
+                dev_efficiency: DevEfficiency(0.0),
+                dev_cost_modifier: Modifier(dev_cost_modifier),
+            };
+
+            let dev = (save.base_tax + save.base_production + save.base_manpower).floor() as i32;
+            let stats = ProvinceStats {
+                dev,
+                institution_progress: current_institution_progress,
+                current_expand_infrastructure: save.expand_infrastructure,
+                exploitable: !save.recently_exploited(self.query.save().meta.date),
+            };
+            let cost = institution_cost(stats, province_modifiers, country_modifers);
+
+            costs.push(ProvinceInstitution {
+                results: cost,
+                dev_cost_modifier: province_modifiers.dev_cost_modifier,
+                current_institution_progress,
+                province: save,
+                province_id: *id,
+                dev,
+            })
+        }
+
+        costs.sort_by(|a, b| a.results.cmp(&b.results));
+
+        let dev_push = costs
+            .into_iter()
+            .map(|x| InstitutionCost {
+                province_id: x.province_id,
+                name: x.province.name.clone(),
+                mana_cost: x.results.mana_cost,
+                additional_expand_infrastructure: x.results.additional_expand_infrastructure,
+                exploit_at: x.results.exploit_at,
+                current_dev: x.dev,
+                final_dev: x.results.final_dev,
+                current_institution_progress: x.current_institution_progress,
+                dev_cost_modifier: x.dev_cost_modifier.0,
+            })
+            .collect();
+
+        CountryInstitution {
+            institutions_available: institutions_spawned as i32,
+            institutions_embraced: institutions_embraced as i32,
+            dev_push,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests generated from: https://docs.google.com/spreadsheets/d/1I45UTLi1twV-std0vq57J_LCJETWLSNEAqJmjhGE-8c/edit#gid=2146778308
+    #[test]
+    fn test_exploit_at() {
+        assert_eq!(exploit_at(3, 0.0), 12);
+        assert_eq!(exploit_at(4, 0.0), 16);
+        assert_eq!(exploit_at(5, 0.0), 21);
+        assert_eq!(exploit_at(6, 0.0), 27);
+        assert_eq!(exploit_at(7, 0.0), 34);
+        assert_eq!(exploit_at(8, 0.0), 8);
+        assert_eq!(exploit_at(9, 0.0), 16);
+        assert_eq!(exploit_at(10, 0.0), 26);
+        assert_eq!(exploit_at(11, 0.0), 11);
+        assert_eq!(exploit_at(12, 0.0), 13);
+        assert_eq!(exploit_at(13, 0.0), 26);
+        assert_eq!(exploit_at(14, 0.0), 14);
+        assert_eq!(exploit_at(15, 0.0), 18);
+        assert_eq!(exploit_at(16, 0.0), 34);
+        assert_eq!(exploit_at(17, 0.0), 17);
+        assert_eq!(exploit_at(18, 0.0), 31);
+        assert_eq!(exploit_at(19, 0.0), 19);
+        assert_eq!(exploit_at(20, 0.0), 31);
+        assert_eq!(exploit_at(21, 0.0), 21);
+        assert_eq!(exploit_at(22, 0.0), 34);
+        assert_eq!(exploit_at(23, 0.0), 23);
+        assert_eq!(exploit_at(24, 0.0), 40);
+        assert_eq!(exploit_at(25, 0.0), 25);
+        assert_eq!(exploit_at(26, 0.0), 26);
+        assert_eq!(exploit_at(27, 0.0), 33);
+        assert_eq!(exploit_at(28, 0.0), 28);
+        assert_eq!(exploit_at(29, 0.0), 29);
+        assert_eq!(exploit_at(30, 0.0), 31);
+    }
+
+    #[test]
+    fn test_exploit_at_partial_4() {
+        assert_eq!(exploit_at(4, 0.000000), 16);
+        assert_eq!(exploit_at(4, 4.991681), 20);
+        assert_eq!(exploit_at(4, 9.983361), 23);
+        assert_eq!(exploit_at(4, 14.975042), 25);
+        assert_eq!(exploit_at(4, 19.966722), 26);
+        assert_eq!(exploit_at(4, 24.958403), 26);
+        assert_eq!(exploit_at(4, 29.950083), 25);
+        assert_eq!(exploit_at(4, 34.941764), 23);
+        assert_eq!(exploit_at(4, 39.933444), 20);
+        assert_eq!(exploit_at(4, 44.925125), 16);
+        assert_eq!(exploit_at(4, 49.916805), 11);
+        assert_eq!(exploit_at(4, 54.908486), 5);
+        assert_eq!(exploit_at(4, 59.900166), 20);
+        assert_eq!(exploit_at(4, 64.891847), 11);
+        assert_eq!(exploit_at(4, 69.883527), 4);
+        assert_eq!(exploit_at(4, 74.875208), 8);
+        assert_eq!(exploit_at(4, 79.866889), 11);
+        assert_eq!(exploit_at(4, 84.858569), 10);
+        assert_eq!(exploit_at(4, 89.850250), 5);
+        assert_eq!(exploit_at(4, 94.841930), 5);
+        assert_eq!(exploit_at(4, 99.833611), 4);
+
+        assert_eq!(end_dev(4, 100.0 * 596.0 / MIN_INSITUTION_POINTS as f64), 5);
+        assert_eq!(
+            exploit_at(4, 100.0 * 596.0 / MIN_INSITUTION_POINTS as f64),
+            5
+        );
+    }
+
+    #[test]
+    fn test_base_dev_cost_modifier() {
+        assert_eq!(base_dev_cost_modifier(3), Modifier::from_percent(0));
+        assert_eq!(base_dev_cost_modifier(4), Modifier::from_percent(0));
+        assert_eq!(base_dev_cost_modifier(5), Modifier::from_percent(0));
+        assert_eq!(base_dev_cost_modifier(6), Modifier::from_percent(0));
+        assert_eq!(base_dev_cost_modifier(7), Modifier::from_percent(0));
+        assert_eq!(base_dev_cost_modifier(8), Modifier::from_percent(0));
+        assert_eq!(base_dev_cost_modifier(9), Modifier::from_percent(0));
+        assert_eq!(base_dev_cost_modifier(10), Modifier::from_percent(3));
+        assert_eq!(base_dev_cost_modifier(11), Modifier::from_percent(6));
+        assert_eq!(base_dev_cost_modifier(12), Modifier::from_percent(9));
+        assert_eq!(base_dev_cost_modifier(13), Modifier::from_percent(12));
+        assert_eq!(base_dev_cost_modifier(14), Modifier::from_percent(15));
+        assert_eq!(base_dev_cost_modifier(15), Modifier::from_percent(18));
+        assert_eq!(base_dev_cost_modifier(16), Modifier::from_percent(21));
+        assert_eq!(base_dev_cost_modifier(17), Modifier::from_percent(24));
+        assert_eq!(base_dev_cost_modifier(18), Modifier::from_percent(27));
+        assert_eq!(base_dev_cost_modifier(19), Modifier::from_percent(30));
+        assert_eq!(base_dev_cost_modifier(20), Modifier::from_percent(36));
+        assert_eq!(base_dev_cost_modifier(21), Modifier::from_percent(42));
+        assert_eq!(base_dev_cost_modifier(22), Modifier::from_percent(48));
+        assert_eq!(base_dev_cost_modifier(23), Modifier::from_percent(54));
+        assert_eq!(base_dev_cost_modifier(24), Modifier::from_percent(60));
+        assert_eq!(base_dev_cost_modifier(25), Modifier::from_percent(66));
+        assert_eq!(base_dev_cost_modifier(26), Modifier::from_percent(72));
+        assert_eq!(base_dev_cost_modifier(27), Modifier::from_percent(78));
+        assert_eq!(base_dev_cost_modifier(28), Modifier::from_percent(84));
+        assert_eq!(base_dev_cost_modifier(29), Modifier::from_percent(90));
+        assert_eq!(base_dev_cost_modifier(30), Modifier::from_percent(99));
+        assert_eq!(base_dev_cost_modifier(31), Modifier::from_percent(108));
+        assert_eq!(base_dev_cost_modifier(32), Modifier::from_percent(117));
+        assert_eq!(base_dev_cost_modifier(33), Modifier::from_percent(126));
+        assert_eq!(base_dev_cost_modifier(34), Modifier::from_percent(135));
+        assert_eq!(base_dev_cost_modifier(35), Modifier::from_percent(144));
+        assert_eq!(base_dev_cost_modifier(36), Modifier::from_percent(153));
+        assert_eq!(base_dev_cost_modifier(37), Modifier::from_percent(162));
+        assert_eq!(base_dev_cost_modifier(38), Modifier::from_percent(171));
+        assert_eq!(base_dev_cost_modifier(39), Modifier::from_percent(180));
+        assert_eq!(base_dev_cost_modifier(40), Modifier::from_percent(192));
+    }
+
+    #[test]
+    fn test_dev_cost_base() {
+        fn dev(dev: i32) -> i32 {
+            let variables = ProvinceVariables {
+                expand_infrastructure_times: dev / 15,
+            };
+            let prov_mods = ProvinceModifiers::default();
+            let country_mods = CountryModifiers {
+                expand_infrastructure_dev_cost_modifier: Modifier(-0.25),
+                ..CountryModifiers::default()
+            };
+            dev_cost(dev, variables, prov_mods, country_mods)
+        }
+
+        assert_eq!(dev(3), 50);
+        assert_eq!(dev(4), 50);
+        assert_eq!(dev(5), 50);
+        assert_eq!(dev(6), 50);
+        assert_eq!(dev(7), 50);
+        assert_eq!(dev(8), 50);
+        assert_eq!(dev(9), 50);
+        assert_eq!(dev(10), 51);
+        assert_eq!(dev(11), 53);
+        assert_eq!(dev(12), 54);
+        assert_eq!(dev(13), 56);
+        assert_eq!(dev(14), 57);
+        assert_eq!(dev(15), 46);
+        assert_eq!(dev(16), 48);
+        assert_eq!(dev(17), 49);
+        assert_eq!(dev(18), 51);
+        assert_eq!(dev(19), 52);
+        assert_eq!(dev(20), 55);
+        assert_eq!(dev(21), 58);
+        assert_eq!(dev(22), 61);
+        assert_eq!(dev(23), 64);
+        assert_eq!(dev(24), 67);
+        assert_eq!(dev(25), 70);
+        assert_eq!(dev(26), 73);
+        assert_eq!(dev(27), 76);
+        assert_eq!(dev(28), 79);
+        assert_eq!(dev(29), 82);
+        assert_eq!(dev(30), 74);
+    }
+
+    #[test]
+    fn test_dev_cost_modifier() {
+        fn dev(dev: i32) -> i32 {
+            let variables = ProvinceVariables {
+                expand_infrastructure_times: dev / 15,
+            };
+            let prov_mods = ProvinceModifiers {
+                dev_cost_modifier: Modifier(-0.1),
+                ..ProvinceModifiers::default()
+            };
+            let country_mods = CountryModifiers {
+                expand_infrastructure_dev_cost_modifier: Modifier(-0.25),
+                ..CountryModifiers::default()
+            };
+            dev_cost(dev, variables, prov_mods, country_mods)
+        }
+
+        assert_eq!(dev(3), 45);
+        assert_eq!(dev(4), 45);
+        assert_eq!(dev(5), 45);
+        assert_eq!(dev(6), 45);
+        assert_eq!(dev(7), 45);
+        assert_eq!(dev(8), 45);
+        assert_eq!(dev(9), 45);
+        assert_eq!(dev(10), 46);
+        assert_eq!(dev(11), 48);
+        assert_eq!(dev(12), 49);
+        assert_eq!(dev(13), 51);
+        assert_eq!(dev(14), 52);
+        assert_eq!(dev(15), 41);
+        assert_eq!(dev(16), 43);
+        assert_eq!(dev(17), 44);
+        assert_eq!(dev(18), 46);
+        assert_eq!(dev(19), 47);
+        assert_eq!(dev(20), 50);
+        assert_eq!(dev(21), 53);
+        assert_eq!(dev(22), 56);
+        assert_eq!(dev(23), 59);
+        assert_eq!(dev(24), 62);
+        assert_eq!(dev(25), 65);
+        assert_eq!(dev(26), 68);
+        assert_eq!(dev(27), 71);
+        assert_eq!(dev(28), 74);
+        assert_eq!(dev(29), 77);
+        assert_eq!(dev(30), 69);
+    }
+
+    #[test]
+    fn test_dev_cost_efficiency() {
+        fn dev(dev: i32) -> i32 {
+            let variables = ProvinceVariables {
+                expand_infrastructure_times: dev / 15,
+            };
+            let prov_mods = ProvinceModifiers::default();
+            let country_mods = CountryModifiers {
+                expand_infrastructure_dev_cost_modifier: Modifier(-0.25),
+                dev_efficiency: DevEfficiency(0.1),
+                ..CountryModifiers::default()
+            };
+            dev_cost(dev, variables, prov_mods, country_mods)
+        }
+
+        assert_eq!(dev(3), 45);
+        assert_eq!(dev(4), 45);
+        assert_eq!(dev(5), 45);
+        assert_eq!(dev(6), 45);
+        assert_eq!(dev(7), 45);
+        assert_eq!(dev(8), 45);
+        assert_eq!(dev(9), 45);
+        assert_eq!(dev(10), 46);
+        assert_eq!(dev(11), 47);
+        assert_eq!(dev(12), 49);
+        assert_eq!(dev(13), 50);
+        assert_eq!(dev(14), 51);
+        assert_eq!(dev(15), 41);
+        assert_eq!(dev(16), 43);
+        assert_eq!(dev(17), 44);
+        assert_eq!(dev(18), 45);
+        assert_eq!(dev(19), 47);
+        assert_eq!(dev(20), 49);
+        assert_eq!(dev(21), 52);
+        assert_eq!(dev(22), 55);
+        assert_eq!(dev(23), 58);
+        assert_eq!(dev(24), 60);
+        assert_eq!(dev(25), 63);
+        assert_eq!(dev(26), 66);
+        assert_eq!(dev(27), 68);
+        assert_eq!(dev(28), 71);
+        assert_eq!(dev(29), 74);
+        assert_eq!(dev(30), 67);
+    }
+
+    #[test]
+    fn test_dev_cost_both() {
+        fn dev(dev: i32) -> i32 {
+            let variables = ProvinceVariables {
+                expand_infrastructure_times: dev / 15,
+            };
+            let prov_mods = ProvinceModifiers {
+                dev_cost_modifier: Modifier(-0.1),
+                ..ProvinceModifiers::default()
+            };
+            let country_mods = CountryModifiers {
+                expand_infrastructure_dev_cost_modifier: Modifier(-0.25),
+                dev_efficiency: DevEfficiency(0.1),
+                ..CountryModifiers::default()
+            };
+            dev_cost(dev, variables, prov_mods, country_mods)
+        }
+
+        assert_eq!(dev(3), 40);
+        assert_eq!(dev(4), 40);
+        assert_eq!(dev(5), 40);
+        assert_eq!(dev(6), 40);
+        assert_eq!(dev(7), 40);
+        assert_eq!(dev(8), 40);
+        assert_eq!(dev(9), 40);
+        assert_eq!(dev(10), 41);
+        assert_eq!(dev(11), 43);
+        assert_eq!(dev(12), 44);
+        assert_eq!(dev(13), 45);
+        assert_eq!(dev(14), 47);
+        assert_eq!(dev(15), 37);
+        assert_eq!(dev(16), 38);
+        assert_eq!(dev(17), 40);
+        assert_eq!(dev(18), 41);
+        assert_eq!(dev(19), 42);
+        assert_eq!(dev(20), 45);
+        assert_eq!(dev(21), 48);
+        assert_eq!(dev(22), 50);
+        assert_eq!(dev(23), 53);
+        assert_eq!(dev(24), 56);
+        assert_eq!(dev(25), 58);
+        assert_eq!(dev(26), 61);
+        assert_eq!(dev(27), 64);
+        assert_eq!(dev(28), 67);
+        assert_eq!(dev(29), 69);
+        assert_eq!(dev(30), 62);
+    }
+
+    #[test]
+    fn test_institution_cost() {
+        fn institution(dev: i32) -> ProvinceDevStrategy {
+            let prov_mods = ProvinceModifiers::default();
+            let country_mods = CountryModifiers::default();
+
+            let stats = ProvinceStats {
+                dev,
+                institution_progress: 0.0,
+                current_expand_infrastructure: 0,
+                exploitable: true,
+            };
+            institution_cost(stats, prov_mods, country_mods)
+        }
+
+        assert_eq!(
+            institution(3),
+            ProvinceDevStrategy {
+                mana_cost: 2121,
+                additional_expand_infrastructure: 1,
+                final_dev: 34,
+                exploit_at: Some(15),
+            }
+        );
+
+        assert_eq!(
+            institution(4),
+            ProvinceDevStrategy {
+                mana_cost: 2072,
+                additional_expand_infrastructure: 1,
+                final_dev: 34,
+                exploit_at: Some(16),
+            }
+        );
+
+        // assert_eq!(institution_cost(5, 0.0, 0.0), 1645);
+        // assert_eq!(institution_cost(6, 0.0, 0.0), 1617);
+        // assert_eq!(institution_cost(7, 0.0, 0.0), 1585);
+        // assert_eq!(institution_cost(8, 0.0, 0.0), 1589);
+        // assert_eq!(institution_cost(9, 0.0, 0.0), 1540);
+        // assert_eq!(institution_cost(10, 0.0, 0.0), 1517);
+        // assert_eq!(institution_cost(11, 0.0, 0.0), 1541);
+        // assert_eq!(institution_cost(12, 0.0, 0.0), 1497);
+        // assert_eq!(institution_cost(13, 0.0, 0.0), 1462);
+        // assert_eq!(institution_cost(14, 0.0, 0.0), 1490);
+        // assert_eq!(institution_cost(15, 0.0, 0.0), 1433);
+        // assert_eq!(institution_cost(16, 0.0, 0.0), 1427);
+        // assert_eq!(institution_cost(17, 0.0, 0.0), 1443);
+        // assert_eq!(institution_cost(18, 0.0, 0.0), 1423);
+        // assert_eq!(institution_cost(19, 0.0, 0.0), 1455);
+        // assert_eq!(institution_cost(20, 0.0, 0.0), 1430);
+        // assert_eq!(institution_cost(21, 0.0, 0.0), 1466);
+        // assert_eq!(institution_cost(22, 0.0, 0.0), 1444);
+        // assert_eq!(institution_cost(23, 0.0, 0.0), 1473);
+        // assert_eq!(institution_cost(24, 0.0, 0.0), 1463);
+        // assert_eq!(institution_cost(25, 0.0, 0.0), 1474);
+        // assert_eq!(institution_cost(26, 0.0, 0.0), 1533);
+        // assert_eq!(institution_cost(27, 0.0, 0.0), 1479);
+        // assert_eq!(institution_cost(28, 0.0, 0.0), 1529);
+        // assert_eq!(institution_cost(29, 0.0, 0.0), 1591);
+        // assert_eq!(institution_cost(30, 0.0, 0.0), 1513);
+    }
+}

--- a/src/wasm-eu4/src/savefile/mod.rs
+++ b/src/wasm-eu4/src/savefile/mod.rs
@@ -17,6 +17,7 @@ use eu4save::{
 use std::collections::{HashMap, HashSet};
 
 mod country_details;
+mod institution;
 mod map;
 mod models;
 mod tag_filter;

--- a/src/wasm-eu4/src/savefile/models.rs
+++ b/src/wasm-eu4/src/savefile/models.rs
@@ -1135,3 +1135,24 @@ pub struct ProvinceConquer {
     pub to: LocalizedTag,
     pub development: f32,
 }
+
+#[derive(Tsify, Debug, Serialize)]
+pub struct InstitutionCost {
+    pub province_id: ProvinceId,
+    pub name: String,
+    pub mana_cost: i32,
+    pub additional_expand_infrastructure: i32,
+    pub exploit_at: Option<i32>,
+    pub current_dev: i32,
+    pub final_dev: i32,
+    pub current_institution_progress: f32,
+    pub dev_cost_modifier: f64,
+}
+
+#[derive(Tsify, Debug, Serialize)]
+#[tsify(into_wasm_abi)]
+pub struct CountryInstitution {
+    pub institutions_available: i32,
+    pub institutions_embraced: i32,
+    pub dev_push: Vec<InstitutionCost>,
+}


### PR DESCRIPTION
For the times when you want to know:

- What province you should dev push to minimize mana cost
- How many expand infrastructure to do
- What is the optimal dev to exploit at

Since there are too many dev cost modifiers, the institution module allows users to tweak country wide dev cost modifiers as well as tweak individual provinces. But at least it's a start!

This did require new game data (terrain dev cost modifier).

For now restricted to developers.

![image](https://github.com/pdx-tools/pdx-tools/assets/2106129/bec62723-0b22-40f9-8750-2963db205fc8)
