### PR TITLE
Add some VIctoria 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dev/.env.*staging
 *.node
 tmp/
 node_modules
+*.swp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,6 +3353,7 @@ dependencies = [
  "schemas",
  "serde",
  "serde-wasm-bindgen",
+ "tsify",
  "vic3save",
  "wasm-bindgen",
  "zstd 0.13.0",

--- a/src/app/src/features/engine/GameView.tsx
+++ b/src/app/src/features/engine/GameView.tsx
@@ -71,7 +71,7 @@ const gameRenderer = (savegame: SaveGameInput | null) => {
     case "vic3":
       return {
         kind: "in-screen",
-        component: () => <DynamicVic3 save={savegame} />,
+        component: () => <DynamicVic3 save={savegame.data} />,
       } as const;
     case "hoi4":
       return {

--- a/src/app/src/features/engine/engineStore.ts
+++ b/src/app/src/features/engine/engineStore.ts
@@ -1,13 +1,14 @@
 import { dequal } from "@/lib/dequal";
 import { create } from "zustand";
 import { type Eu4SaveInput } from "@/features/eu4/store";
+import { type Vic3SaveInput } from "@/features/vic3/store";
 
 export type SaveGameInput =
   | { kind: "eu4"; data: Eu4SaveInput }
   | { kind: "ck3"; file: File }
   | { kind: "hoi4"; file: File }
   | { kind: "imperator"; file: File }
-  | { kind: "vic3"; file: File };
+  | { kind: "vic3"; data: Vic3SaveInput };
 
 export type DetectedDataType = SaveGameInput["kind"];
 

--- a/src/app/src/features/engine/hooks/useFilePublisher.ts
+++ b/src/app/src/features/engine/hooks/useFilePublisher.ts
@@ -5,30 +5,34 @@ type AnalyzeInput = FileKind;
 
 async function inputSaveGame(input: AnalyzeInput): Promise<SaveGameInput> {
   const game = extensionType(input.file.name);
-  if (game === "eu4") {
-    if (input.kind === "handle") {
-      const name = (await input.file.getFile()).name;
+  switch (game) {
+    case "vic3":
+    case "eu4": {
+      if (input.kind === "handle") {
+        const name = (await input.file.getFile()).name;
+        return {
+          kind: game,
+          data: {
+            kind: "handle",
+            file: input.file,
+            name,
+          },
+        };
+      } else {
+        return {
+          kind: game,
+          data: input,
+        };
+      }
+    }
+    default: {
+      const file =
+        input.kind === "handle" ? await input.file.getFile() : input.file;
       return {
         kind: game,
-        data: {
-          kind: "handle",
-          file: input.file,
-          name,
-        },
-      };
-    } else {
-      return {
-        kind: game,
-        data: input,
+        file,
       };
     }
-  } else {
-    const file =
-      input.kind === "handle" ? await input.file.getFile() : input.file;
-    return {
-      kind: game,
-      file,
-    };
   }
 }
 

--- a/src/app/src/features/vic3/CountryStats.tsx
+++ b/src/app/src/features/vic3/CountryStats.tsx
@@ -1,15 +1,15 @@
 import { Table } from "@/components/Table";
 import { DataTable } from "@/components/DataTable";
 import { createColumnHelper } from "@tanstack/react-table";
-import { formatFloat, formatInt } from "@/lib/format";
-import { Vic3Stats } from "./worker/types";
+import { formatFloat } from "@/lib/format";
+import { Vic3GraphData } from "./worker/types";
 
 export interface CountryStatsProps {
-  stats: [Vic3Stats];
+  stats: Vic3GraphData[];
 }
 
 export const CountryStatsTable = ({ stats }: CountryStatsProps) => {
-  const columnHelper = createColumnHelper<Vic3Stats>();
+  const columnHelper = createColumnHelper<Vic3GraphData>();
   const columns = [
     columnHelper.accessor("date", {
       sortingFn: "basic",
@@ -39,10 +39,6 @@ export const CountryStatsTable = ({ stats }: CountryStatsProps) => {
       ),
     }),
   ];
-  return (
-    <DataTable
-      data={stats.filter((_v, i, _) => i % 250 == 0)}
-      columns={columns}
-    />
-  );
+
+  return <DataTable data={stats} columns={columns} />;
 };

--- a/src/app/src/features/vic3/CountryStats.tsx
+++ b/src/app/src/features/vic3/CountryStats.tsx
@@ -1,0 +1,48 @@
+import { Table } from "@/components/Table";
+import { DataTable } from "@/components/DataTable";
+import { createColumnHelper } from "@tanstack/react-table";
+import { formatFloat, formatInt } from "@/lib/format";
+import { Vic3Stats } from "./worker/types";
+
+export interface CountryStatsProps {
+  stats: [Vic3Stats];
+}
+
+export const CountryStatsTable = ({ stats }: CountryStatsProps) => {
+  const columnHelper = createColumnHelper<Vic3Stats>();
+  const columns = [
+    columnHelper.accessor("date", {
+      sortingFn: "basic",
+      header: ({ column }) => (
+        <Table.ColumnHeader column={column} title="Date" />
+      ),
+    }),
+    columnHelper.accessor("gdp", {
+      sortingFn: "basic",
+      cell: (info) => formatFloat(info.getValue()),
+      header: ({ column }) => (
+        <Table.ColumnHeader column={column} title="GDP" />
+      ),
+    }),
+    columnHelper.accessor("gdpc", {
+      sortingFn: "basic",
+      cell: (info) => formatFloat(info.getValue()),
+      header: ({ column }) => (
+        <Table.ColumnHeader column={column} title="GDP/c" />
+      ),
+    }),
+    columnHelper.accessor("sol", {
+      sortingFn: "basic",
+      cell: (info) => formatFloat(info.getValue()),
+      header: ({ column }) => (
+        <Table.ColumnHeader column={column} title="SoL" />
+      ),
+    }),
+  ];
+  return (
+    <DataTable
+      data={stats.filter((_v, i, _) => i % 250 == 0)}
+      columns={columns}
+    />
+  );
+};

--- a/src/app/src/features/vic3/TagSelect.tsx
+++ b/src/app/src/features/vic3/TagSelect.tsx
@@ -1,26 +1,22 @@
 import { Button } from "@/components/Button";
 import { PlayIcon } from "@heroicons/react/20/solid";
 import { Select } from "@/components/Select";
+import { useVic3Meta } from "./store";
+import { useMemo } from "react";
 
 export interface TagSelectProps {
   value: string;
-  tags: [string];
-  onChange: (s: string | undefined) => void;
+  onChange: (s: string) => void;
 }
-export const TagSelect = ({ value, tags, onChange }: TagSelectProps) => {
-  const tag_items = [];
-  const unique_tags = tags.filter(function (elem, index, self) {
-    return index === self.indexOf(elem);
-  });
-  for (var t of unique_tags) {
-    tag_items.push(
-      <Select.Item key={t} value={t}>
-        {t}
-      </Select.Item>,
-    );
-  }
+export const TagSelect = ({ value, onChange }: TagSelectProps) => {
+  const { availableTags } = useVic3Meta();
+  const uniqueTags = useMemo(
+    () => [...new Set(availableTags)].sort(),
+    [availableTags],
+  );
+
   return (
-    <Select key={value ?? "def"} value={value} onValueChange={onChange}>
+    <Select key={value} value={value} onValueChange={onChange}>
       <Select.Trigger asChild className="h-10 w-60">
         <Button>
           <Select.Value placeholder="Select country tag" />
@@ -29,7 +25,13 @@ export const TagSelect = ({ value, tags, onChange }: TagSelectProps) => {
           </Select.Icon>
         </Button>
       </Select.Trigger>
-      <Select.Content className="max-h-96">{tag_items}</Select.Content>
+      <Select.Content className="max-h-96">
+        {uniqueTags.map((tag) => (
+          <Select.Item key={tag} value={tag}>
+            {tag}
+          </Select.Item>
+        ))}
+      </Select.Content>
     </Select>
   );
 };

--- a/src/app/src/features/vic3/TagSelect.tsx
+++ b/src/app/src/features/vic3/TagSelect.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@/components/Button";
+import { PlayIcon } from "@heroicons/react/20/solid";
+import { Select } from "@/components/Select";
+
+export interface TagSelectProps {
+  value: string;
+  tags: [string];
+  onChange: (s: string | undefined) => void;
+}
+export const TagSelect = ({ value, tags, onChange }: TagSelectProps) => {
+  const tag_items = [];
+  const unique_tags = tags.filter(function (elem, index, self) {
+    return index === self.indexOf(elem);
+  });
+  for (var t of unique_tags) {
+    tag_items.push(
+      <Select.Item key={t} value={t}>
+        {t}
+      </Select.Item>,
+    );
+  }
+  return (
+    <Select key={value ?? "def"} value={value} onValueChange={onChange}>
+      <Select.Trigger asChild className="h-10 w-60">
+        <Button>
+          <Select.Value placeholder="Select country tag" />
+          <Select.Icon asChild>
+            <PlayIcon className="h-3 w-3 rotate-90 opacity-50 self-center" />
+          </Select.Icon>
+        </Button>
+      </Select.Trigger>
+      <Select.Content className="max-h-96">{tag_items}</Select.Content>
+    </Select>
+  );
+};

--- a/src/app/src/features/vic3/store/Vic3StoreProvider.tsx
+++ b/src/app/src/features/vic3/store/Vic3StoreProvider.tsx
@@ -1,0 +1,10 @@
+import { Vic3SaveContext, Vic3Store } from "./vic3Store";
+
+type Vic3StoreProviderProps = React.PropsWithChildren<{ store: Vic3Store }>;
+export function Vic3StoreProvider({ children, store }: Vic3StoreProviderProps) {
+  return (
+    <Vic3SaveContext.Provider value={store}>
+      {children}
+    </Vic3SaveContext.Provider>
+  );
+}

--- a/src/app/src/features/vic3/store/index.ts
+++ b/src/app/src/features/vic3/store/index.ts
@@ -1,0 +1,3 @@
+export * from "./vic3Store";
+export { useLoadVic3, type Vic3SaveInput } from "./useLoadVic3";
+export * from "./Vic3StoreProvider";

--- a/src/app/src/features/vic3/store/useLoadVic3.ts
+++ b/src/app/src/features/vic3/store/useLoadVic3.ts
@@ -1,0 +1,123 @@
+import { logMs } from "@/lib/log";
+import { emitEvent } from "@/lib/plausible";
+import { timeit } from "@/lib/timeit";
+import { getVic3Worker } from "../worker";
+import { captureException } from "@/features/errors";
+import { useEffect, useReducer } from "react";
+import { pdxAbortController } from "@/lib/abortController";
+import { Vic3Store, createVic3Store } from "./vic3Store";
+
+export type Vic3SaveInput =
+  | { kind: "file"; file: File }
+  | { kind: "handle"; file: FileSystemFileHandle; name: string };
+
+type Task<T> = {
+  fn: () => T | Promise<T>;
+  name: string;
+};
+
+async function loadVic3Save(save: Vic3SaveInput, signal: AbortSignal) {
+  const run = async <T>({ fn, name }: Task<T>) => {
+    signal.throwIfAborted();
+    const result = await timeit(fn).then((res) => {
+      logMs(res, name);
+      return res.data;
+    });
+    signal.throwIfAborted();
+    return result;
+  };
+
+  const worker = getVic3Worker();
+  emitEvent({ kind: "parse", game: "vic3" });
+
+  await Promise.all([
+    run({
+      fn: () => worker.initializeWasm(),
+      name: "initialized vic3 wasm",
+    }),
+
+    run({
+      fn: () => worker.fetchData(save),
+      name: "save data read",
+    }),
+  ]);
+
+  return await run({
+    fn: () => worker.parseVic3(),
+    name: "parse vic3 file",
+  });
+}
+
+type Vic3LoadState = {
+  loading: boolean;
+  data: Vic3Store | null;
+  error: unknown | null;
+};
+
+type Vic3LoadActions =
+  | { kind: "start" }
+  | { kind: "data"; data: Vic3Store }
+  | { kind: "error"; error: unknown };
+
+const loadStateReducer = (
+  state: Vic3LoadState,
+  action: Vic3LoadActions,
+): Vic3LoadState => {
+  switch (action.kind) {
+    case "start": {
+      return {
+        ...state,
+        error: null,
+        loading: true,
+      };
+    }
+    case "data": {
+      return {
+        ...state,
+        data: action.data,
+        loading: false,
+      };
+    }
+    case "error": {
+      return {
+        ...state,
+        error: action.error,
+      };
+    }
+  }
+};
+
+export function useLoadVic3(save: Vic3SaveInput) {
+  const [{ loading, data, error }, dispatch] = useReducer(loadStateReducer, {
+    loading: false,
+    data: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    dispatch({ kind: "start" });
+    const controller = pdxAbortController();
+    loadVic3Save(save, controller.signal)
+      .then(async (data) => {
+        dispatch({
+          kind: "data",
+          data: await createVic3Store({
+            save: { meta: data, filename: save.file.name },
+          }),
+        });
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        dispatch({ kind: "error", error });
+        captureException(error);
+      });
+    return () => {
+      controller.abort("cancelling save load");
+    };
+  }, [save]);
+
+  return { loading, data, error };
+}

--- a/src/app/src/features/vic3/store/vic3Store.ts
+++ b/src/app/src/features/vic3/store/vic3Store.ts
@@ -1,0 +1,34 @@
+import { StoreApi, create, useStore } from "zustand";
+import { Vic3Metadata } from "../worker/types";
+import { createContext, useContext } from "react";
+import { check } from "@/lib/isPresent";
+
+type Vic3StateProps = {
+  save: {
+    meta: Vic3Metadata;
+    filename: string;
+  };
+};
+type Vic3State = Vic3StateProps;
+
+export type Vic3Store = StoreApi<Vic3State>;
+export const Vic3SaveContext = createContext<Vic3Store | null>(null);
+
+export const createVic3Store = async ({ save }: Vic3StateProps) => {
+  return create<Vic3State>()((set, get) => ({
+    save,
+  }));
+};
+
+export function useVic3Context() {
+  return check(useContext(Vic3SaveContext), "Missing Vic3 Save Context");
+}
+
+function useVic3Store<T>(
+  selector: (state: Vic3State) => T,
+  equalityFn?: (left: T, right: T) => boolean,
+): T {
+  return useStore(useVic3Context(), selector, equalityFn);
+}
+export const useVic3Meta = () => useVic3Store((x) => x.save.meta);
+export const useSaveFilename = () => useVic3Store((x) => x.save.filename);

--- a/src/app/src/features/vic3/vic3Ui.tsx
+++ b/src/app/src/features/vic3/vic3Ui.tsx
@@ -1,49 +1,35 @@
-import { useState, useReducer, useEffect } from "react";
-import { log, logMs } from "@/lib/log";
-import { timeit } from "@/lib/timeit";
+import { useState, useCallback } from "react";
 import Head from "next/head";
 import { getVic3Worker } from "./worker";
 import { CountryStatsTable } from "./CountryStats";
 import { TagSelect } from "./TagSelect";
 import { MeltButton } from "@/components/MeltButton";
-import { Vic3Stats, Vic3Metadata } from "./worker/types";
-import { captureException } from "../errors";
 import { Alert } from "@/components/Alert";
 import { getErrorMessage } from "@/lib/getErrorMessage";
-import { emitEvent } from "@/lib/plausible";
-import { pdxAbortController } from "@/lib/abortController";
+import {
+  Vic3SaveInput,
+  Vic3StoreProvider,
+  useLoadVic3,
+  useSaveFilename,
+  useVic3Meta,
+} from "./store";
+import { useVic3Worker } from "./worker/useVic3Worker";
 
-export type Vic3SaveFile = { save: { file: File } };
-type Vic3StatsProps = {
-  meta: Vic3Metadata;
-  played_tag: string;
-  tags: [string];
-};
-type Vic3PageProps = Vic3SaveFile & Vic3StatsProps;
+export const Vic3Page = () => {
+  const meta = useVic3Meta();
+  const filename = useSaveFilename();
+  const [selectedTag, setSelectedTag] = useState(meta.lastPlayedTag);
+  const { data: stats } = useVic3Worker(
+    useCallback(
+      (worker) => worker.get_country_stats(selectedTag),
+      [selectedTag],
+    ),
+  );
 
-export const Vic3Page = ({ save, meta, played_tag, tags }: Vic3PageProps) => {
-  const [displayed_tag, setDisplayedTag] = useState<string>(played_tag);
-  const [tag_stats, setTagStats] = useState<[Vic3Stats]>([]);
-  if (!tags) {
-    tags = [];
-  }
-
-  useEffect(() => {
-    if (!displayed_tag) {
-      return () => {};
-    }
-    const worker = getVic3Worker();
-    if (worker) {
-      worker.get_country_stats(displayed_tag).then((tag_s) => {
-        log("Got tag stats", displayed_tag);
-        setTagStats(tag_s);
-      });
-    }
-  }, [displayed_tag]);
   return (
     <main className="mx-auto mt-4 max-w-screen-lg">
       <Head>
-        <title>{`${save.file.name.replace(".v3", "")} - Vic3 (${
+        <title>{`${filename.replace(".v3", "")} - Vic3 (${
           meta.date
         }) - PDX Tools`}</title>
       </Head>
@@ -56,130 +42,18 @@ export const Vic3Page = ({ save, meta, played_tag, tags }: Vic3PageProps) => {
           <MeltButton
             game="vic3"
             worker={getVic3Worker()}
-            filename={save.file.name}
+            filename={filename}
           />
         )}
-        <TagSelect
-          value={displayed_tag}
-          tags={tags}
-          onChange={setDisplayedTag}
-        />
-        <CountryStatsTable stats={tag_stats} />
+        <TagSelect value={selectedTag} onChange={setSelectedTag} />
+        <CountryStatsTable stats={stats?.data ?? []} />
       </div>
     </main>
   );
 };
 
-type Task<T> = {
-  fn: () => T | Promise<T>;
-  name: string;
-};
-
-async function loadVic3Save(file: File, signal: AbortSignal) {
-  const run = async <T,>({ fn, name }: Task<T>) => {
-    signal.throwIfAborted();
-    const result = await timeit(fn).then((res) => {
-      logMs(res, name);
-      return res.data;
-    });
-    signal.throwIfAborted();
-    return result;
-  };
-
-  const worker = getVic3Worker();
-  emitEvent({ kind: "parse", game: "vic3" });
-
-  await Promise.all([
-    run({
-      fn: () => worker.initializeWasm(),
-      name: "initialized vic3 wasm",
-    }),
-
-    run({
-      fn: () => worker.fetchData(file),
-      name: "save data read",
-    }),
-  ]);
-
-  const { meta, tags, played_tag } = await run({
-    fn: () => worker.parseVic3(),
-    name: "parse vic3 file",
-  });
-
-  return { meta, tags, played_tag };
-}
-
-type Vic3LoadState = {
-  loading: boolean;
-  data: Vic3StatsProps | null;
-  error: unknown | null;
-};
-
-type Vic3LoadActions =
-  | { kind: "start" }
-  | { kind: "data"; data: Vic3StatsProps }
-  | { kind: "error"; error: unknown };
-
-const loadStateReducer = (
-  state: Vic3LoadState,
-  action: Vic3LoadActions,
-): Vic3LoadState => {
-  switch (action.kind) {
-    case "start": {
-      return {
-        ...state,
-        error: null,
-        loading: true,
-      };
-    }
-    case "data": {
-      return {
-        ...state,
-        data: action.data,
-        loading: false,
-      };
-    }
-    case "error": {
-      return {
-        ...state,
-        error: action.error,
-      };
-    }
-  }
-};
-
-function useLoadVic3(input: Vic3SaveFile) {
-  const [{ loading, data, error }, dispatch] = useReducer(loadStateReducer, {
-    loading: false,
-    data: null,
-    error: null,
-  });
-
-  useEffect(() => {
-    dispatch({ kind: "start" });
-    const controller = pdxAbortController();
-    loadVic3Save(input.save.file, controller.signal)
-      .then(({ meta, tags, played_tag }) => {
-        dispatch({ kind: "data", data: { meta, tags, played_tag } });
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) {
-          return;
-        }
-
-        dispatch({ kind: "error", error });
-        captureException(error);
-      });
-    return () => {
-      controller.abort("cancelling save load");
-    };
-  }, [input]);
-
-  return { loading, data, error };
-}
-
-export const Vic3Ui = (props: Vic3SaveFile) => {
-  const { data, error, stats } = useLoadVic3(props);
+export const Vic3Ui = (props: { save: Vic3SaveInput }) => {
+  const { data, error } = useLoadVic3(props.save);
 
   return (
     <>
@@ -189,12 +63,9 @@ export const Vic3Ui = (props: Vic3SaveFile) => {
         </Alert>
       )}
       {data && (
-        <Vic3Page
-          {...props}
-          meta={data.meta}
-          tags={data.tags}
-          played_tag={data.played_tag}
-        />
+        <Vic3StoreProvider store={data}>
+          <Vic3Page />
+        </Vic3StoreProvider>
       )}
     </>
   );

--- a/src/app/src/features/vic3/worker/init.ts
+++ b/src/app/src/features/vic3/worker/init.ts
@@ -1,5 +1,5 @@
 import { wasm } from "./common";
-import { Vic3Metadata } from "./types";
+import { Vic3Metadata, Vic3Stats } from "./types";
 
 export const initializeWasm = wasm.initializeModule;
 export async function fetchData(file: File) {
@@ -10,5 +10,12 @@ export async function fetchData(file: File) {
 export async function parseVic3() {
   wasm.save = wasm.module.parse_save(wasm.takeStash());
   const meta: Vic3Metadata = wasm.save.metadata();
-  return { meta };
+  const played_tag: string = wasm.save.get_played_tag();
+  const tags: [string] = wasm.save.get_available_tags();
+  return { meta, tags, played_tag };
+}
+
+export async function get_country_stats(tag: string) {
+  const stats: [Vic3Stats] = wasm.save.get_country_stats(tag);
+  return stats;
 }

--- a/src/app/src/features/vic3/worker/types.ts
+++ b/src/app/src/features/vic3/worker/types.ts
@@ -2,3 +2,11 @@ export interface Vic3Metadata {
   date: string;
   isMeltable: boolean;
 }
+
+export interface Vic3Stats {
+  date: string;
+  gdp: number;
+  sol: number;
+  pop: number;
+  gdpc: number;
+}

--- a/src/app/src/features/vic3/worker/types.ts
+++ b/src/app/src/features/vic3/worker/types.ts
@@ -1,12 +1,1 @@
-export interface Vic3Metadata {
-  date: string;
-  isMeltable: boolean;
-}
-
-export interface Vic3Stats {
-  date: string;
-  gdp: number;
-  sol: number;
-  pop: number;
-  gdpc: number;
-}
+export type * from "../../../../../wasm-vic3/pkg/wasm_vic3";

--- a/src/app/src/features/vic3/worker/useVic3Worker.ts
+++ b/src/app/src/features/vic3/worker/useVic3Worker.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from "react";
+import { captureException } from "@/features/errors";
+import { Vic3Worker } from "./bridge";
+import { getErrorMessage } from "@/lib/getErrorMessage";
+import { getVic3Worker } from ".";
+import { useVic3Meta } from "../store";
+
+export const useVic3Worker = <T>(cb: (arg0: Vic3Worker) => Promise<T>) => {
+  const [isLoading, setLoading] = useState(false);
+  const [data, setData] = useState<T | undefined>(undefined);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const meta = useVic3Meta();
+
+  const onNewSave = useCallback(() => {
+    let mounted = true;
+    async function getData() {
+      try {
+        if (mounted) {
+          setLoading(true);
+          const worker = getVic3Worker();
+          const result = await cb(worker);
+          if (mounted) {
+            setError(undefined);
+            setData(result);
+          }
+        }
+      } catch (error) {
+        captureException(error);
+        setError(getErrorMessage(error));
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    }
+    getData();
+
+    return () => {
+      mounted = false;
+    };
+  }, [cb]);
+
+  useEffect(() => {
+    onNewSave();
+  }, [meta, onNewSave]);
+
+  return { isLoading, data, error };
+};

--- a/src/vic3save/src/bin/cli/main.rs
+++ b/src/vic3save/src/bin/cli/main.rs
@@ -2,17 +2,24 @@ use std::{env, error::Error, io::Read};
 
 mod fmt;
 mod melt;
+mod stats_cli;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let stdin = std::io::stdin();
     let mut lock = stdin.lock();
     let mut buf = Vec::new();
-    lock.read_to_end(&mut buf)?;
 
     match args[1].as_str() {
-        "fmt" => fmt::run(&buf),
-        "melt" => melt::run(&buf),
+        "fmt" => {
+            lock.read_to_end(&mut buf)?;
+            fmt::run(&buf)
+        }
+        "melt" => {
+            lock.read_to_end(&mut buf)?;
+            melt::run(&buf)
+        }
+        "stats" => stats_cli::run(&args[1..]),
         x => panic!("unrecognized argument: {}", x),
     }?;
 

--- a/src/vic3save/src/bin/cli/stats_cli.rs
+++ b/src/vic3save/src/bin/cli/stats_cli.rs
@@ -1,0 +1,34 @@
+use std::error::Error;
+use std::fs;
+use vic3save::savefile::Vic3Save;
+use vic3save::{tokens, Vic3File};
+
+pub fn run(raw_args: &[String]) -> Result<(), Box<dyn Error>> {
+    let data = fs::read(raw_args[1].clone())?;
+    let file = Vic3File::from_slice(data.as_slice())?;
+    let mut zip_sink = Vec::new();
+    let parsed_file = file.parse(&mut zip_sink)?;
+    let save: Vic3Save = parsed_file.deserializer(&tokens::EnvTokens).deserialize()?;
+    let tag = save.get_last_played_country().definition.as_ref();
+    let country = save.get_country(tag).expect("tag to be found");
+
+    let gdp_line = country.gdp.iter();
+    let sol_line = country.avgsoltrend.iter();
+    let pop_line = country.pop_statistics.trend_population.iter();
+    for (date, ((gdp, sol), pop)) in gdp_line
+        .zip_aligned(sol_line)
+        .zip_aligned(pop_line)
+        .step_by(52)
+    {
+        let pop_adj = pop / 100000.0;
+        println!(
+            "{:?}\t{:0.2}\t{:.2}\t{:.2}",
+            date,
+            gdp / 1000000.0,
+            gdp / pop_adj,
+            sol
+        );
+    }
+
+    Ok(())
+}

--- a/src/vic3save/src/lib.rs
+++ b/src/vic3save/src/lib.rs
@@ -4,6 +4,8 @@ pub mod file;
 pub(crate) mod flavor;
 mod header;
 mod melt;
+pub mod savefile;
+pub mod stats;
 pub mod tokens;
 mod vic3date;
 

--- a/src/vic3save/src/savefile.rs
+++ b/src/vic3save/src/savefile.rs
@@ -1,0 +1,261 @@
+use crate::stats::Vic3CountryStats;
+use crate::Vic3Date;
+use serde::de;
+use serde::de::Unexpected;
+use serde::{de::DeserializeOwned, Deserialize, Deserializer};
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct MetaData {
+    pub version: String,
+    pub game_date: Vic3Date,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Counters {
+    week: Option<i32>,
+    tick: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Vic3CountryBudget {
+    pub weekly_income: Vec<f64>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct PopStatistics {
+    pub trend_population: Vic3CountryStats,
+}
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Vic3Country {
+    pub definition: String,
+    pub government: Option<String>,
+    pub budget: Vic3CountryBudget,
+    pub gdp: Vic3CountryStats,
+    pub literacy: Vic3CountryStats,
+    pub prestige: Vic3CountryStats,
+    pub avgsoltrend: Vic3CountryStats,
+    pub pop_statistics: PopStatistics,
+}
+
+#[derive(Debug, PartialEq)]
+struct Maybe<T>(Option<T>);
+impl<'de, T> de::Deserialize<'de> for Maybe<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Maybe<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MaybeVisitor<T> {
+            marker: PhantomData<Maybe<T>>,
+        }
+        impl<'de, T1> de::Visitor<'de> for MaybeVisitor<T1>
+        where
+            T1: Deserialize<'de>,
+        {
+            type Value = Maybe<T1>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_fmt(format_args!(
+                    "struct {} or none",
+                    std::any::type_name::<T1>()
+                ))
+            }
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match v {
+                    "none" => Ok(Maybe(None)),
+                    _ => Err(E::invalid_value(Unexpected::Other(v), &self)),
+                }
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                T1::deserialize(de::value::MapAccessDeserializer::new(map)).map(|x| Maybe(Some(x)))
+            }
+        }
+        deserializer.deserialize_any(MaybeVisitor {
+            marker: PhantomData,
+        })
+    }
+}
+
+fn maybe_map<'de, D, K, V>(deser: D) -> Result<HashMap<K, Option<V>>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: Deserialize<'de> + Hash + Eq,
+    V: Deserialize<'de>,
+{
+    struct MaybeVisitor<K, V> {
+        marker: PhantomData<HashMap<K, Option<V>>>,
+    }
+
+    impl<'de, K1, V1> de::Visitor<'de> for MaybeVisitor<K1, V1>
+    where
+        K1: Deserialize<'de> + Hash + Eq,
+        V1: Deserialize<'de>,
+    {
+        type Value = HashMap<K1, Option<V1>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("A maybe map")
+        }
+
+        fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            let mut map = HashMap::with_capacity(access.size_hint().unwrap_or(0));
+            while let Some((key, value)) = access.next_entry::<K1, Maybe<V1>>()? {
+                map.insert(key, value.0);
+            }
+
+            Ok(map)
+        }
+    }
+
+    deser.deserialize_map(MaybeVisitor {
+        marker: PhantomData,
+    })
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Vic3Manager<Of>
+where
+    Of: DeserializeOwned,
+{
+    #[serde(deserialize_with = "maybe_map")]
+    pub database: HashMap<u32, Option<Of>>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Player {
+    pub idtype: u32,
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Vic3Save {
+    pub meta_data: MetaData,
+    pub counters: Counters,
+    pub country_manager: Vic3Manager<Vic3Country>,
+    pub previous_played: Vec<Player>,
+}
+
+impl Vic3Save {
+    pub fn get_country<'a>(&'a self, country_tag: &str) -> Option<&'a Vic3Country> {
+        let mngr = &self.country_manager;
+        return mngr.database.iter().find_map(|(_, country)| match country {
+            Some(
+                country @ Vic3Country {
+                    definition: def, ..
+                },
+            ) if def == country_tag => Some(country),
+            _ => None,
+        });
+    }
+
+    pub fn get_last_played_country(&self) -> &Vic3Country {
+        let mngr = &self.country_manager;
+        let last_played_id = &self.previous_played[0].idtype;
+        let Some(ref country) = mngr.database[last_played_id] else {
+            panic!("played country not found")
+        };
+        country
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jomini::text::de::from_utf8_slice;
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct Vic3Country {
+        pub definition: String,
+        pub government: String,
+        pub budget: Vic3CountryBudget,
+    }
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub struct Vic3Save {
+        pub meta_data: MetaData,
+        pub counters: Counters,
+        pub country_manager: Vic3Manager<Vic3Country>,
+    }
+
+    const SAVE_FILE: &[u8] = br#"
+meta_data={
+	save_game_version=1700230462
+	version="1.5.9"
+	game_date=1887.1.1
+	real_date=123.11.17
+	name="Paraguay"
+	rank="minor_power"
+}
+country_manager={
+	database={
+		50331652=none
+		16777216={
+			definition="GER"
+			government="gov_absolute_duchy"
+			capital=125
+			budget={
+				hello={ 0 1 2}
+				weekly_income={
+					0.0 5024.26541 2323.37397 7485.98455 0.0 0.0 16592.54442 5147.93229 0.0 0.0
+				}
+
+						
+}}}}
+
+counters={
+	command=520993
+	tick=74461
+	week=2660
+	province_theater=144569
+}"#;
+    #[test]
+    fn test_full_save() {
+        let out: Vic3Save = from_utf8_slice(SAVE_FILE).unwrap();
+        let country = out.country_manager.database[&16777216].as_ref().unwrap();
+        assert_eq!(country.definition, "GER");
+    }
+
+    #[test]
+    fn test_country() {
+        let country_segment = br#"country={101={
+definition="GER"
+government="gov_absolute_duchy"
+capital=125
+budget={
+  weekly_income={ 0.0 5024.26541 2323.37397  }
+}
+}}"#;
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct TestCountry {
+            #[serde(deserialize_with = "maybe_map")]
+            country: HashMap<u32, Option<Vic3Country>>,
+        }
+        let out: TestCountry = from_utf8_slice(country_segment).unwrap();
+        let country = out.country[&101].as_ref().unwrap();
+        assert_eq!(country.definition, "GER");
+        let out1: TestCountry = from_utf8_slice(b"country={101=none}").unwrap();
+        assert_eq!(out1.country[&101], None);
+        assert_eq!(
+            true,
+            from_utf8_slice::<TestCountry>(b"country={101=None}").is_err()
+        );
+    }
+}

--- a/src/vic3save/src/stats.rs
+++ b/src/vic3save/src/stats.rs
@@ -1,0 +1,243 @@
+use crate::Vic3Date;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct VicStatsChannel {
+    // Date of last sample
+    pub date: Vic3Date,
+    //  next free index (number of samples + 1)
+    pub index: i32,
+    // Value
+    pub values: Vec<f64>,
+}
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Vic3CountryStats {
+    // Sample rate of ticks (sample rate of 28, works to 1 week)
+    pub sample_rate: i32,
+    // Not sure, double the index?
+    pub count: i32,
+    #[serde(default)]
+    pub channels: HashMap<i32, VicStatsChannel>,
+}
+
+#[derive(Debug)]
+pub struct Vic3CountryStatsIter<'a> {
+    stats: &'a Vic3CountryStats,
+    index: usize,
+}
+impl<'a> Iterator for Vic3CountryStatsIter<'a> {
+    type Item = (Vic3Date, f64);
+    fn next(&mut self) -> Option<Self::Item> {
+        let game_start_date: Vic3Date = Vic3Date::from_ymdh(1836, 1, 1, 0);
+        let channel = self.stats.channels.get(&0)?;
+        let days_between_start_and_end = game_start_date.days_until(&channel.date);
+        let days_per_index = self.stats.sample_rate / 4;
+        let days_to_start_date = days_between_start_and_end - (channel.index * days_per_index);
+        let start_date = game_start_date.add_days(days_to_start_date + 1);
+        if self.index + 1 >= (channel.index as usize) {
+            return None;
+        }
+        let elem = channel.values.get(self.index)?;
+        self.index += 1;
+
+        let new_date = start_date.add_days(self.index as i32 * days_per_index);
+        Some((new_date, elem.clone()))
+    }
+}
+
+#[derive(Debug)]
+pub struct Vic3CountryStatsAllignedIter<T1, T2> {
+    a: T1,
+    b: T2,
+}
+impl<A, B, T1, T2> Iterator for Vic3CountryStatsAllignedIter<T1, T2>
+where
+    T1: Iterator<Item = (Vic3Date, A)>,
+    T2: Iterator<Item = (Vic3Date, B)>,
+{
+    type Item = (Vic3Date, (A, B));
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.a.next(), self.b.next()) {
+            (Some((date_a, x)), Some((date_b, y))) if date_a == date_b => Some((date_a, (x, y))),
+            (Some((date_a, x)), Some((date_b, y))) if date_a < date_b => {
+                let mut prev_date = date_a;
+                let mut prev_x = x;
+                loop {
+                    let Some((date_next, x1)) = self.a.next() else {
+                        println!("iterator empty equal");
+                        return Some((prev_date, (prev_x, y)));
+                    };
+                    if date_next == date_b {
+                        return Some((date_b, (x1, y)));
+                    }
+
+                    if date_next > date_b {
+                        println!("{:?} and {:?} misallign, picking {:?} (WIP, maybe need to handle better)", date_next, date_b, date_next);
+                        return Some((date_next, (x1, y)));
+                    }
+                    prev_date = date_next;
+                    prev_x = x1;
+                }
+            }
+            (Some((date_a, x)), Some((date_b, y))) if date_b < date_a => {
+                let mut prev_date = date_b;
+                let mut prev_y = y;
+                loop {
+                    let Some((date_next, y1)) = self.b.next() else {
+                        return Some((prev_date, (x, prev_y)));
+                    };
+                    if date_next == date_a {
+                        return Some((date_a, (x, y1)));
+                    }
+
+                    if date_next > date_a {
+                        println!("{:?} and {:?} misallign, picking {:?} (WIP, maybe need to handle better)", date_next, date_a, date_next);
+                        return Some((date_next, (x, y1)));
+                    }
+                    prev_date = date_next;
+                    prev_y = y1;
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+impl<'a> Vic3CountryStatsIter<'a> {
+    pub fn zip_aligned<T, T1>(self, other: T1) -> Vic3CountryStatsAllignedIter<Self, T1>
+    where
+        T1: Iterator<Item = (Vic3Date, T)>,
+    {
+        Vic3CountryStatsAllignedIter { a: self, b: other }
+    }
+}
+impl<A, B> Vic3CountryStatsAllignedIter<A, B> {
+    pub fn zip_aligned<T, T1>(self, other: T1) -> Vic3CountryStatsAllignedIter<Self, T1>
+    where
+        T1: Iterator<Item = (Vic3Date, T)>,
+    {
+        Vic3CountryStatsAllignedIter { a: self, b: other }
+    }
+}
+
+impl Vic3CountryStats {
+    pub fn iter(&self) -> Vic3CountryStatsIter {
+        Vic3CountryStatsIter {
+            stats: self,
+            index: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::stats::Vic3CountryStats;
+    use jomini::text::de::from_utf8_slice;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct TestCountryForStats {
+        gdp: Vic3CountryStats,
+    }
+    const TEST_STATS: &[u8] = br#"gdp={
+				sample_rate=28
+				count=4
+				channels={
+					0={
+						date=1836.1.28
+						index=4
+						values={
+							1194501.51448 1194520.51448 1194300.51448 
+						}
+					}
+				}
+}"#;
+
+    #[test]
+    fn test_country_stats() {
+        let stats: TestCountryForStats = from_utf8_slice(TEST_STATS).expect("test");
+        assert_eq!(stats.gdp.sample_rate, 28);
+        let (_dates, values): (Vec<_>, Vec<_>) = stats.gdp.iter().unzip();
+        println!("Into iter {:?}", values);
+        assert_eq!(vec![1194501.51448, 1194520.51448, 1194300.51448], values);
+    }
+
+    #[test]
+    fn test_stats_align_multiple_sample_rate() {
+        let date = Vic3Date::from_ymdh(1836, 1, 1, 0);
+        let stats_a: Vec<(Vic3Date, i32)> = vec![
+            (date.add_days(0), 1),
+            (date.add_days(2), 1),
+            (date.add_days(4), 1),
+            (date.add_days(6), 1),
+            (date.add_days(8), 1),
+            (date.add_days(10), 1),
+            (date.add_days(12), 1),
+        ];
+        let stats_b: Vec<(Vic3Date, i32)> = vec![
+            (date.add_days(0), 1),
+            (date.add_days(4), 1),
+            (date.add_days(8), 1),
+        ];
+
+        let zip_a_b = Vic3CountryStatsAllignedIter {
+            a: stats_a.iter().copied(),
+            b: stats_b.iter().copied(),
+        };
+        let zip_b_a = Vic3CountryStatsAllignedIter {
+            b: stats_a.iter().copied(),
+            a: stats_b.iter().copied(),
+        };
+        let zipped_a_b: Vec<_> = zip_a_b.collect();
+        let zipped_b_a: Vec<_> = zip_b_a.collect();
+        assert_eq!(3, zipped_a_b.len());
+        assert_eq!(zipped_b_a.len(), zipped_a_b.len());
+    }
+
+    #[test]
+    fn test_stats_align_non_multiple_sample_rate() {
+        let date = Vic3Date::from_ymdh(1836, 1, 1, 0);
+        let stats_a: Vec<(Vic3Date, i32)> = vec![
+            (date.add_days(0), 1),
+            (date.add_days(2), 1),
+            (date.add_days(4), 1),
+            (date.add_days(6), 1),
+            (date.add_days(8), 1),
+            (date.add_days(10), 1),
+            (date.add_days(12), 1),
+        ];
+        let stats_b: Vec<(Vic3Date, i32)> = vec![
+            (date.add_days(0), 1),
+            (date.add_days(3), 1),
+            (date.add_days(6), 1),
+            (date.add_days(9), 1),
+            (date.add_days(12), 1),
+        ];
+
+        let zip_a_b = Vic3CountryStatsAllignedIter {
+            a: stats_a.iter().copied(),
+            b: stats_b.iter().copied(),
+        };
+        let zip_b_a = Vic3CountryStatsAllignedIter {
+            b: stats_a.iter().copied(),
+            a: stats_b.iter().copied(),
+        };
+        let zipped_a_b: Vec<_> = zip_a_b.collect();
+        let zipped_b_a: Vec<_> = zip_b_a.collect();
+        println!("Into iter {:?}", zipped_a_b);
+        assert_eq!(5, zipped_a_b.len());
+        assert_eq!(zipped_b_a.len(), zipped_a_b.len());
+    }
+
+    #[test]
+    fn test_stats_align_same_len() {
+        let stats_a: TestCountryForStats = from_utf8_slice(TEST_STATS).expect("test");
+        let stats_b: TestCountryForStats = from_utf8_slice(TEST_STATS).expect("test");
+        let zip = stats_b.gdp.iter().zip_aligned(stats_a.gdp.iter());
+        let zipped: Vec<_> = zip.collect();
+        println!("Into iter {:?}", zipped);
+        assert_eq!(3, zipped.len());
+    }
+}

--- a/src/vic3save/src/stats.rs
+++ b/src/vic3save/src/stats.rs
@@ -42,7 +42,7 @@ impl<'a> Iterator for Vic3CountryStatsIter<'a> {
         self.index += 1;
 
         let new_date = start_date.add_days(self.index as i32 * days_per_index);
-        Some((new_date, elem.clone()))
+        Some((new_date, *elem))
     }
 }
 

--- a/src/vic3save/src/vic3date.rs
+++ b/src/vic3save/src/vic3date.rs
@@ -102,14 +102,10 @@ impl Vic3Date {
         )
     }
 
-    pub fn days_until<Q>(self, other0: Q) -> i32
-    where
-        Q: std::borrow::Borrow<Self>,
-    {
-        let other = other0.borrow();
+    pub fn days_until(self, other: &Vic3Date) -> i32 {
         let self_date = Date::from_ymd(self.year(), self.month(), self.day());
         let other_date = Date::from_ymd(other.year(), other.month(), other.day());
-        return self_date.days_until(&other_date);
+        self_date.days_until(&other_date)
     }
 }
 
@@ -265,8 +261,8 @@ mod tests {
     #[test]
     fn test_days_until() {
         let base = Vic3Date::from_ymdh(1837, 6, 25, 0);
-        assert_eq!(base.days_until(Vic3Date::from_ymdh(1837, 6, 26, 0)), 1);
-        assert_eq!(base.days_until(Vic3Date::from_ymdh(1838, 6, 25, 0)), 365);
+        assert_eq!(base.days_until(&Vic3Date::from_ymdh(1837, 6, 26, 0)), 1);
+        assert_eq!(base.days_until(&Vic3Date::from_ymdh(1838, 6, 25, 0)), 365);
         assert_eq!(base.days_until(&base), 0);
     }
 }

--- a/src/vic3save/src/vic3date.rs
+++ b/src/vic3save/src/vic3date.rs
@@ -1,5 +1,5 @@
 pub use jomini::common::PdsDate;
-use jomini::common::{DateError, DateFormat, PdsDateFormatter, RawDate};
+use jomini::common::{Date, DateError, DateFormat, PdsDateFormatter, RawDate};
 use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
@@ -90,6 +90,26 @@ impl Vic3Date {
     /// Date hour. Can be 0, 6, 12, or 18.
     pub fn hour(&self) -> u8 {
         self.raw.hour()
+    }
+
+    pub fn add_days(self, days: i32) -> Vic3Date {
+        let new_date = Date::from_ymd(self.year(), self.month(), self.day()).add_days(days);
+        Self::from_ymdh(
+            new_date.year(),
+            new_date.month(),
+            new_date.day(),
+            self.hour(),
+        )
+    }
+
+    pub fn days_until<Q>(self, other0: Q) -> i32
+    where
+        Q: std::borrow::Borrow<Self>,
+    {
+        let other = other0.borrow();
+        let self_date = Date::from_ymd(self.year(), self.month(), self.day());
+        let other_date = Date::from_ymd(other.year(), other.month(), other.day());
+        return self_date.days_until(&other_date);
     }
 }
 
@@ -212,5 +232,41 @@ impl<'de> Deserialize<'de> for Vic3Date {
         D: Deserializer<'de>,
     {
         deserializer.deserialize_any(DateVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Vic3Date;
+    #[test]
+    fn test_date_arithmetic() {
+        assert_eq!(
+            Vic3Date::from_ymdh(1836, 1, 1, 0).add_days(364),
+            Vic3Date::from_ymdh(1836, 12, 31, 0)
+        );
+        assert_eq!(
+            Vic3Date::from_ymdh(1836, 1, 1, 0).add_days(365),
+            Vic3Date::from_ymdh(1837, 1, 1, 0)
+        );
+        assert_eq!(
+            Vic3Date::from_ymdh(1837, 12, 31, 0).add_days(1),
+            Vic3Date::from_ymdh(1838, 1, 1, 0)
+        );
+        assert_eq!(
+            Vic3Date::from_ymdh(1837, 12, 31, 0).add_days(32),
+            Vic3Date::from_ymdh(1838, 2, 1, 0)
+        );
+        let base = Vic3Date::from_ymdh(1837, 6, 25, 0);
+        assert_eq!(base.add_days(3), Vic3Date::from_ymdh(1837, 6, 28, 0));
+        assert_eq!(base.add_days(8), Vic3Date::from_ymdh(1837, 7, 3, 0));
+        assert_eq!(base.add_days(61), Vic3Date::from_ymdh(1837, 8, 25, 0));
+        assert_eq!(base.add_days(365), Vic3Date::from_ymdh(1838, 6, 25, 0));
+    }
+    #[test]
+    fn test_days_until() {
+        let base = Vic3Date::from_ymdh(1837, 6, 25, 0);
+        assert_eq!(base.days_until(Vic3Date::from_ymdh(1837, 6, 26, 0)), 1);
+        assert_eq!(base.days_until(Vic3Date::from_ymdh(1838, 6, 25, 0)), 365);
+        assert_eq!(base.days_until(&base), 0);
     }
 }

--- a/src/wasm-vic3/Cargo.toml
+++ b/src/wasm-vic3/Cargo.toml
@@ -20,6 +20,7 @@ serde-wasm-bindgen = "0.5"
 serde = { version = "1", features = ["derive"] }
 vic3save = { path = "../vic3save" }
 js-sys = "0.3"
+tsify = { version = "0.4.5", default-features = false, features = ["js"] } 
 zstd = { version = "0.13.0", default-features = false }
 
 [package.metadata.wasm-pack.profile.release]

--- a/src/wasm-vic3/src/lib.rs
+++ b/src/wasm-vic3/src/lib.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
-use vic3save::{
-    FailedResolveStrategy, PdsDate, SaveHeader, SaveHeaderKind, Vic3Date, Vic3Error, Vic3File,
-};
+use vic3save::savefile::Vic3Save;
+use vic3save::{FailedResolveStrategy, SaveHeader, SaveHeaderKind, Vic3Date, Vic3Error, Vic3File};
 use wasm_bindgen::prelude::*;
 
 mod tokens;
@@ -9,8 +8,12 @@ pub use tokens::*;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Vic3Save {
+pub struct Vic3GraphData {
     date: Vic3Date,
+    gdp: f64,
+    sol: f64,
+    pop: f64,
+    gdpc: f64,
 }
 
 #[derive(Debug, Serialize)]
@@ -38,19 +41,56 @@ impl SaveFile {
     pub fn metadata(&self) -> JsValue {
         to_json_value(&self.0.metadata())
     }
+    pub fn get_country_stats(&self, tag: &str) -> JsValue {
+        to_json_value(&self.0.get_country_stats(tag))
+    }
+    pub fn get_available_tags(&self) -> JsValue {
+        to_json_value(&self.0.get_available_tags())
+    }
+    pub fn get_played_tag(&self) -> JsValue {
+        to_json_value(&self.0.get_played_tag())
+    }
 }
 
 impl SaveFileImpl {
     pub fn metadata(&self) -> Vic3Metadata {
         Vic3Metadata {
-            date: Vic3Date::from_ymdh(
-                self.save.date.year(),
-                self.save.date.month(),
-                self.save.date.day(),
-                0,
-            ),
+            date: self.save.meta_data.game_date,
             is_meltable: self.is_meltable(),
         }
+    }
+    pub fn get_played_tag(&self) -> String {
+        self.save.get_last_played_country().definition.clone()
+    }
+
+    pub fn get_available_tags(&self) -> Vec<String> {
+        let mngr = &self.save.country_manager;
+        return mngr
+            .database
+            .iter()
+            .filter_map(|(_, country)| country.as_ref())
+            .map(|x| x.definition.clone())
+            .collect();
+    }
+    pub fn get_country_stats(&self, tag: &str) -> Vec<Vic3GraphData> {
+        let country = self.save.get_country(tag).unwrap();
+        let gdp_line = country.gdp.iter();
+        let sol_line = country.avgsoltrend.iter();
+        let pop_line = country.pop_statistics.trend_population.iter();
+        gdp_line
+            .zip_aligned(sol_line)
+            .zip_aligned(pop_line)
+            .map(|(date_p, ((gdp, sol), pop))| {
+                let pop_adj = pop / 100000.0;
+                Vic3GraphData {
+                    gdp: gdp / 1000000.0,
+                    gdpc: gdp / pop_adj,
+                    pop: pop_adj,
+                    date: date_p,
+                    sol,
+                }
+            })
+            .collect()
     }
 
     fn is_meltable(&self) -> bool {
@@ -66,7 +106,7 @@ fn _parse_save(data: &[u8]) -> Result<SaveFile, Vic3Error> {
     let header = file.header();
     let mut zip_sink = Vec::new();
     let parsed = file.parse(&mut zip_sink)?;
-    let save = parsed.deserializer(tokens::get_tokens()).deserialize()?;
+    let save: Vic3Save = parsed.deserializer(tokens::get_tokens()).deserialize()?;
     Ok(SaveFile(SaveFileImpl {
         save,
         header: header.clone(),

--- a/src/wasm-vic3/src/models.rs
+++ b/src/wasm-vic3/src/models.rs
@@ -1,0 +1,32 @@
+#![allow(nonstandard_style)]
+
+use serde::Serialize;
+use tsify::Tsify;
+use vic3save::Vic3Date;
+
+#[derive(Tsify, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi)]
+pub struct Vic3Metadata {
+    pub date: Vic3Date,
+    pub is_meltable: bool,
+    pub last_played_tag: String,
+    pub available_tags: Vec<String>,
+}
+
+#[derive(Tsify, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi)]
+pub struct Vic3GraphResponse {
+    pub data: Vec<Vic3GraphData>,
+}
+
+#[derive(Tsify, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Vic3GraphData {
+    pub date: Vic3Date,
+    pub gdp: f64,
+    pub sol: f64,
+    pub pop: f64,
+    pub gdpc: f64,
+}


### PR DESCRIPTION
This PR adds some support for vic3 savefiles, see picture for a demo:

<img width="992" alt="image" src="https://github.com/pdx-tools/pdx-tools/assets/310855/dd42adc0-a86f-41a0-8cbf-6fe72a946f93">


Are you interested in this type of contribution? What I'm mostly interested in adding is the kind of stats show in the picture, perhaps add a graph, compute growth rate, extract some more stats ... but I don't want to commit to much more functionality then shown here. 

Some notes:

* Other games seem to have separate repos for detailed parsing, so I created my own vic3save2. But I'm happy to PR that code somewhere else or copy those files here. 
* I haven't tested with binary saves, so I'm not sure if the deserialisation works correctly there.
* The code needs some cleanup, but happy for any comments!