### PR TITLE
Add growth stats and GDP, GDP/c charts

### DIFF
--- a/src/app/src/features/vic3/CountryChart.tsx
+++ b/src/app/src/features/vic3/CountryChart.tsx
@@ -1,0 +1,89 @@
+import {
+  Line,
+  LineConfig,
+  useVisualizationDispatch,
+  VisualizationProvider,
+} from "@/components/viz";
+import dynamic from "next/dynamic";
+import { Vic3GraphData } from "./worker/types";
+import React, { useEffect } from "react";
+import { createCsv } from "@/lib/csv";
+import { VisualizationLoader } from "@/components/viz/VisualizationLoader";
+import { formatFloat } from "@/lib/format";
+
+export interface CountryChartProps {
+  stats: Vic3GraphData[];
+  type: (keyof Vic3GraphData)[];
+}
+
+const DualAxes: ComponentType<TreemapConfig> = React.memo(
+  dynamic(() => import("@ant-design/plots").then((mod) => mod.DualAxes), {
+    ssr: false,
+    loading: () => <VisualizationLoader />,
+  }),
+);
+
+const type_map = {
+  gdp: "GDP (M)",
+  gdpc: "GDP/c",
+  gdpcGrowth: "GDP inc (%)",
+  gdpGrowth: "GDP/c inc (%)",
+};
+
+export const CountryGDPChart = ({ stats, type }: CountryStatsProps) => {
+  //const columnHelper = createColumnHelper<Vic3GraphData>();
+  const visualizationDispatch = useVisualizationDispatch();
+  const fix_date = stats.map((obj) => {
+    return {
+      ...obj,
+      date: obj.date.slice(0, 4),
+      gdpGrowth: obj.gdpGrowth * 100,
+      gdpcGrowth: obj.gdpcGrowth * 100,
+    };
+  });
+  const props = {
+    data: [fix_date, fix_date],
+    xField: "date",
+    yField: [type, type + "Growth"],
+    legend: {
+      itemName: {
+        formatter: (text, item) => {
+          return type_map[item.value];
+        },
+      },
+    },
+    tooltip: {
+      // Fromat of d = {date: ..., gdpGrowth: ....}
+      formatter: (d) => {
+        var line_name = "Unknown";
+        for (var k in d) {
+          line_name = type_map[k];
+          var suffix = "";
+
+          if (line_name !== undefined) {
+            if (k.endsWith("Growth")) {
+              suffix = "%";
+            }
+
+            return { name: line_name, value: formatFloat(d[k], 2) + suffix };
+          }
+        }
+
+        return { line_name: line_name, value: d.gdp };
+      },
+    },
+    geometryOptions: [
+      {
+        geometry: "line",
+      },
+      {
+        geometry: "line",
+        lineStyle: {
+          lineWidth: 0.5,
+          lineDash: [5, 5],
+        },
+      },
+    ],
+  };
+  return <DualAxes {...props} />;
+};

--- a/src/app/src/features/vic3/CountryStats.tsx
+++ b/src/app/src/features/vic3/CountryStats.tsx
@@ -24,11 +24,25 @@ export const CountryStatsTable = ({ stats }: CountryStatsProps) => {
         <Table.ColumnHeader column={column} title="GDP" />
       ),
     }),
+    columnHelper.accessor("gdpGrowth", {
+      sortingFn: "basic",
+      cell: (info) => formatFloat(info.getValue() * 100, 2) + "%",
+      header: ({ column }) => (
+        <Table.ColumnHeader column={column} title="GDP growth" />
+      ),
+    }),
     columnHelper.accessor("gdpc", {
       sortingFn: "basic",
       cell: (info) => formatFloat(info.getValue()),
       header: ({ column }) => (
         <Table.ColumnHeader column={column} title="GDP/c" />
+      ),
+    }),
+    columnHelper.accessor("gdpcGrowth", {
+      sortingFn: "basic",
+      cell: (info) => formatFloat(info.getValue() * 100, 2) + "%",
+      header: ({ column }) => (
+        <Table.ColumnHeader column={column} title="GDP growth" />
       ),
     }),
     columnHelper.accessor("sol", {

--- a/src/app/src/features/vic3/vic3Ui.tsx
+++ b/src/app/src/features/vic3/vic3Ui.tsx
@@ -2,10 +2,12 @@ import { useState, useCallback } from "react";
 import Head from "next/head";
 import { getVic3Worker } from "./worker";
 import { CountryStatsTable } from "./CountryStats";
+import { CountryGDPChart } from "./CountryChart";
 import { TagSelect } from "./TagSelect";
 import { MeltButton } from "@/components/MeltButton";
 import { Alert } from "@/components/Alert";
 import { getErrorMessage } from "@/lib/getErrorMessage";
+import { VisualizationProvider } from "@/components/viz";
 import {
   Vic3SaveInput,
   Vic3StoreProvider,
@@ -25,6 +27,7 @@ export const Vic3Page = () => {
       [selectedTag],
     ),
   );
+    console.log(stats);
 
   return (
     <main className="mx-auto mt-4 max-w-screen-lg">
@@ -46,6 +49,18 @@ export const Vic3Page = () => {
           />
         )}
         <TagSelect value={selectedTag} onChange={setSelectedTag} />
+        <VisualizationProvider>
+          <div className="flex flex-row ">
+            <div className="w-[calc(50%-1px)] text-center p-2">
+              <span> GDP/c </span>
+              <CountryGDPChart type="gdpc" stats={stats?.data ?? []} />
+            </div>
+            <div className="w-[calc(50%-1px)] text-center p-2">
+              <span> GDP (M) </span>
+              <CountryGDPChart type="gdp" stats={stats?.data ?? []} />
+            </div>
+          </div>
+        </VisualizationProvider>
         <CountryStatsTable stats={stats?.data ?? []} />
       </div>
     </main>

--- a/src/vic3save/src/savefile.rs
+++ b/src/vic3save/src/savefile.rs
@@ -1,4 +1,5 @@
-use crate::{stats::Vic3CountryStats, Vic3Date};
+use crate::stats::{Vic3CountryStats};
+use crate::Vic3Date;
 use serde::{
     de::{self, DeserializeOwned, Unexpected},
     Deserialize, Deserializer,
@@ -204,7 +205,7 @@ impl Vic3Save {
 
             for channel in channels {
                 for value in &mut channel.values {
-                    *value *= 10_000.0;
+                    *value *= 100_000.0;
                 }
             }
         }

--- a/src/vic3save/src/stats.rs
+++ b/src/vic3save/src/stats.rs
@@ -1,6 +1,7 @@
 use crate::Vic3Date;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::collections::VecDeque;
 
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct VicStatsChannel {
@@ -51,6 +52,7 @@ pub struct Vic3CountryStatsAllignedIter<T1, T2> {
     a: T1,
     b: T2,
 }
+
 impl<A, B, T1, T2> Iterator for Vic3CountryStatsAllignedIter<T1, T2>
 where
     T1: Iterator<Item = (Vic3Date, A)>,
@@ -73,7 +75,8 @@ where
                     }
 
                     if date_next > date_b {
-                        println!("{:?} and {:?} misallign, picking {:?} (WIP, maybe need to handle better)", date_next, date_b, date_next);
+                        // This is noisy, but leaving it here as a reminder that maybe something better can be done
+                        //println!("{:?} and {:?} misallign, picking {:?} (WIP, maybe need to handle better)", date_next, date_b, date_next);
                         return Some((date_next, (x1, y)));
                     }
                     prev_date = date_next;
@@ -92,7 +95,7 @@ where
                     }
 
                     if date_next > date_a {
-                        println!("{:?} and {:?} misallign, picking {:?} (WIP, maybe need to handle better)", date_next, date_a, date_next);
+                        //println!("{:?} and {:?} misallign, picking {:?} (WIP, maybe need to handle better)", date_next, date_a, date_next);
                         return Some((date_next, (x, y1)));
                     }
                     prev_date = date_next;
@@ -101,6 +104,161 @@ where
             }
             _ => None,
         }
+    }
+}
+/*
+The idea of the code bellow is to flatten a tuple of structure
+T1: E
+T1: (T1, E)
+
+Into array [E;N] for arbitrary N
+*/
+pub struct One;
+pub struct Succ<T>(std::marker::PhantomData<T>);
+
+pub trait Value {
+    const N: usize;
+}
+
+impl Value for One {
+    const N: usize = 1;
+}
+
+impl<T> Value for Succ<T>
+where
+    T: Value,
+{
+    const N: usize = 1 + T::N;
+}
+
+// N is the size of the output
+// Idx keeps track at which position each recursion needs to insert
+pub trait FlattenedTuple<const N: usize, Idx, Elem: std::marker::Copy>
+where
+    Idx: Value,
+{
+    fn flattened(self) -> [Elem; N];
+}
+
+impl<const N: usize, Elem: std::marker::Copy> FlattenedTuple<N, One, Elem> for Elem {
+    fn flattened(self) -> [Elem; N] {
+        let arr: [Elem; N] = [self; N];
+        arr
+    }
+}
+
+impl<const N: usize, T, Idx, Elem: std::marker::Copy> FlattenedTuple<N, Succ<Idx>, Elem>
+    for (T, Elem)
+where
+    T: FlattenedTuple<N, Idx, Elem>,
+    Idx: Value,
+{
+    fn flattened(self) -> [Elem; N] {
+        let (rest, z) = self;
+        let mut rec_arr = rest.flattened();
+        rec_arr[Idx::N] = z;
+        rec_arr
+    }
+}
+
+fn flattened_iter<const N: usize, T, Idx, Itm>(
+    iter: T,
+) -> impl Iterator<Item = (Vic3Date, [f64; N])>
+where
+    T: Iterator<Item = (Vic3Date, Itm)>,
+    Itm: FlattenedTuple<N, Idx, f64>,
+    Idx: Value,
+{
+    // This should be encoded into the type system, but it's not for some
+    // reason.
+    assert!(Idx::N == N, "flattened_iter called with wrong types. Are you destructuring the right amount of elements?");
+    iter.map(|(date, s)| (date, s.flattened()))
+}
+/* ======= */
+
+// Computes GDP growth, based on growth from avg GDP in Q1 to avg GDP Q4
+#[derive(Debug)]
+pub struct Vic3StatsGDPIter<T> {
+    gdp_stats: T,
+    last_year: VecDeque<(Vic3Date, f64)>,
+}
+
+impl<T> Vic3StatsGDPIter<T> {
+    pub fn new(gdp_stats: T) -> Vic3StatsGDPIter<T> {
+        Vic3StatsGDPIter {
+            gdp_stats,
+            last_year: VecDeque::with_capacity(366),
+        }
+    }
+}
+
+impl<T1> Iterator for Vic3StatsGDPIter<T1>
+where
+    T1: Iterator<Item = (Vic3Date, f64)>,
+{
+    type Item = T1::Item;
+    fn next(&mut self) -> Option<Self::Item> {
+        // Vaguely based off https://www.investopedia.com/terms/r/realeconomicrate.asp
+        self.last_year.push_back(self.gdp_stats.next()?);
+        let (old_date, _old_gdp) = self.last_year.front()?;
+        let (new_date, _new_gdp) = *self.last_year.back()?;
+
+        if old_date.days_until(&new_date) < 365 {
+            // Not enough data, return 0 gorwth
+            return Some((new_date, 0.0));
+        }
+        let q1_idx = self
+            .last_year
+            .partition_point(|(date, _)| old_date.days_until(date) < 90);
+        let q3_idx = self
+            .last_year
+            .partition_point(|(date, _)| old_date.days_until(date) < 270);
+        let q1 = self.last_year.iter().take(q1_idx);
+        let q4 = self.last_year.iter().skip(q3_idx);
+        let q1_avg_gdp: f64 = q1.map(|(_, g)| g).sum::<f64>() / q1_idx as f64;
+        let q4_avg_gdp: f64 =
+            q4.map(|(_, g)| g).sum::<f64>() / ((self.last_year.len() - q3_idx) as f64);
+        self.last_year.pop_front();
+        Some((new_date, q4_avg_gdp / q1_avg_gdp - 1.0))
+    }
+}
+
+#[derive(Debug)]
+pub struct Vic3CountryStatsRateIter<T> {
+    stats: T,
+    days_back: i32,
+    prev: Option<(Vic3Date, f64)>,
+}
+
+//Another way to compute GDP, but more jumpy
+impl<T> Vic3CountryStatsRateIter<T> {
+    pub fn new(stats: T, days_back: i32) -> Vic3CountryStatsRateIter<T> {
+        Vic3CountryStatsRateIter {
+            stats,
+            days_back,
+            prev: None,
+        }
+    }
+}
+
+impl<T1> Iterator for Vic3CountryStatsRateIter<T1>
+where
+    T1: Iterator<Item = (Vic3Date, f64)>,
+{
+    type Item = T1::Item;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.prev.is_none() {
+            self.prev = self.stats.next();
+        }
+
+        let (prev_date, prev_x) = self.prev?;
+        let (mut curr_date, mut x) = self.stats.next()?;
+        while prev_date.days_until(&curr_date) < self.days_back {
+            (curr_date, x) = self.stats.next()?;
+        }
+        self.prev = Some((curr_date, x));
+
+        Some((curr_date, (x - prev_x) / prev_x))
     }
 }
 
@@ -112,12 +270,21 @@ impl<'a> Vic3CountryStatsIter<'a> {
         Vic3CountryStatsAllignedIter { a: self, b: other }
     }
 }
-impl<A, B> Vic3CountryStatsAllignedIter<A, B> {
+
+impl<A: Iterator, B: Iterator> Vic3CountryStatsAllignedIter<A, B> {
     pub fn zip_aligned<T, T1>(self, other: T1) -> Vic3CountryStatsAllignedIter<Self, T1>
     where
         T1: Iterator<Item = (Vic3Date, T)>,
     {
         Vic3CountryStatsAllignedIter { a: self, b: other }
+    }
+    pub fn flat<const N: usize, Idx, Itm>(self) -> impl Iterator<Item = (Vic3Date, [f64; N])>
+    where
+        Self: Iterator<Item = (Vic3Date, Itm)>,
+        Itm: FlattenedTuple<N, Idx, f64>,
+        Idx: Value,
+    {
+        flattened_iter(self)
     }
 }
 
@@ -127,6 +294,17 @@ impl Vic3CountryStats {
             stats: self,
             index: 0,
         }
+    }
+    pub fn growth_rate(&self, days_back: i32) -> Vic3CountryStatsRateIter<Vic3CountryStatsIter> {
+        Vic3CountryStatsRateIter {
+            stats: self.iter(),
+            days_back,
+            prev: None,
+        }
+    }
+
+    pub fn gdp_growth(&self) -> Vic3StatsGDPIter<Vic3CountryStatsIter> {
+        Vic3StatsGDPIter::new(self.iter())
     }
 }
 
@@ -239,5 +417,103 @@ mod tests {
         let zipped: Vec<_> = zip.collect();
         println!("Into iter {:?}", zipped);
         assert_eq!(3, zipped.len());
+    }
+
+    #[test]
+    fn test_flatten() {
+        let date = Vic3Date::from_ymdh(1836, 1, 1, 0);
+        let t1: ((f64, f64), f64) = ((1.0, 2.0), 3.0);
+        let [x, y, z]: [f64; 3] = t1.flattened();
+        assert_eq!(x, 1.0);
+        assert_eq!(y, 2.0);
+        assert_eq!(z, 3.0);
+        let t1_vec = vec![(date, t1.clone()), (date, t1.clone()), (date, t1.clone())];
+        let t1_flat: Vec<f64> = flattened_iter(t1_vec.iter().copied())
+            .map(|(_, [_, y, _])| y)
+            .collect();
+        assert_eq!(vec![2.0, 2.0, 2.0], t1_flat);
+        let t2: (_, f64) = (t1, 0.0);
+        let [_, _y, _z, x]: [f64; 4] = t2.flattened();
+        assert_eq!(x, 0.0);
+        let t2_vec = vec![(date, t2.clone()), (date, t2.clone()), (date, t2.clone())];
+        let t2_flat: Vec<f64> = flattened_iter(t2_vec.iter().copied())
+            .map(|(_, [_, _, y, _])| y)
+            .collect();
+        assert_eq!(vec![3.0, 3.0, 3.0], t2_flat);
+
+        let t3: (_, f64) = (t2, 0.0);
+        let t3_vec = vec![(date, t3.clone()), (date, t3.clone()), (date, t3.clone())];
+        assert_eq!(x, 0.0);
+        let t3_flat: Vec<f64> = flattened_iter(t3_vec.iter().copied())
+            .map(|(_, [_, _, y, _, _])| y)
+            .collect();
+        assert_eq!(vec![3.0, 3.0, 3.0], t3_flat);
+    }
+    #[test]
+    fn test_growth_rate() {
+        let date = Vic3Date::from_ymdh(1836, 1, 1, 0);
+        let stats: Vec<(Vic3Date, f64)> = vec![
+            (date.add_days(0), 1.0),
+            (date.add_days(365), 1.2),
+            (date.add_days(730), 1.44),
+            (date.add_days(1095), 2.0736),
+            (date.add_days(1460), 4.1472),
+        ];
+        let rate_iter = Vic3CountryStatsRateIter {
+            stats: stats.iter().copied(),
+            days_back: 365,
+            prev: None,
+        };
+        let (_, rate): (Vec<_>, Vec<_>) = rate_iter.unzip();
+        assert_eq!(vec![0.19999999999999996, 0.2, 0.44, 1.0], rate);
+    }
+
+    #[test]
+    fn test_gdp_growth_rate() {
+        let date = Vic3Date::from_ymdh(1836, 1, 1, 0);
+        let stats: Vec<(Vic3Date, f64)> = vec![
+            (date.add_days(0), 1.0),
+            (date.add_days(90), 1.0),
+            (date.add_days(180), 1.1),
+            (date.add_days(270), 1.4),
+            (date.add_days(365), 1.4),
+            (date.add_days(455), 1.4),
+            (date.add_days(545), 1.4),
+        ];
+        let rate_iter = Vic3StatsGDPIter::new(stats.iter().copied());
+        let (_, rate): (Vec<_>, Vec<_>) = rate_iter.unzip();
+        assert_eq!(
+            vec![
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.3999999999999999,
+                0.3999999999999999,
+                0.2727272727272725
+            ],
+            rate
+        );
+    }
+
+    use std::iter::{repeat, successors};
+    #[test]
+    fn test_exp_growth_rate() {
+        let date = Vic3Date::from_ymdh(1836, 1, 1, 0);
+        let ex = || successors(Some(1.0), |n| Some(n + 1.0)).map(|n: f64| n.exp());
+        const N: usize = 20;
+        let days = |add| successors(Some(date), move |d| Some(d.clone().add_days(add)));
+        let exp_stats = days(365).take(N).zip(ex());
+        let rate_iter = Vic3CountryStatsRateIter {
+            stats: exp_stats,
+            days_back: 365,
+            prev: None,
+        };
+        let diff = rate_iter
+            .map(|(_date, rate)| rate)
+            .zip(repeat(std::f64::consts::E).map(|n| n - 1.0))
+            .map(|(l, r)| (l - r).abs())
+            .filter(|n| n < &0.00001);
+        assert_eq!(N - 1, diff.count());
     }
 }

--- a/src/wasm-vic3/src/models.rs
+++ b/src/wasm-vic3/src/models.rs
@@ -1,5 +1,5 @@
 #![allow(nonstandard_style)]
-
+use jomini::common::Date;
 use serde::Serialize;
 use tsify::Tsify;
 use vic3save::Vic3Date;
@@ -24,9 +24,11 @@ pub struct Vic3GraphResponse {
 #[derive(Tsify, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Vic3GraphData {
-    pub date: Vic3Date,
+    pub date: Date,
     pub gdp: f64,
     pub sol: f64,
     pub pop: f64,
     pub gdpc: f64,
+    pub gdp_growth: f64,
+    pub gdpc_growth: f64,
 }


### PR DESCRIPTION
Main point  of PR is to show some graph with GDP and it's growth rate, see picture:

<img width="807" alt="image" src="https://github.com/pdx-tools/pdx-tools/assets/310855/d652a802-e9d1-412d-b8db-1144fc272d6b">

* Change front end to add some graphs and support two growth values
* Fix the binary constant issue (it was off by 100k not 10k)
* Add 2 iterators to compute growth rate, 1) GDP one and 2) general one
* Add FlattenedTuple to make managing of zipped stats easier
