### PR TITLE
Update zip_next to 0.11.0

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -40,5 +40,5 @@ tempfile = "3.3"
 tokio = { version = "1", features = ["full"], optional = true }
 tokio-stream = { version = "0.1.8", optional = true }
 walkdir = "2.3.1"
-zip_next = { version = "0.10.0", default-features = false, features = ["deflate", "zstd"] }
+zip_next = { version = "0.11.0", default-features = false, features = ["deflate", "zstd"] }
 zstd = { version = "0.13.0", features = ["zstdmt"], optional = true }

--- a/src/wasm-compress/Cargo.toml
+++ b/src/wasm-compress/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = { version = "0.2" }
-zip_next = { version = "0.10.0", default-features = false, features = ["deflate", "zstd"] }
+zip_next = { version = "0.11.0", default-features = false, features = ["deflate", "zstd"] }
 zstd = { version = "0.13.0", default-features = false }
 js-sys = "0.3"
 tsify = { version = "0.4.5", default-features = false, features = ["js"] } 


### PR DESCRIPTION
This version provides fixes for several bugs that were found by overhauling the fuzz tests. The interface to read archives,  decompress unencrypted files and do basic compression remains the same.