### PR TITLE
Transition all map assets to lossless webp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,18 +655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,12 +668,6 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
-name = "bytemuck"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
@@ -1266,12 +1248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures-channel"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,7 +1549,6 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
- "rayon",
 ]
 
 [[package]]
@@ -1930,24 +1905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "oxipng"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e5c341ef78a228e47a551bfd15ff885d8c501af49f953358763a538c01f14d"
-dependencies = [
- "bitvec",
- "crossbeam-channel",
- "filetime",
- "indexmap",
- "libdeflater",
- "log",
- "rayon",
- "rgb",
- "rustc-hash",
- "rustc_version",
-]
-
-[[package]]
 name = "p256"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,7 +1964,6 @@ dependencies = [
  "flate2",
  "jomini",
  "log",
- "oxipng",
  "rayon",
  "regex",
  "schemas",
@@ -2148,12 +2104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,15 +2230,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rgb"
-version = "0.8.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,12 +2248,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -2732,12 +2667,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -3581,15 +3510,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xattr"

--- a/justfile
+++ b/justfile
@@ -357,16 +357,16 @@ prep-frontend:
   for VERSION in "${VERSIONS[@]}"; do
     cat >> "$OUTPUT" << EOF
     case "$VERSION": return {
-      provinces1: require(\`../../../../assets/game/eu4/$VERSION/map/provinces-1.png\`),
-      provinces2: require(\`../../../../assets/game/eu4/$VERSION/map/provinces-2.png\`),
+      provinces1: require(\`../../../../assets/game/eu4/$VERSION/map/provinces-1.webp\`),
+      provinces2: require(\`../../../../assets/game/eu4/$VERSION/map/provinces-2.webp\`),
       colorMap: require(\`../../../../assets/game/eu4/$VERSION/map/colormap_summer.webp\`),
       sea: require(\`../../../../assets/game/eu4/$VERSION/map/colormap_water.webp\`),
       normal: require(\`../../../../assets/game/eu4/$VERSION/map/world_normal.webp\`),
-      terrain1: require(\`../../../../assets/game/eu4/$VERSION/map/terrain-1.png\`),
-      terrain2: require(\`../../../../assets/game/eu4/$VERSION/map/terrain-2.png\`),
-      rivers1: require(\`../../../../assets/game/eu4/$VERSION/map/rivers-1.png\`),
-      rivers2: require(\`../../../../assets/game/eu4/$VERSION/map/rivers-2.png\`),
-      stripes: require(\`../../../../assets/game/eu4/$VERSION/map/occupation.png\`),
+      terrain1: require(\`../../../../assets/game/eu4/$VERSION/map/terrain-1.webp\`),
+      terrain2: require(\`../../../../assets/game/eu4/$VERSION/map/terrain-2.webp\`),
+      rivers1: require(\`../../../../assets/game/eu4/$VERSION/map/rivers-1.webp\`),
+      rivers2: require(\`../../../../assets/game/eu4/$VERSION/map/rivers-2.webp\`),
+      stripes: require(\`../../../../assets/game/eu4/$VERSION/map/occupation.webp\`),
       water: require(\`../../../../assets/game/eu4/$VERSION/map/noise-2d.webp\`),
       surfaceRock: require(\`../../../../assets/game/eu4/$VERSION/map/atlas0_rock.webp\`),
       surfaceGreen: require(\`../../../../assets/game/eu4/$VERSION/map/atlas0_green.webp\`),

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -9,7 +9,7 @@ admin = ["create_bundle", "fetch_assets", "tokenize", "dep:applib", "dep:eu4game
 fun = ["compile_assets", "dep:applib", "dep:eu4game", "dep:eu4save", "dep:flate2"]
 
 create_bundle = ["dep:zstd"]
-compile_assets = ["dep:attohttpc", "dep:eu4save", "dep:jomini", "dep:eu4game-data", "dep:oxipng", "dep:schemas", "schemas?/inline", "dep:zstd"]
+compile_assets = ["dep:attohttpc", "dep:eu4save", "dep:jomini", "dep:eu4game-data", "dep:schemas", "schemas?/inline", "dep:zstd"]
 fetch_assets = ["dep:aws-config", "dep:aws-sdk-s3", "dep:tokio", "dep:tokio-stream"]
 tokenize = ["dep:zstd", "dep:schemas"]
 
@@ -30,7 +30,6 @@ filetime = "0.2"
 flate2 = { version = "1.0", optional = true }
 jomini = { version = "0.25", optional = true }
 log = "0.4"
-oxipng = { version = "9.0", optional = true, default-features = false, features = ["filetime", "parallel"] }
 rayon = "1"
 regex = "1"
 schemas = { path = "../schemas", optional = true }


### PR DESCRIPTION
315 KB (33%) bytes saved in transit

Everything seems to work. I know we had to fix the output of PNG to be 32 bits, but maybe we never tried lossless webp 🤷 

If we ever want to support newer or upcoming games, it's probably best to start making sure we already have a proven asset pipeline that can scale with much larger maps.