### PR TITLE
3x faster shader linkage and map draws with optimized map fragment shader

### DIFF
--- a/src/map/assets/shaders/map.frag
+++ b/src/map/assets/shaders/map.frag
@@ -26,317 +26,193 @@ layout(location = 1) out vec4 outColor;
 
 const vec3 viewDirection = vec3(0.0, 0.0, 1.0);
 
-vec3 terrainAt(highp vec2 tc) {
-	if (tc.x <= 0.5) {
-		vec2 loc = vec2(tc.x * 2.0, tc.y);
-		return texture(u_terrainImage1, loc).rgb;
-	} else {
-		vec2 loc = vec2((tc.x - 0.5) * 2.0, tc.y);
-		return texture(u_terrainImage2, loc).rgb;
-	}
+vec3 tcLayer(highp vec2 tc) {
+    float layer = roundEven(tc.x);
+    return vec3((tc.x - 0.5 * layer) * 2.0, tc.y, layer);
 }
 
-vec3 riversAt(highp vec2 tc) {
-	if (tc.x <= 0.5) {
-		vec2 loc = vec2(tc.x * 2.0, tc.y);
-		return texture(u_riversImage1, loc).rgb;
-	} else {
-		vec2 loc = vec2((tc.x - 0.5) * 2.0, tc.y);
-		return texture(u_riversImage2, loc).rgb;
-	}
+vec3 provincesAt3(highp vec3 tc) {
+    return tc.z <= 0.5 ?
+        texture(u_provincesImage1, vec2(tc)).rgb :
+        texture(u_provincesImage2, vec2(tc)).rgb;
 }
 
-vec3 provincesAt(highp vec2 tc) {
-	if (tc.x <= 0.5) {
-		vec2 loc = vec2(tc.x * 2.0, tc.y);
-		return texture(u_provincesImage1, loc).rgb;
-	} else {
-		vec2 loc = vec2((tc.x - 0.5) * 2.0, tc.y);
-		return texture(u_provincesImage2, loc).rgb;
-	}
+vec3 terrainAt3(highp vec3 tc) {
+    return tc.z <= 0.5 ?
+        texture(u_terrainImage1, vec2(tc)).rgb :
+        texture(u_terrainImage2, vec2(tc)).rgb;
+}
+
+vec3[5] neighborhood(highp vec2 tc, vec2 ps) {
+    return vec3[5](
+        tcLayer(tc),
+        tcLayer(tc + vec2(0, -ps.y)),
+        tcLayer(tc + vec2(0, ps.y)),
+        tcLayer(tc + vec2(-ps.x, 0)),
+        tcLayer(tc + vec2(ps.x, 0))
+    );
 }
 
 // Use terrain image to determine sea terrain by checking against fixed sea terrain colors.
-bool isSeaAt(highp vec2 tc)
-{
-  vec3 terrain_color = terrainAt(tc);
-  bool isDeepSea = all(greaterThan(terrain_color, vec3(0.03,0.12, 0.5))) && all(lessThan(terrain_color, vec3(0.04, 0.122, 0.52)));
-  if (isDeepSea)
-  {
-    return true;
-  }
-  
-  bool isInlandSea = all(greaterThan(terrain_color, vec3(0.21,0.35, 0.86))) && all(lessThan(terrain_color, vec3(0.218, 0.355, 0.865)));
-  if (isInlandSea)
-  {
-    return true;
-  }
-
-  return false;
-}
-
-bool isCoastAt(highp vec2 tc)
-{
-  vec3 terrain_color = terrainAt(tc);
-  bool isCoast = terrain_color.r == 1.0 && terrain_color.b == 0.0 && terrain_color.g > 0.965 && terrain_color.g < 0.971;
-  return isCoast;
-}
-
-bool isRiverAt(highp vec2 tc)
-{
-	vec3 rivers_map_color = riversAt(tc);
-	return any(greaterThan(rivers_map_color, vec3(0.7))) && any(lessThan(rivers_map_color, vec3(0.9)));
+bool isSeaAt(highp vec3 terrain_color) {
+    bool isDeepSea = all(greaterThan(terrain_color, vec3(0.03,0.12, 0.5))) && all(lessThan(terrain_color, vec3(0.04, 0.122, 0.52)));
+    bool isInlandSea = all(greaterThan(terrain_color, vec3(0.21,0.35, 0.86))) && all(lessThan(terrain_color, vec3(0.218, 0.355, 0.865)));
+    return isDeepSea || isInlandSea;
 }
 
 float ordering(vec3 c1, vec3 c2) {
-	vec3 result = sign(c1 - c2);
-	return dot(result, vec3(4.0, 2.0, 1.0));
+    vec3 result = sign(c1 - c2);
+    return dot(result, vec3(4.0, 2.0, 1.0));
 }
-
-bool borderCompare(highp vec3 here, highp vec2 hereTc, vec2 d) {
-	if (isSeaAt(hereTc) && !isSeaAt(hereTc + d)) {
-		return false;
-	}
-
-	if(!isSeaAt(hereTc) && isSeaAt(hereTc + d)) {
-		return true;
-	}
-
-	vec3 other = provincesAt(hereTc + d);
-	return ordering(here, other) > 0.0;
-}
-
 
 // Get index of color in the ordered color array u_orderedColors
 ivec2 getOrderedProvinceColorIndex(vec3 color)
 {
-	// Do binary search on u_orderedColors with float indices, since the ordered color data is saved in a texture
-	uint l = 0u;
-	uint r = u_provinceCount;
-	while (l <= r)
-	{
-		uint m = (l + r) / 2u;
+    // Do binary search on u_orderedColors with float indices, since the ordered color data is saved in a texture
+    uint l = 0u;
+    uint r = u_provinceCount;
+    while (l <= r)
+    {
+        uint m = (l + r) / 2u;
 
-		uint col = m % 4096u;
-		uint row = m / 4096u;
-		ivec2 prov = ivec2(int(col), int(row));
+        uint col = m % 4096u;
+        uint row = m / 4096u;
+        ivec2 prov = ivec2(int(col), int(row));
 
-		vec3 colorAtIndex = texelFetch(u_provincesUniqueColorsImage, prov, 0).rgb;
-		float order = ordering(color, colorAtIndex);
-		if (order > 0.0)
-		{
-			l = m + 1u;
-			continue;
-		}
-		
-		if (order < 0.0)
-		{
-			r = m - 1u;
-			continue;
-		}
-		return prov;
-	}
-	return ivec2(0, 0);
-}
+        vec3 colorAtIndex = texelFetch(u_provincesUniqueColorsImage, prov, 0).rgb;
+        float order = ordering(color, colorAtIndex);
+        if (order > 0.0) {
+            l = m + 1u;
+            continue;
+        }
 
-bool renderBorderAt(highp vec2 tc, vec2 ps)
-{
-	if (!u_renderProvinceBorders) {
-		return false;
-	}
-
-	vec3 provincesImgHere = provincesAt(tc);
-	if (borderCompare(provincesImgHere, tc, vec2(0, ps.y)))
-	{
-		return true;
-	}
-	if (borderCompare(provincesImgHere, tc, vec2(0, -ps.y)))
-	{
-		return true;
-	}
-	if (borderCompare(provincesImgHere, tc, vec2(ps.x, 0.0)))
-	{
-		return true;
-	}
-	if (borderCompare(provincesImgHere, tc, vec2(-ps.x, 0.0)))
-	{
-		return true;
-	}
-
-	return false;
-}
-
-bool mapmodeBorderCompare(highp vec3 here, highp vec2 hereTc, vec2 d) {
-	vec3 other = provincesAt(hereTc + d);
-	ivec2 otherProvinceIndex = getOrderedProvinceColorIndex(other);
-	vec3 otherPrimaryColor = texelFetch(u_primaryProvincesColorImage, otherProvinceIndex, 0).rgb;
-
-	if (here != otherPrimaryColor) {
-		return true;
-	}
-	return false;
-}
-
-bool countryBorderCompare(highp vec3 here, highp vec2 hereTc, vec2 d) {
-	vec3 other = provincesAt(hereTc + d);
-	ivec2 otherProvinceIndex = getOrderedProvinceColorIndex(other);
-	vec3 otherPrimaryColor = texelFetch(u_countryProvincesColorImage, otherProvinceIndex, 0).rgb;
-
-	if (here != otherPrimaryColor) {
-		return true;
-	}
-	return false;
-}
-
-bool renderMapmodeBorderAt(highp vec2 tc, vec2 ps)
-{
-	if (!u_renderMapmodeBorders) {
-		return false;
-	}
-
-	ivec2 provinceIndex = getOrderedProvinceColorIndex(provincesAt(tc));
-	vec3 primaryColor = texelFetch(u_primaryProvincesColorImage, provinceIndex, 0).rgb;
-	if (mapmodeBorderCompare(primaryColor, tc, vec2(0, ps.y)))
-	{
-		return true;
-	}
-	if (mapmodeBorderCompare(primaryColor, tc, vec2(0, -ps.y)))
-	{
-		return true;
-	}
-	if (mapmodeBorderCompare(primaryColor, tc, vec2(ps.x, 0.0)))
-	{
-		return true;
-	}
-	if (mapmodeBorderCompare(primaryColor, tc, vec2(-ps.x, 0.0)))
-	{
-		return true;
-	}
-
-	return false;
-}
-
-bool renderCountryBorderAt(highp vec2 tc, vec2 ps)
-{
-	if (!u_renderCountryBorders) {
-		return false;
-	}
-
-	ivec2 provinceIndex = getOrderedProvinceColorIndex(provincesAt(tc));
-	vec3 primaryColor = texelFetch(u_countryProvincesColorImage, provinceIndex, 0).rgb;
-	if (countryBorderCompare(primaryColor, tc, vec2(0, ps.y)))
-	{
-		return true;
-	}
-	if (countryBorderCompare(primaryColor, tc, vec2(0, -ps.y)))
-	{
-		return true;
-	}
-	if (countryBorderCompare(primaryColor, tc, vec2(ps.x, 0.0)))
-	{
-		return true;
-	}
-	if (countryBorderCompare(primaryColor, tc, vec2(-ps.x, 0.0)))
-	{
-		return true;
-	}
-
-	return false;
+        if (order < 0.0) {
+            r = m - 1u;
+            continue;
+        }
+        return prov;
+    }
+    return ivec2(0, 0);
 }
 
 bool renderSecondaryColorAt(highp vec2 tc) {
-	vec2 size = vec2(textureSize(u_provincesImage1, 0)) * vec2(2.0, 1.0);
-	vec2 pixel_coord = tc * size * 5.0;
-	vec2 stripes_tc = mod(pixel_coord, 128.0)  / 128.0;
-	stripes_tc.x = -stripes_tc.x;
-	vec4 stripes_color = texture(u_stripesImage, stripes_tc);
-	return stripes_color.a > 0.0;
+    vec2 size = vec2(textureSize(u_provincesImage1, 0)) * vec2(2.0, 1.0);
+    vec2 pixel_coord = tc * size * 5.0;
+    vec2 stripes_tc = mod(pixel_coord, 128.0)  / 128.0;
+    stripes_tc.x = -stripes_tc.x;
+    vec4 stripes_color = texture(u_stripesImage, stripes_tc);
+    return stripes_color.a > 0.0;
 }
 
-vec3 edgeDetectionImage(highp vec2 tc, vec2 ps) {
-	if (isSeaAt(tc)) {
-		return vec3(0.5);
-	}
+bool borderCompare(highp vec3 t1, highp vec3 t2, vec3 prov1, vec3 prov2) {
+    if (isSeaAt(t1) && !isSeaAt(t2)) {
+        return false;
+    }
 
-	if (renderCountryBorderAt(tc, ps)) {
-		ivec2 provinceIndex = getOrderedProvinceColorIndex(provincesAt(tc));
-		vec4 primaryColor = texelFetch(u_countryProvincesColorImage, provinceIndex, 0);
-		return primaryColor.rgb - vec3(0.2, 0.2, 0.2);
-	}
-
-	if (renderMapmodeBorderAt(tc, ps)) {
-		ivec2 provinceIndex = getOrderedProvinceColorIndex(provincesAt(tc));
-		vec4 primaryColor = texelFetch(u_primaryProvincesColorImage, provinceIndex, 0);
-		return primaryColor.rgb - vec3(0.2, 0.2, 0.2);
-	}
-
-	if (renderBorderAt(tc, ps)) {
-		return vec3(0.1);
-	}
-
-	ivec2 provinceIndex = getOrderedProvinceColorIndex(provincesAt(tc));
-	vec4 primaryColor = texelFetch(u_primaryProvincesColorImage, provinceIndex, 0);
-	vec4 secondaryColor = texelFetch(u_secondaryProvincesColorImage, provinceIndex, 0);
-	if (primaryColor != secondaryColor) {
-		if (renderSecondaryColorAt(tc)) {
-			return vec3(0.5);
-		}
-	}
-
-	vec3 res = primaryColor.rgb;
-	bool river = isRiverAt(tc);
-	if (river) {
-		//return vec3(1.0);
-	}
-
-	return res;
+    return (!isSeaAt(t1) && isSeaAt(t2)) || ordering(prov1, prov2) > 0.0;
 }
 
-vec4 displayImage(highp vec2 tc, vec2 ps) {
-	if (isSeaAt(tc)) {
-		return vec4(0.0, 0.0, 1.0, 0.2);
-	}
+bool hasBorder(highp vec4[5] data) {
+    return data[0] != data[1] || data[0] != data[2] || data[0] != data[3] || data[0] != data[4];
+}
 
-	if (renderCountryBorderAt(tc, ps)) {
-		ivec2 provinceIndex = getOrderedProvinceColorIndex(provincesAt(tc));
-		vec4 primaryColor = texelFetch(u_countryProvincesColorImage, provinceIndex, 0);
-		return primaryColor - vec4(0.2, 0.2, 0.2, 0.0);
-	}
+vec3 edgeDetectionImage(
+    highp vec3[5] tc,
+    highp vec3[5] terrain,
+    highp vec3[5] provinces,
+    ivec2[5] provinceIndices,
+    highp vec4[5] country,
+    highp vec4[5] mapMode
+) {
+    if (isSeaAt(terrain[0])) {
+        return vec3(0.5);
+    }
 
-	if (renderMapmodeBorderAt(tc, ps)) {
-		ivec2 provinceIndex = getOrderedProvinceColorIndex(provincesAt(tc));
-		vec4 primaryColor = texelFetch(u_primaryProvincesColorImage, provinceIndex, 0);
-		return primaryColor - vec4(0.2, 0.2, 0.2, 0.0);
-	}
+    if (u_renderCountryBorders && hasBorder(country)) {
+        return country[0].rgb - vec3(0.2, 0.2, 0.2);
+    }
 
-	if (renderBorderAt(tc, ps)) {
-		return vec4(0.1, 0.1, 0.1, 1.0);
-	}
+    if (u_renderMapmodeBorders && hasBorder(mapMode)) {
+        return mapMode[0].rgb - vec3(0.2, 0.2, 0.2);
+    }
 
-	bool river = isRiverAt(tc);
+    if (u_renderProvinceBorders) {
+        for (int i = 1; i < 5; i++) {
+            if (borderCompare(terrain[0], terrain[i], provinces[0], provinces[i])) {
+                return vec3(0.1);
+            }
+        }
+    }
 
-	ivec2 provinceIndex = getOrderedProvinceColorIndex(provincesAt(tc));
-	vec4 primaryColor = texelFetch(u_primaryProvincesColorImage, provinceIndex, 0);
-	vec4 secondaryColor = texelFetch(u_secondaryProvincesColorImage, provinceIndex, 0);
-	if (primaryColor != secondaryColor) {
-		if (renderSecondaryColorAt(tc)) {
-			return vec4(secondaryColor.rgb, secondaryColor.a * (river ? 0.8 :1.0));
-		}
-	}
+    vec4 primaryColor = mapMode[0];
+    vec4 secondaryColor = texelFetch(u_secondaryProvincesColorImage, provinceIndices[0], 0);
+    if (primaryColor != secondaryColor && renderSecondaryColorAt(v_texCoord)) {
+        return vec3(0.5);
+    }
 
-	bool renderTerrain = primaryColor.a == 0.0;
-	if (renderTerrain) {
-		return vec4(0.0, 0.0, 0.0, river ? 0.4 : 0.4);
-	}
+    return primaryColor.rgb;
+}
 
-	vec3 res = primaryColor.rgb;
-	return vec4(res, primaryColor.a * (river ? 1.0 : 1.0));
+vec4 displayImage(
+    highp vec3[5] tc,
+    highp vec3[5] terrain,
+    highp vec3[5] provinces,
+    ivec2[5] provinceIndices,
+    highp vec4[5] country,
+    highp vec4[5] mapMode   
+) {
+    if (isSeaAt(terrain[0])) {
+        return vec4(0.0, 0.0, 1.0, 0.2);
+    }
+
+    if (u_renderCountryBorders && hasBorder(country)) {
+        return country[0] - vec4(0.2, 0.2, 0.2, 0.0);
+    }
+
+    if (u_renderMapmodeBorders && hasBorder(mapMode)) {
+        return mapMode[0] - vec4(0.2, 0.2, 0.2, 0.0);
+    }
+
+    if (u_renderProvinceBorders) {
+        for (int i = 1; i < 5; i++) {
+            if (borderCompare(terrain[0], terrain[i], provinces[0], provinces[i])) {
+                return vec4(0.1, 0.1, 0.1, 1.0);
+            }
+        }
+    }
+
+    vec4 primaryColor = mapMode[0];
+    vec4 secondaryColor = texelFetch(u_secondaryProvincesColorImage, provinceIndices[0], 0);
+    if (primaryColor != secondaryColor && renderSecondaryColorAt(v_texCoord)) {
+        return secondaryColor;
+    }
+
+    bool renderTerrain = primaryColor.a == 0.0;
+    if (renderTerrain) {
+        return vec4(0.0, 0.0, 0.0, 0.4);
+    }
+
+    return primaryColor;
 }
 
 void main() {
-	vec2 ps = vec2(1.0 / u_textureSize.x, 1.0 / u_textureSize.y);
-	vec4 res = vec4(edgeDetectionImage(v_texCoord, ps), 1.0);
-	outEdgesColor = res;
-	res = displayImage(v_texCoord, ps);
-	outColor = res;
+    vec2 ps = vec2(1.0 / u_textureSize.x, 1.0 / u_textureSize.y);
+
+    vec3[5] tc = neighborhood(v_texCoord, ps);
+    vec3[5] terrain;
+    vec3[5] provinces;
+    ivec2[5] provinceIndices;
+    vec4[5] country;
+    vec4[5] mapMode;
+
+    for (int i = 0; i < 5; i++) {
+        terrain[i] = terrainAt3(tc[i]);
+        provinces[i] = provincesAt3(tc[i]);
+        provinceIndices[i] = getOrderedProvinceColorIndex(provinces[i]);
+        country[i] = texelFetch(u_countryProvincesColorImage, provinceIndices[i], 0);
+        mapMode[i] = texelFetch(u_primaryProvincesColorImage, provinceIndices[i], 0);
+    }
+
+    outEdgesColor = vec4(edgeDetectionImage(tc, terrain, provinces, provinceIndices, country, mapMode), 1.0);
+    outColor = displayImage(tc, terrain, provinces, provinceIndices, country, mapMode);
 }

--- a/src/map/assets/shaders/map.frag
+++ b/src/map/assets/shaders/map.frag
@@ -31,13 +31,13 @@ vec3 tcLayer(highp vec2 tc) {
     return vec3((tc.x - 0.5 * layer) * 2.0, tc.y, layer);
 }
 
-vec3 provincesAt3(highp vec3 tc) {
+vec3 provincesAt(highp vec3 tc) {
     return tc.z <= 0.5 ?
         texture(u_provincesImage1, vec2(tc)).rgb :
         texture(u_provincesImage2, vec2(tc)).rgb;
 }
 
-vec3 terrainAt3(highp vec3 tc) {
+vec3 terrainAt(highp vec3 tc) {
     return tc.z <= 0.5 ?
         texture(u_terrainImage1, vec2(tc)).rgb :
         texture(u_terrainImage2, vec2(tc)).rgb;
@@ -206,8 +206,8 @@ void main() {
     vec4[5] mapMode;
 
     for (int i = 0; i < 5; i++) {
-        terrain[i] = terrainAt3(tc[i]);
-        provinces[i] = provincesAt3(tc[i]);
+        terrain[i] = terrainAt(tc[i]);
+        provinces[i] = provincesAt(tc[i]);
         provinceIndices[i] = getOrderedProvinceColorIndex(provinces[i]);
         country[i] = texelFetch(u_countryProvincesColorImage, provinceIndices[i], 0);
         mapMode[i] = texelFetch(u_primaryProvincesColorImage, provinceIndices[i], 0);


### PR DESCRIPTION
Chromium browsers can handle our current shaders very well. No issues.

Firefox is not so good. I narrowed in on the map fragment shader being problematic, so I decided to see if it can be optimized. Turns out it can be!

Before:
```
shaders linked: 1428ms
canvas redrawn: 1910ms
total:          3338ms
```

After:
```
shaders linked:  849ms
canvas redrawn:  282ms
total:          1131ms
```

That's a 3x improvement across the board with much faster map redraws.

Chromium browsers improve but to a lesser extent (and are still much faster than firefox).

I'll need to check to make sure there isn't a regression on mobile browsers.