### PR TITLE
Remove cache headers from S3 save retrieval

### DIFF
--- a/src/app/app/api/saves/[saveId]/file/route.ts
+++ b/src/app/app/api/saves/[saveId]/file/route.ts
@@ -9,21 +9,8 @@ const saveSchema = z.object({ saveId: z.string() });
 export const GET = withCore(
   async (_req: NextRequest, { params }: { params: { saveId: string } }) => {
     const save = saveSchema.parse(params);
-    const resp = await s3FetchOk(`${BUCKET}/${save.saveId}`, {
+    return s3FetchOk(`${BUCKET}/${save.saveId}`, {
       cache: "no-store",
-    });
-
-    return new Response(resp.body, {
-      status: resp.status,
-      headers: {
-        ...resp.headers,
-
-        // Cache the file for ten minutes in the browser,
-        // Consider it fresh on the cdn for one day
-        // Allow cache to reuse response for six more days
-        "Cache-Control":
-          "public, max-age=600, s-maxage=86400, stale-while-revalidate=518400",
-      },
     });
   },
 );


### PR DESCRIPTION
Looks like I might be getting dinged in Vercel's "Fast Origin Transfer" usage by saying that uploaded saves can be stored in their CDN cache.

The hope is that I can remove this caching all and still take advantage of backblaze B2 (the S3 provider) and cloudflare (where vercel deploys the edge runtime) bandwidth alliance. All without performance impact too.

Before testing, I was worried that there would be no more browser caching of save files, but instead I still observed caching (perhaps it is etag?).