### PR TITLE
Add unique constraint on save hash column

### DIFF
--- a/src/app/drizzle-kit.config.ts
+++ b/src/app/drizzle-kit.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/server-lib/db/schema.ts",
+  out: "./migrations",
+});

--- a/src/app/migrations/0004_amusing_penance.sql
+++ b/src/app/migrations/0004_amusing_penance.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "idx_save_hash";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_save_hash" ON "saves" USING btree ("hash");

--- a/src/app/migrations/meta/0004_snapshot.json
+++ b/src/app/migrations/meta/0004_snapshot.json
@@ -1,0 +1,348 @@
+{
+  "id": "baf3886b-8255-41b0-9722-15e1e14f0f8d",
+  "prevId": "ac708c03-3d70-4ef8-9e13-975a78c4c1fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.saves": {
+      "name": "saves",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked": {
+          "name": "locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days": {
+          "name": "days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_days": {
+          "name": "score_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_tag": {
+          "name": "player_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_tag_name": {
+          "name": "player_tag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "save_version_first": {
+          "name": "save_version_first",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "save_version_second": {
+          "name": "save_version_second",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "save_version_third": {
+          "name": "save_version_third",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "save_version_fourth": {
+          "name": "save_version_fourth",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achieve_ids": {
+          "name": "achieve_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "players": {
+          "name": "players",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_start_tag": {
+          "name": "player_start_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_start_tag_name": {
+          "name": "player_start_tag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_difficulty": {
+          "name": "game_difficulty",
+          "type": "game_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aar": {
+          "name": "aar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playthrough_id": {
+          "name": "playthrough_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_save_achieve_ids": {
+          "name": "idx_save_achieve_ids",
+          "columns": [
+            {
+              "expression": "achieve_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_save_creation": {
+          "name": "idx_save_creation",
+          "columns": [
+            {
+              "expression": "created_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_save_hash": {
+          "name": "idx_save_hash",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_save_players": {
+          "name": "idx_save_players",
+          "columns": [
+            {
+              "expression": "players",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_saves_playthrough_id": {
+          "name": "idx_saves_playthrough_id",
+          "columns": [
+            {
+              "expression": "playthrough_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saves_user_id_users_user_id_fk": {
+          "name": "saves_user_id_users_user_id_fk",
+          "tableFrom": "saves",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account": {
+          "name": "account",
+          "type": "account",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "display": {
+          "name": "display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_steam_id": {
+          "name": "idx_users_steam_id",
+          "columns": [
+            {
+              "expression": "steam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.account": {
+      "name": "account",
+      "schema": "public",
+      "values": [
+        "free",
+        "admin"
+      ]
+    },
+    "public.game_difficulty": {
+      "name": "game_difficulty",
+      "schema": "public",
+      "values": [
+        "very_easy",
+        "easy",
+        "normal",
+        "hard",
+        "very_hard"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/app/migrations/meta/_journal.json
+++ b/src/app/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1708604791905,
       "tag": "0003_stormy_beast",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1723586927105,
+      "tag": "0004_amusing_penance",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -10,6 +10,7 @@
     "test": "jest",
     "postinstall": "patch-package",
     "cloudflare-headers": "echo 'const { csp, docsCsp } = require(`./next.cors`); console.log(`/*\\n  Content-Security-Policy: ${csp.join(`; `)}`); [`/docs*`, `/blog*`, `/changelog*`].forEach((path) => { console.log(`${path}\\n  ! Content-Security-Policy\n  Content-Security-Policy: ${docsCsp.join(`; `)}`)});' | node -",
+    "generate": "drizzle-kit generate --config drizzle-kit.config.ts",
     "start": "next start"
   },
   "dependencies": {

--- a/src/app/src/server-lib/db/schema.ts
+++ b/src/app/src/server-lib/db/schema.ts
@@ -75,7 +75,7 @@ export const saves = pgTable(
   (saves) => ({
     achieveIdsIndex: index("idx_save_achieve_ids").on(saves.achieveIds),
     createdOnIndex: index("idx_save_creation").on(saves.createdOn),
-    hashIndex: index("idx_save_hash").on(saves.hash),
+    hashIndex: uniqueIndex("idx_save_hash").on(saves.hash),
     playersIndex: index("idx_save_players").on(saves.players),
     playthroughIdIndex: index("idx_saves_playthrough_id").on(
       saves.playthroughId,


### PR DESCRIPTION
Currently, there's application level code to check for uniqueness when uploading a save. I believe I originally wrote the code this way to be flexible (flexible in what way remains a mystery).

Well, it's been a few years and that flexibility isn't needed, so let's use unique constraints so the DB can save us from the small race condition.

I'm also on a bit of a kick to minimize the number of SQL statements needed to execute