### PR TITLE
Reduce save SQL statements and ask for forgiveness

### DIFF
--- a/src/app/src/server-lib/auth/middleware.ts
+++ b/src/app/src/server-lib/auth/middleware.ts
@@ -5,7 +5,8 @@ import { parseBasicAuth } from "./basic";
 import { getSessionPayload } from "./session";
 import { Account } from "../db/schema";
 
-export type SessionRoute = { session: { uid: string; account: Account } };
+export type Session = { uid: string; account: Account };
+export type SessionRoute = { session: Session };
 const unauthResponse = () =>
   NextResponse.json({ msg: "unable to authorize" }, { status: 401 });
 

--- a/src/app/src/server-lib/db/index.ts
+++ b/src/app/src/server-lib/db/index.ts
@@ -114,7 +114,11 @@ export async function useDb<T>(
 }
 
 type DbDrizzle = ReturnType<typeof drizzle>;
-export type DbRoute = { dbConn: Promise<ReturnType<typeof drizzle>> };
+export type DbConnection = ReturnType<typeof drizzle>;
+export type DbTransaction = Parameters<
+  Parameters<DbConnection["transaction"]>[0]
+>[0];
+export type DbRoute = { dbConn: Promise<DbConnection> };
 
 function createDbPool() {
   const pool = new Pool({ connectionString: process.env["DATABASE_URL"] });

--- a/src/app/src/server-lib/errors.ts
+++ b/src/app/src/server-lib/errors.ts
@@ -8,6 +8,20 @@ export class ValidationError extends Error {
   }
 }
 
+export class AuthorizationError extends Error {
+  constructor() {
+    super("forbidden from performing action");
+    this.name = "AuthorizationError";
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
 export const withErrorHandling = (handler: NextApiHandler): NextApiHandler => {
   return async (req, res) => {
     await handler(req, res);

--- a/src/app/src/server-lib/middleware.ts
+++ b/src/app/src/server-lib/middleware.ts
@@ -1,5 +1,10 @@
 import { NextApiHandler } from "next";
-import { ValidationError, withErrorHandling } from "./errors";
+import {
+  AuthorizationError,
+  NotFoundError,
+  ValidationError,
+  withErrorHandling,
+} from "./errors";
 import { log, withLogger } from "./logging";
 import { NextResponse } from "next/server";
 import { ZodError } from "zod";
@@ -25,6 +30,13 @@ export function withCore<T extends Array<any>>(
 
       if (err.name === ValidationError.name) {
         return NextResponse.json(obj, { status: 400 });
+      } else if (err instanceof AuthorizationError) {
+        return NextResponse.json(obj, { status: 403 });
+      } else if (err instanceof NotFoundError) {
+        return NextResponse.json(
+          { ...obj, msg: `${obj.msg} not found` },
+          { status: 404 },
+        );
       } else if (err instanceof ZodError) {
         return NextResponse.json(
           {


### PR DESCRIPTION
The `withSave` middleware would issue a `SELECT` (for sometimes more data than needed) that wasn't marked in a transaction with `FOR UPDATE` on patch and delete routes. Thus some race conditions were present.

This commit fixes this by using transactions and checking for permission after the database has been mutated using the returned value from the mutation. If the user didn't have permission, the database is rolled back.