### PR TITLE
Date Clamping for victoria 3 data

### DIFF
--- a/src/vic3save/src/stats.rs
+++ b/src/vic3save/src/stats.rs
@@ -35,14 +35,25 @@ impl<'a> Iterator for Vic3CountryStatsIter<'a> {
         let days_between_start_and_end = game_start_date.days_until(&channel.date);
         let days_per_index = self.stats.sample_rate / 4;
         let days_to_start_date = days_between_start_and_end - (channel.index * days_per_index);
-        let start_date = game_start_date.add_days(days_to_start_date + 1);
-        if self.index + 1 >= (channel.index as usize) {
+        let start_date = game_start_date.add_days(days_to_start_date);
+
+        if self.index >= (channel.index as usize) {
             return None;
         }
-        let elem = channel.values.get(self.index)?;
-        self.index += 1;
 
-        let new_date = start_date.add_days(self.index as i32 * days_per_index);
+        let elem = channel.values.get(self.index)?;
+
+
+        let mut new_date = start_date.add_days(self.index as i32 * days_per_index);
+
+        use jomini::common::PdsDate;
+        // Ensure the new_date does not cross into the next year
+        if new_date.year() > start_date.year() {
+            new_date = Vic3Date::from_ymdh(new_date.year(), 12, 31, 0);
+        }
+
+        self.index += 1;        
+
         Some((new_date, *elem))
     }
 }


### PR DESCRIPTION
Implemented a check to ensure that dates do not spill over into following years resulting in a cascading of dates.

With these changes, 1836 data should also be populated appropriately.
![Graphed Post Edit Changes](https://github.com/user-attachments/assets/ed002a5d-f8f6-4deb-b4bf-7c40a0850f66)
![Graphed Pre Edits Data](https://github.com/user-attachments/assets/cfffd523-6015-43cd-bdf6-40d798110440)
![Data Excel Comparison Export](https://github.com/user-attachments/assets/a65590ba-3e3d-4655-8af2-bbc972fc1569)
