### PR TITLE
Update to docker compose v2 syntax, and update manual build environment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,11 @@ If not using vscode and the Dev Container, one can setup an environment manually
 A Linux environment assumed (WSL on Windows untested but probably supported). The following applications must be installed in order to instantiate the dev environment.
 
 - docker
-- docker-compose
-- node js
+- docker compose plugin v2
+- node js, including npm
+- clang
+- jq
+- psql
 - [rust](https://www.rust-lang.org/tools/install)
 - [imagemagick](https://imagemagick.org/index.php) with the `convert` command in `$PATH`
 - [just](https://github.com/casey/just/releases/latest)

--- a/justfile
+++ b/justfile
@@ -211,7 +211,7 @@ dev-environment +cmd:
   trap 'rm -rf -- "$MY_TMP"' EXIT
   cat src/app/.env.development ./dev/.env.dev >> "$MY_TMP"
 
-  docker-compose -f ./dev/docker-compose.test.yml --env-file "$MY_TMP" --project-name pdx_dev "$@"
+  docker compose -f ./dev/docker-compose.test.yml --env-file "$MY_TMP" --project-name pdx_dev "$@"
 
 test-environment +cmd:
   #!/usr/bin/env bash
@@ -220,7 +220,7 @@ test-environment +cmd:
   trap 'rm -rf -- "$MY_TMP"' EXIT
   cat src/app/.env.test ./dev/.env.test >> "$MY_TMP"
 
-  docker-compose -f ./dev/docker-compose.test.yml --env-file "$MY_TMP" --project-name pdx_test "$@"
+  docker compose -f ./dev/docker-compose.test.yml --env-file "$MY_TMP" --project-name pdx_test "$@"
 
 deploy-db-schema ENVIRONMENT:
   #!/usr/bin/env bash


### PR DESCRIPTION
Today I went through and set up the environment manually, and I ran into a number of dependency issues that weren't discussed in the guide, so I updated the guide accordingly.  I also noticed that the justfile used 'docker-compose', which is no longer compatible with the v2 syntax 'docker compose' and updated that accordingly.