### PR TITLE
Add alpha tolerance when calculating terrain

### DIFF
--- a/src/map/assets/shaders/xbr.frag
+++ b/src/map/assets/shaders/xbr.frag
@@ -127,10 +127,10 @@ vec3 postProcess(highp vec2 tc) {
 
 	if (!u_renderTerrain) {
 		// Sea
-		if (map.a == 0.2) {
+		if (abs(map.a - 0.20) < 0.0001) {
 			return vec3(68.0, 107.0, 163.0) / vec3(256.0, 256.0, 256.0);
 		}
-		if (map.a == 0.4) {
+		if (abs(map.a - 0.4) < 0.0001) {
 			return vec3(0.3, 0.3, 0.3);
 		}
 		return map.rgb;
@@ -141,7 +141,7 @@ vec3 postProcess(highp vec2 tc) {
 	float normal_map_res = dot(viewDirection, normal);
 
 	// Sea
-	if (map.a == 0.2) {
+	if (abs(map.a - 0.20) < 0.0001) {
 		vec2 seaTc = mod(tc * u_textureSize * 6.0, 256.0) / 256.0;
 		vec3 sea_overlay_color = texture(u_waterImage, seaTc).rgb;
 		vec3 sea_background_color = texture(u_seaImage, tc * vec2(u_textureSize.x / u_usedTextureSize.x, 1.0)).rgb * pow(normal_map_res, 4.0) * 1.2;


### PR DESCRIPTION
Playing around with puppeteer rendering the page and found out that mountains and seas weren't being rendering properly due to conditionals being untrue. Adding tolerance to these conditions fixed the issue.
Before: ![image](https://github.com/user-attachments/assets/a02b91d1-e5d7-49ff-bf59-e9d57c360b9e)
After: ![image](https://github.com/user-attachments/assets/86aef751-9d7e-42bf-aa4b-3b8e5ba138a0)
