### PR TITLE
Add og preview images to save links

### DIFF
--- a/dev/docker-compose.test.yml
+++ b/dev/docker-compose.test.yml
@@ -12,6 +12,14 @@ services:
       - POSTGRES_PASSWORD=${DATABASE_ADMIN_PASSWORD}
       - DATABASE_BACKUP_PASSWORD=${DATABASE_BACKUP_PASSWORD}
 
+  og:
+    image: ghcr.io/browserless/chromium
+    ports:
+      - "3010:3000"
+    environment:
+      - TOKEN=${PUPPETEER_TOKEN}
+      - CONCURRENT=3
+
   s3:
     image: minio/minio@sha256:c92f04149c93010eefc4e4581b18fb4b9ea46af8e9f658291c377388b7691828
     environment:

--- a/src/app/.env.development
+++ b/src/app/.env.development
@@ -11,3 +11,5 @@ S3_ENDPOINT=http://localhost:$S3_PORT
 SESSION_SECRET="fdviwdAbBi2DWRh0fN4sBGEdVngfRhRj"
 PARSE_API_PORT=8082
 PARSE_API_ENDPOINT=http://localhost:$PARSE_API_PORT
+PUPPETEER_URL=http://localhost:3010
+PUPPETEER_TOKEN=trustmeiknowwhatiamdoing

--- a/src/app/app/api/saves/[saveId]/og/route.ts
+++ b/src/app/app/api/saves/[saveId]/og/route.ts
@@ -1,0 +1,25 @@
+import { withCore } from "@/server-lib/middleware";
+import { generateOgIntoS3 } from "@/server-lib/og";
+import { BUCKET, s3Fetch, s3FetchOk } from "@/server-lib/s3";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+
+export const runtime = "edge";
+
+const saveSchema = z.object({ saveId: z.string().regex(/^[a-z0-9_-]*$/i) });
+export const GET = withCore(
+  async (_req: NextRequest, { params }: { params: { saveId: string } }) => {
+    const save = saveSchema.parse(params);
+
+    const s3Key = `${BUCKET}/previews/${save.saveId}`;
+    const existing = await s3Fetch(s3Key, {
+      method: "GET",
+    });
+
+    if (existing.ok) {
+      return existing;
+    }
+
+    return await generateOgIntoS3(save.saveId, s3Key);
+  },
+);

--- a/src/app/app/api/saves/route.ts
+++ b/src/app/app/api/saves/route.ts
@@ -16,7 +16,8 @@ import {
   headerMetadata,
   uploadMetadata,
 } from "@/server-lib/models";
-import { deleteFile, uploadFileToS3 } from "@/server-lib/s3";
+import { generateOgIntoS3 } from "@/server-lib/og";
+import { BUCKET, deleteFile, uploadFileToS3 } from "@/server-lib/s3";
 import { parseSave } from "@/server-lib/save-parser";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -107,6 +108,13 @@ async function handler(
     const response: SavePostResponse = {
       save_id: saveId,
     };
+
+    if (process.env.NODE_ENV === "production") {
+      const s3Key = `${BUCKET}/previews/${saveId}`;
+      generateOgIntoS3(saveId, s3Key).catch((err) => {
+        log.error({ msg: "unable to generate og image", err });
+      });
+    }
 
     return NextResponse.json(response);
   } catch (ex) {

--- a/src/app/src/components/head/HtmlHead.tsx
+++ b/src/app/src/components/head/HtmlHead.tsx
@@ -8,9 +8,13 @@ import social from "../landing/social.png";
 
 interface HtmlHeadProps {
   children: React.ReactNode;
+  social?: string;
 }
 
-export const HtmlHead = ({ children }: HtmlHeadProps) => {
+export const HtmlHead = ({
+  children,
+  social: socialImage = `https://pdx.tools${social}`,
+}: HtmlHeadProps) => {
   const router = useRouter();
   const canonicalUrl = `https://pdx.tools${router.asPath}`;
   return (
@@ -25,7 +29,7 @@ export const HtmlHead = ({ children }: HtmlHeadProps) => {
       <link rel="icon" type="image/png" sizes="16x16" href={fav16} />
       <link rel="canonical" href={canonicalUrl} />
       <meta name="twitter:card" content="summary_large_image" />
-      <meta property="og:image" content={`https://pdx.tools${social}`} />
+      <meta property="og:image" content={socialImage} />
       <meta property="og:image:width" content="1200" />
       <meta property="og:image:height" content="630" />
       {children}

--- a/src/app/src/pages/eu4/saves/[save_id].tsx
+++ b/src/app/src/pages/eu4/saves/[save_id].tsx
@@ -12,9 +12,11 @@ export const Eu4Save = () => {
     return null;
   }
 
+  const addr = process.env.NEXT_PUBLIC_EXTERNAL_ADDRESS;
+  const social = addr ? `${addr}/api/saves/${save_id}/og` : undefined;
   return (
     <Root>
-      <HtmlHead>
+      <HtmlHead social={social}>
         <title>Loading Save: {save_id} - EU4 - PDX Tools</title>
       </HtmlHead>
       <SavePage saveId={save_id} />

--- a/src/app/src/server-lib/og.ts
+++ b/src/app/src/server-lib/og.ts
@@ -1,0 +1,61 @@
+import { fetchOk } from "@/lib/fetch";
+import { getEnv } from "./env";
+import { s3FetchOk } from "./s3";
+
+export async function generateOgIntoS3(saveId: string, s3Key: string) {
+  const puppeteerCmd = `
+    export default async function ({ page }) {
+      page.setViewport({
+        width: 1405,
+        height: 640,
+      });
+
+      const pageUrl = "https://pdx.tools/eu4/saves/${saveId}";
+      await page.goto(pageUrl, {
+        waitUntil: "load",
+      });
+
+      // Wait for any button to show up on the UI
+      await page.waitForSelector("button[data-state='closed']");
+  
+      // Dismiss alert about unsupported webgl
+      await page.click("[role='alert'] button");
+  
+      // Take a screenshot
+      const image = await page.screenshot({
+        clip: {
+          width: 1200.0,
+          height: 630.0,
+          x: 130,
+          y: 0,
+        },
+      });
+
+      return image;
+    }
+    `;
+
+  const puppeteerUrl = new URL(getEnv("PUPPETEER_URL") + "/function");
+  puppeteerUrl.searchParams.set("token", getEnv("PUPPETEER_TOKEN"));
+
+  const imageResp = await fetchOk(puppeteerUrl, {
+    method: "POST",
+    body: puppeteerCmd,
+    headers: {
+      "Content-Type": "application/javascript",
+    },
+  });
+
+  const image = await imageResp.blob();
+  const headers = { "Content-Type": "image/png" };
+  await s3FetchOk(s3Key, {
+    method: "PUT",
+    body: image,
+    headers: {
+      ...headers,
+      "Content-Length": `${image.size}`,
+    },
+  });
+
+  return new Response(image, { headers });
+}


### PR DESCRIPTION
This works by running puppeteer to execute the page and take a screenshot.

The screenshot is then saved in s3 as a cache.