### PR TITLE
Optimize MapWorker type definition

### DIFF
--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -1,7 +1,6 @@
 import {wrap, transfer} from "comlink";
-import type { MapWorker } from "./src/map-worker-bridge";
 import { MapController } from "./src/MapController";
-import { createMapWorker } from "./src";
+import { createMapWorker, type MapWorker } from "./src";
 
 async function fetchColorData(kind: string) {
   const raw = await fetch(`assets/game/eu4/data/color-${kind}-data.bin`).then(

--- a/src/map/src/index.ts
+++ b/src/map/src/index.ts
@@ -5,10 +5,10 @@ export { ProvinceFinder } from "./ProvinceFinder";
 export { compileShaders } from "./shaderCompiler";
 export { XbrShader } from "./XbrShader";
 export { type StaticResources, type TerrainOverlayResources } from "./types";
-export { type MapWorker } from "./map-worker-bridge";
 export { MapController } from "./MapController";
 export { type InitToken } from "./map-worker";
 export * from "./canvasOverlays";
+export type MapWorker = typeof import("./map-worker");
 
 export function createMapWorker() {
   return new Worker(new URL("./map-worker-bridge", import.meta.url), {

--- a/src/map/src/map-worker-bridge.ts
+++ b/src/map/src/map-worker-bridge.ts
@@ -1,5 +1,4 @@
 import * as Comlink from "comlink";
 import * as mod from "./map-worker";
 
-export type MapWorker = typeof mod;
 Comlink.expose(mod);


### PR DESCRIPTION
Defining the type in comlink exposure file caused
some headaches with vite, so move the definition
to a side-effect free export file.