### PR TITLE
Update CI to test no token builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
   push:
@@ -9,7 +11,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: "!github.event.pull_request.head.repo.fork || contains(github.event.pull_request.labels.*.name, 'safe to test')"
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
+    strategy:
+      matrix:
+        include:
+          - name: "with-tokens"
+            remove_tokens: false
+          - name: "no-tokens"
+            remove_tokens: true
+    name: build-${{ matrix.name }}
     env:
       CARGO_TERM_VERBOSE: true
     steps:
@@ -26,6 +39,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -57,8 +71,9 @@ jobs:
           GH_PAT
         runCmd: |
           just admin-sync-assets && \
+          ${{ matrix.remove_tokens && 'rm -rf assets/tokens && ' || '' }} \
           just package-all && \
           just build-wasm-dev && \
-          just test && \
+          ${{ !matrix.remove_tokens && 'just test && ' || '' }} \
           just build-app
 

--- a/justfile
+++ b/justfile
@@ -130,12 +130,12 @@ test-app *cmd: prep-frontend prep-test-app
     "npx wrangler dev --env test --port 3000" \
     "sleep 2 && npm test -- run {@}" -- "$@"
 
-prep-test-app: (test-environment "build") (test-environment "up" "--no-start") (test-environment "up" "-d")
+prep-test-app: (test-environment "build") (test-environment "up" "--no-start") (test-environment "up" "--wait" "db") (test-environment "up" "-d")
   #!/usr/bin/env bash
   set -euxo pipefail
-  just dev-environment exec -u postgres --no-TTY db pg_isready --timeout=5
+  just test-environment exec -u postgres --no-TTY db pg_isready --timeout=5
 
-prep-dev-app: (dev-environment "build") (dev-environment "up" "--no-start") (dev-environment "up" "-d")
+prep-dev-app: (dev-environment "build") (dev-environment "up" "--no-start") (dev-environment "up" "--wait" "db") (dev-environment "up" "-d")
   #!/usr/bin/env bash
   set -euxo pipefail
   just dev-environment exec -u postgres --no-TTY db pg_isready --timeout=5


### PR DESCRIPTION
It's expected that contributors won't have the binary tokens available, and it's too common that I break this workflow. Let's guard against it by having CI test with token and without token flows.

CI has also been updated to test the PR logic. Previously it would only test the base code, which would lead to errors slipping by.