### PR TITLE
Remove dependence on cross

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,7 @@ ARG JUST_VERSION=1.5.0
 RUN apt-get update && apt-get install -y \
       clang \
       imagemagick \
+      musl-tools \
       openssl \
       rclone \
       webp \
@@ -22,6 +23,7 @@ RUN bash /tmp/library-scripts/dependencies.sh
 USER node
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal --component rustfmt --component clippy -y && \
     . $HOME/.cargo/env && \
+    rustup target add x86_64-unknown-linux-musl && \
     tmp/library-scripts/npm-dependencies.sh && \
     tmp/library-scripts/opt-dependencies.sh
 

--- a/.devcontainer/library-scripts/opt-dependencies.sh
+++ b/.devcontainer/library-scripts/opt-dependencies.sh
@@ -7,7 +7,6 @@ trap 'rm -rf -- "$MY_TMP"' EXIT
 # Nice to have dependencies that are not critical
 cargo install cargo-upgrades
 npm install -g npm-check-updates
-cargo install cross
 
 # Install gcloud
 cd "$HOME"

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ release:
   just publish-app
   just publish-api
 
-build: build-wasm (cross "--package" "pdx-tools-api" "--release") build-docker
+build: build-wasm (static-build "--package" "pdx-tools-api" "--release") build-docker
 
 dev: build-wasm-dev dev-app
 
@@ -82,23 +82,14 @@ build-docker:
   docker build -t ghcr.io/pdx-tools/api:nightly -f ./dev/api.dockerfile ./target/x86_64-unknown-linux-musl/release/
 
 build-admin:
-  just cross --package pdx --features admin --release
+  just static-build --package pdx --features admin --release
 
 cargo *cmd:
   cargo "$@"
 
-cross *cmd:
+static-build *cmd:
   #!/usr/bin/env bash
-  set -euxo pipefail
-  if [[ "${REMOTE_CONTAINERS:-}" == "true" ]]; then
-    # If we're within the dev container then we need to use special cross within
-    # docker instructions, and workaround how the devcontainer uses "host"
-    # networking so `hostname` doesn't return the name of the container.
-    export HOSTNAME=$(docker ps | grep vsc-pdx-tools | cut -d' ' -f 1)
-  elif [[ -n "${GH_PAT:-}" ]]; then
-    export HOSTNAME=$(docker ps | tail -n1 | cut -d' ' -f 1)
-  fi
-  cross build --target x86_64-unknown-linux-musl "$@"
+  cargo build --target x86_64-unknown-linux-musl "$@"
 
 dev-app: prep-frontend prep-dev-app
   #!/usr/bin/env bash


### PR DESCRIPTION
I'm unable to cut a release due to a glibc issue with cross and build scripts. See issue: https://github.com/cross-rs/cross/issues/724

This PR removes cross and instead directly builds it via the target, which is achieved by installing the `musl-tools` package.