### PR TITLE
Move dependency declarations to workspace root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,7 +2368,6 @@ dependencies = [
  "eu4save",
  "jomini",
  "js-sys",
- "once_cell",
  "schemas",
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,59 @@ members = [
     "src/wasm-vic3",
 ]
 
+[workspace.dependencies]
+anyhow = "1.0"
+applib = { path = "src/applib" }
+attohttpc = "0.28.0"
+axum = "0.7.5"
+base64 = "0.13"
+chrono = "0.4"
+ck3save = { git = "https://github.com/rakaly/ck3save.git" }
+clap = "4.1"
+criterion = "0.5"
+csv = "1.1"
+env_logger = "0.10"
+erased-serde = "0.4.5"
+eu4game = { path = "src/eu4game", default-features = false }
+eu4game-data = { path = "src/eu4game-data", default-features = false }
+eu4save = { git = "https://github.com/rakaly/eu4save.git", default-features = false }
+flatbuffers = "24.3.25"
+flate2 = { version = "1.1.0", default-features = false }
+getrandom = "0.2"
+highway = "1.2"
+hoi4save = { git = "https://github.com/rakaly/hoi4save.git" }
+image = { version = "0.25.2", default-features = false }
+imperator-save = { git = "https://github.com/rakaly/imperator-save.git" }
+jomini = "0.28.0"
+js-sys = "0.3"
+log = "0.4"
+mathru = "0.15.3"
+mimalloc = "0.1.43"
+rand = "0.8"
+rawzip = "0.1.0"
+rayon = "1"
+regex = "1"
+schemas = { path = "src/schemas" }
+serde = "1.0.195"
+serde-wasm-bindgen = "0.5"
+serde_json = "1.0.114"
+serde_path_to_error = "0.1"
+specta = "1.0.4"
+tar = "0.4"
+tempfile = "3.3"
+thiserror = "2.0.0"
+tokio = "1.28.2"
+tower-http = "0.5.2"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tsify = { version = "0.4.5", default-features = false }
+vic3save = { path = "src/vic3save" }
+walkdir = "2.3.1"
+wasm-bindgen = { version = "0.2", default-features = false }
+wasm-bindgen-test = "0.3.0"
+webp = "0.3"
+zstd = { version = "0.13.0", default-features = false }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = { version = "0.7.5" }
-tokio = { version = "1.28.2", features = ["rt", "macros", "rt-multi-thread", "signal"] }
-applib = { path = "../applib" }
-eu4game = { path = "../eu4game" }
-tower-http = { version = "0.5.2", features = ["trace"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-webp = "0.3"
-image = { version = "0.25.2", default-features = false, features = ["png"] }
+axum = { workspace = true }
+tokio = { features = ["rt", "macros", "rt-multi-thread", "signal"] , workspace = true }
+applib = { workspace = true }
+eu4game = { workspace = true }
+tower-http = { features = ["trace"] , workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { features = ["env-filter"] , workspace = true }
+webp = { workspace = true }
+image = { default-features = false, features = ["png"] , workspace = true }
 
 [target.'cfg(target_env = "musl")'.dependencies]
-mimalloc = "0.1.43"
+mimalloc = { workspace = true }

--- a/src/applib/Cargo.toml
+++ b/src/applib/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [features]
 
 [dependencies]
-serde = {version = "1", features = ["derive"]}
-eu4save = { git = "https://github.com/rakaly/eu4save.git", default-features = false, features = ["serialize", "zstd", "specta"] }
-eu4game = { path = "../eu4game", default-features = false, features = ["embedded"] }
-thiserror = "2.0.0"
-specta = { version = "1.0.4", features = ["typescript", "export"] }
+serde = { features = ["derive"], workspace = true }
+eu4save = { default-features = false, features = ["serialize", "zstd", "specta"] , workspace = true }
+eu4game = { default-features = false, features = ["embedded"] , workspace = true }
+thiserror = { workspace = true }
+specta = { features = ["typescript", "export"] , workspace = true }

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -13,30 +13,30 @@ compile_assets = ["dep:attohttpc", "dep:eu4save", "dep:jomini", "dep:eu4game-dat
 tokenize = ["dep:zstd", "dep:schemas"]
 
 [dependencies]
-anyhow = "1.0"
-applib = { path = "../applib", optional = true }
-attohttpc = { version = "0.28", features = ["json"], optional = true }
-chrono = "0.4"
-clap = { version = "4.1", features = ["derive", "env"] }
-csv = { version = "1.1" }
-env_logger = "0.10"
-eu4game = { path = "../eu4game", optional = true, default-features = false }
-eu4game-data = { path = "../eu4game-data", optional = true, default-features = false }
-eu4save = { git = "https://github.com/rakaly/eu4save.git", default-features = false, features = ["serialize", "zstd"], optional = true }
-flate2 = { version = "1.1.0", optional = true, default-features = false, features = ["zlib-rs"] }
-highway = "1.2"
-jomini = { version = "0.28", optional = true }
-log = "0.4"
-rayon = "1"
-regex = "1"
-schemas = { path = "../schemas", optional = true }
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.114"
-tar = "0.4"
-tempfile = "3.3"
-walkdir = "2.3.1"
-rawzip = "0.1.0"
-zstd = { version = "0.13.0", features = ["zstdmt"], optional = true }
+anyhow = { workspace = true }
+applib = { optional = true , workspace = true }
+attohttpc = { features = ["json"], optional = true , workspace = true }
+chrono = { workspace = true }
+clap = { features = ["derive", "env"] , workspace = true }
+csv = { workspace = true }
+env_logger = { workspace = true }
+eu4game = { optional = true, default-features = false , workspace = true }
+eu4game-data = { optional = true, default-features = false , workspace = true }
+eu4save = { default-features = false, features = ["serialize", "zstd"], optional = true , workspace = true }
+flate2 = { optional = true, default-features = false, features = ["zlib-rs"] , workspace = true }
+highway = { workspace = true }
+jomini = { optional = true , workspace = true }
+log = { workspace = true }
+rayon = { workspace = true }
+regex = { workspace = true }
+schemas = { optional = true , workspace = true }
+serde = { features = ["derive"] , workspace = true }
+serde_json = { workspace = true }
+tar = { workspace = true }
+tempfile = { workspace = true }
+walkdir = { workspace = true }
+rawzip = { workspace = true }
+zstd = { features = ["zstdmt"], optional = true , workspace = true }
 
 [target.'cfg(target_env = "musl")'.dependencies]
-mimalloc = "0.1.43"
+mimalloc = { workspace = true }

--- a/src/eu4game-data/Cargo.toml
+++ b/src/eu4game-data/Cargo.toml
@@ -10,9 +10,9 @@ embedded = []
 tsify = ["dep:tsify", "dep:wasm-bindgen"]
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-tsify = { version = "0.4.5", default-features = false, optional = true }
-wasm-bindgen = { version = "0.2", default-features = false, optional = true }
+serde = { features = ["derive"] , workspace = true }
+tsify = { default-features = false, optional = true , workspace = true }
+wasm-bindgen = { default-features = false, optional = true , workspace = true }
 
 [build-dependencies]
-regex = "1.5"
+regex = { workspace = true }

--- a/src/eu4game/Cargo.toml
+++ b/src/eu4game/Cargo.toml
@@ -10,21 +10,21 @@ default = ["embedded"]
 embedded = ["eu4game-data/embedded"]
 
 [dependencies]
-jomini = { version = "0.28" }
-erased-serde = "0.4.5"
-eu4game-data = { path = "../eu4game-data" }
-eu4save = { git = "https://github.com/rakaly/eu4save.git", default-features = false, features = ["zstd"] }
-schemas = { path = "../schemas", features = ["inline"] }
-serde = { version = "1.0.195", features = ["derive"] }
-serde_path_to_error = "0.1"
-highway = "1.2"
-base64 = "0.13"
-thiserror = "2.0.0"
-zstd = { version = "0.13.0", default-features = false }
+jomini = { workspace = true }
+erased-serde = { workspace = true }
+eu4game-data = { workspace = true }
+eu4save = { default-features = false, features = ["zstd"] , workspace = true }
+schemas = { features = ["inline"] , workspace = true }
+serde = { features = ["derive"] , workspace = true }
+serde_path_to_error = { workspace = true }
+highway = { workspace = true }
+base64 = { workspace = true }
+thiserror = { workspace = true }
+zstd = { default-features = false , workspace = true }
 
 [dev-dependencies]
-attohttpc = "0.28"
-walkdir = "2"
+attohttpc = { workspace = true }
+walkdir = { workspace = true }
 
 [build-dependencies]
-regex = "1.5"
+regex = { workspace = true }

--- a/src/schemas/Cargo.toml
+++ b/src/schemas/Cargo.toml
@@ -8,12 +8,12 @@ publish = false
 inline = []
 
 [dependencies]
-flatbuffers = "24.3.25"
-jomini = {version = "0.28" }
+flatbuffers = { workspace = true }
+jomini = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.5"
-rand = "0.8"
+criterion = { workspace = true }
+rand = { workspace = true }
 
 [[bench]]
 name = "schema_benchmark"

--- a/src/vic3save/Cargo.toml
+++ b/src/vic3save/Cargo.toml
@@ -8,14 +8,14 @@ publish = false
 [features]
 
 [dependencies]
-jomini =  { version = "0.28.0", features = ["json"] }
-serde = { version = "1.0.195", features = ["derive"] }
-thiserror = "2.0.0"
-serde_path_to_error = "0.1"
-getrandom = { version = "0.2", features = ["js"]}
-mathru = "0.15.3"
-flate2 = { version = "1.1.0", default-features = false, features = ["zlib-rs"] }
-rawzip = "0.1.0"
+jomini =  { features = ["json"] , workspace = true }
+serde = { features = ["derive"] , workspace = true }
+thiserror = { workspace = true }
+serde_path_to_error = { workspace = true }
+getrandom = { features = ["js"], workspace = true }
+mathru = { workspace = true }
+flate2 = { default-features = false, features = ["zlib-rs"] , workspace = true }
+rawzip = { workspace = true }
 
 [dev-dependencies]
-attohttpc = "0.28.0"
+attohttpc = { workspace = true }

--- a/src/wasm-app/Cargo.toml
+++ b/src/wasm-app/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2" }
-tsify = { version = "0.4.5", default-features = false, features = ["js"] } 
-serde = { version = "1.0.195", features = ["derive"] }
-eu4game-data = { path = "../eu4game-data", features = ["tsify"] }
-jomini = { version = "0.28" }
+wasm-bindgen = { workspace = true }
+tsify = { default-features = false, features = ["js"] , workspace = true }
+serde = { features = ["derive"] , workspace = true }
+eu4game-data = { features = ["tsify"] , workspace = true }
+jomini = { workspace = true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-ck3/Cargo.toml
+++ b/src/wasm-ck3/Cargo.toml
@@ -12,14 +12,14 @@ crate-type = ["cdylib", "rlib"]
 default = ["zstd/fat-lto"]
 
 [dependencies]
-jomini = "0.28"
-schemas = { path = "../schemas" }
-wasm-bindgen = { version = "0.2" }
-serde-wasm-bindgen = "0.5"
-serde = { version = "1.0.195", features = ["derive"] }
-ck3save = { git = "https://github.com/rakaly/ck3save.git" }
-js-sys = "0.3"
-zstd = { version = "0.13.0", default-features = false }
+jomini = { workspace = true }
+schemas = { workspace = true }
+wasm-bindgen = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+serde = { features = ["derive"] , workspace = true }
+ck3save = { workspace = true }
+js-sys = { workspace = true }
+zstd = { default-features = false , workspace = true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-compress/Cargo.toml
+++ b/src/wasm-compress/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2" }
-flate2 = { version = "1.1.0", default-features = false, features = ["zlib-rs"] }
-rawzip = "0.1.0"
-zstd = { version = "0.13.0", default-features = false }
-js-sys = "0.3"
-tsify = { version = "0.4.5", default-features = false, features = ["js"] } 
-serde = { version = "1.0", features = ["derive"] }
+wasm-bindgen = { workspace = true }
+flate2 = { default-features = false, features = ["zlib-rs"] , workspace = true }
+rawzip = { workspace = true }
+zstd = { default-features = false , workspace = true }
+js-sys = { workspace = true }
+tsify = { default-features = false, features = ["js"] , workspace = true }
+serde = { features = ["derive"] , workspace = true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-eu4/Cargo.toml
+++ b/src/wasm-eu4/Cargo.toml
@@ -12,20 +12,19 @@ crate-type = ["cdylib", "rlib"]
 default = ["zstd/fat-lto"]
 
 [dependencies]
-jomini = { version = "0.28" }
-js-sys = "0.3"
-once_cell = "1.13"
-wasm-bindgen = { version = "0.2" }
-serde = { version = "1", features = ["derive"] }
-serde-wasm-bindgen = "0.5"
-eu4save = { git = "https://github.com/rakaly/eu4save.git", default-features = false, features = ["zstd", "tsify"] }
-eu4game = { path = "../eu4game", default-features = false }
-schemas = { path = "../schemas" }
-tsify = { version = "0.4.5", default-features = false, features = ["js"] } 
-zstd = { version = "0.13.0", default-features = false }
+jomini = { workspace = true }
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true }
+serde = { features = ["derive"] , workspace = true }
+serde-wasm-bindgen = { workspace = true }
+eu4save = { default-features = false, features = ["zstd", "tsify"] , workspace = true }
+eu4game = { default-features = false , workspace = true }
+schemas = { workspace = true }
+tsify = { default-features = false, features = ["js"] , workspace = true }
+zstd = { default-features = false , workspace = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
+wasm-bindgen-test = { workspace = true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-hoi4/Cargo.toml
+++ b/src/wasm-hoi4/Cargo.toml
@@ -11,15 +11,15 @@ crate-type = ["cdylib", "rlib"]
 default = ["zstd/fat-lto"]
 
 [dependencies]
-jomini = "0.28"
-schemas = { path = "../schemas" }
-wasm-bindgen = { version = "0.2" }
-serde-wasm-bindgen = "0.5"
-serde = { version = "1.0.195", features = ["derive"] }
-hoi4save = { git = "https://github.com/rakaly/hoi4save.git" }
-js-sys = "0.3"
-zstd = { version = "0.13.0", default-features = false }
-tsify = { version = "0.4.5", default-features = false, features = ["js"] }
+jomini = { workspace = true }
+schemas = { workspace = true }
+wasm-bindgen = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+serde = { features = ["derive"] , workspace = true }
+hoi4save = { workspace = true }
+js-sys = { workspace = true }
+zstd = { default-features = false , workspace = true }
+tsify = { default-features = false, features = ["js"] , workspace = true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-imperator/Cargo.toml
+++ b/src/wasm-imperator/Cargo.toml
@@ -11,14 +11,14 @@ crate-type = ["cdylib", "rlib"]
 default = ["zstd/fat-lto"]
 
 [dependencies]
-jomini = "0.28"
-schemas = { path = "../schemas" }
-wasm-bindgen = { version = "0.2" }
-serde-wasm-bindgen = "0.5"
-serde = { version = "1", features = ["derive"] }
-imperator-save = { git = "https://github.com/rakaly/imperator-save.git" }
-js-sys = "0.3"
-zstd = { version = "0.13.0", default-features = false }
+jomini = { workspace = true }
+schemas = { workspace = true }
+wasm-bindgen = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+serde = { features = ["derive"] , workspace = true }
+imperator-save = { workspace = true }
+js-sys = { workspace = true }
+zstd = { default-features = false , workspace = true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/src/wasm-vic3/Cargo.toml
+++ b/src/wasm-vic3/Cargo.toml
@@ -11,16 +11,15 @@ crate-type = ["cdylib", "rlib"]
 default = ["zstd/fat-lto"]
 
 [dependencies]
-jomini = {version = "0.28.0"}
-schemas = { path = "../schemas" }
-wasm-bindgen = { version = "0.2" }
-serde-wasm-bindgen = "0.5"
-serde = { version = "1.0.195", features = ["derive"] }
-vic3save = { path = "../vic3save" }
-js-sys = "0.3"
-tsify = { version = "0.4.5", default-features = false, features = ["js"] } 
-zstd = { version = "0.13.0", default-features = false }
-
+jomini = { workspace = true }
+schemas = { workspace = true }
+wasm-bindgen = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+serde = { features = ["derive"] , workspace = true }
+vic3save = { workspace = true }
+js-sys = { workspace = true }
+tsify = { default-features = false, features = ["js"] , workspace = true }
+zstd = { default-features = false , workspace = true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false


### PR DESCRIPTION
This way, it makes it easier to track what dependencies are use and be able to bump a instance across all members at once.