### PR TITLE
Use a monospace font for timelapse date

### DIFF
--- a/src/app/app/features/eu4/features/settings/Timelapse.tsx
+++ b/src/app/app/features/eu4/features/settings/Timelapse.tsx
@@ -397,7 +397,7 @@ export const Timelapse = () => {
             </Popover.Content>
           </Popover>
         </div>
-        <div className="whitespace-nowrap text-base opacity-60">
+        <div className="whitespace-nowrap text-base opacity-60 font-mono">
           <TimelapseDate />
         </div>
       </div>


### PR DESCRIPTION
This way there isn't any layout shift depending on the charcters used in the date (ie: "0" is wider than "1").