### PR TITLE
Include 1.35 introduced idea sets as seed ideas

### DIFF
--- a/src/app/app/features/eu4/features/charts/IdeaGroupsChart.tsx
+++ b/src/app/app/features/eu4/features/charts/IdeaGroupsChart.tsx
@@ -51,6 +51,12 @@ export const IdeaGroupsChart = () => {
         seedIdeas.push("indigenous");
       }
 
+      if (meta.savegame_version.second >= 35) {
+        seedIdeas.push("court");
+        seedIdeas.push("infrastructure");
+        seedIdeas.push("mercenary");
+      }
+
       type IdeaGroupStats = { count: number; completed: number };
       const ideas = new Map<string, IdeaGroupStats>(
         seedIdeas.map((x) => [x, { count: 0, completed: 0 }]),


### PR DESCRIPTION
This makes them consistent with the other idea groups (ie: even if no occurences, they will still be shown in the chart).