### PR TITLE
Fix institution ui omission of exploit step

### DIFF
--- a/src/app/app/components/DataTable.tsx
+++ b/src/app/app/components/DataTable.tsx
@@ -45,12 +45,13 @@ const usePaginationStore = create<PaginationSettings>()(
     }),
     {
       name: "pdx-tools-pagination-settings",
-    }
-  )
+    },
+  ),
 );
 
 const usePageSize = () => usePaginationStore((state) => state.pageSize);
-const usePaginationActions = () => usePaginationStore((state) => state.setPageSize);
+const usePaginationActions = () =>
+  usePaginationStore((state) => state.setPageSize);
 
 type DataTableProps<TData> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/app/features/eu4/features/country-details/CountryInstitution.tsx
+++ b/src/app/app/features/eu4/features/country-details/CountryInstitution.tsx
@@ -71,7 +71,8 @@ function InstructionSteps({ row }: { row: InstitutionCost }) {
           case "develop":
             return (
               <div key={`dev-${index}`}>
-                Dev {step.from} → {step.to}
+                Dev {step.from}
+                {step.to !== step.from ? ` → ${step.to}` : ""}
                 {step.followedBy.map((f) =>
                   f.type == "expand" ? (
                     <abbr
@@ -80,7 +81,7 @@ function InstructionSteps({ row }: { row: InstitutionCost }) {
                       className="cursor-help text-purple-600 no-underline dark:text-purple-400"
                     >
                       {" "}
-                      (expand)
+                      (expand){(f.times ?? 1) > 1 ? ` (${f.times}x)` : ""}
                     </abbr>
                   ) : (
                     <abbr
@@ -95,17 +96,6 @@ function InstructionSteps({ row }: { row: InstitutionCost }) {
                 )}
               </div>
             );
-
-          case "expand":
-            return (
-              <div key={`expand-${index}`}>
-                Start by expanding infra{" "}
-                {(step.times ?? 1) > 1 ? ` (${step.times}x)` : ""}
-              </div>
-            );
-
-          case "exploit":
-            return <div key={`exploit-${index}`}>Start by exploiting dev</div>;
         }
       })}
     </div>

--- a/src/app/app/features/eu4/features/country-details/institutionSteps.test.ts
+++ b/src/app/app/features/eu4/features/country-details/institutionSteps.test.ts
@@ -282,7 +282,12 @@ describe("consolidateSteps", () => {
       { type: "develop", from: 15, to: 20 },
     ] satisfies InstitutionStep[];
     const expected = [
-      { type: "expand", at: 15, times: 1, followedBy: [] },
+      {
+        type: "develop",
+        from: 15,
+        to: 15,
+        followedBy: [{ type: "expand", at: 15, times: 1 }],
+      },
       { type: "develop", from: 15, to: 20, followedBy: [] },
     ];
     const result = consolidateSteps(steps);
@@ -298,15 +303,49 @@ describe("consolidateSteps", () => {
     ] satisfies InstitutionStep[];
     const expected = [
       {
-        type: "expand",
-        at: 15,
+        type: "develop",
+        from: 15,
+        to: 15,
         followedBy: [
+          { type: "expand", at: 15 },
           { type: "expand", at: 15 },
           { type: "exploit", at: 15 },
         ],
       },
       { type: "develop", from: 14, to: 20, followedBy: [] },
     ];
+    const result = consolidateSteps(steps);
+    expect(result).toEqual(expected);
+  });
+
+  it("should handle expand, exploit, develop, expand, develop sequence", () => {
+    const steps = [
+      { type: "expand", at: 25, times: 1 },
+      { type: "exploit", at: 25 },
+      { type: "develop", from: 24, to: 30 },
+      { type: "expand", at: 30 },
+      { type: "develop", from: 30, to: 42 },
+    ] satisfies InstitutionStep[];
+
+    const expected = [
+      {
+        type: "develop",
+        from: 25,
+        to: 25,
+        followedBy: [
+          { type: "expand", at: 25, times: 1 },
+          { type: "exploit", at: 25 },
+        ],
+      },
+      {
+        type: "develop",
+        from: 24,
+        to: 30,
+        followedBy: [{ type: "expand", at: 30 }],
+      },
+      { type: "develop", from: 30, to: 42, followedBy: [] },
+    ];
+
     const result = consolidateSteps(steps);
     expect(result).toEqual(expected);
   });


### PR DESCRIPTION
When the first steps are expand and exploit, the exploit step was not being displayed in the UI.

The fix is to add a pseudo no-op dev step as the first step that is followed by expand and exploit.