### PR TITLE
Fix referencing detached country color buffers

### DIFF
--- a/src/app/app/features/eu4/store/eu4Store.tsx
+++ b/src/app/app/features/eu4/store/eu4Store.tsx
@@ -174,7 +174,7 @@ export const createEu4Store = async ({
       setMapMode: async (mode: Eu4State["mapMode"]) => {
         const countryColors =
           !dateEnabledMapMode(mode) && dateEnabledMapMode(get().mapMode)
-            ? get().save.initialPoliticalMapColors
+            ? new Uint8Array(get().save.initialPoliticalMapColors)
             : undefined;
         set({ mapMode: mode });
         emitEvent({ kind: "Map mode switch", mode });

--- a/src/app/app/features/eu4/store/useLoadEu4.tsx
+++ b/src/app/app/features/eu4/store/useLoadEu4.tsx
@@ -297,6 +297,8 @@ async function loadEu4Save(
     progress: 4,
   });
 
+  const initialPoliticalMapColors = new Uint8Array(primary);
+
   const map = await mapControllerTask;
   map.updateProvinceColors(primary, secondary, { country: primary });
 
@@ -312,7 +314,7 @@ async function loadEu4Save(
     meta,
     achievements,
     countries,
-    initialPoliticalMapColors: primary,
+    initialPoliticalMapColors,
     defaultSelectedCountry: defaultSelectedTag,
     saveInfo,
   };


### PR DESCRIPTION
Currently when one toggles different map modes, the initial country colors (for the latest date of the save), is detached from the very start and will cause an exception -- resulting in requiring two clicks to change the map mode.