### PR TITLE
Make color-scheme an unconditional html header

### DIFF
--- a/src/app/app/root.tsx
+++ b/src/app/app/root.tsx
@@ -44,15 +44,13 @@ export const links: LinksFunction = () => [
   { rel: "apple-touch-icon", sizes: "180x180", href: appleIconUrl },
 ];
 
-export const meta: MetaFunction = () => [
-  { name: "color-scheme", content: "light dark" },
-  ...seo({
+export const meta: MetaFunction = () =>
+  seo({
     title: "PDX Tools - Modern EU4 Save Analyzer",
     description:
       "View maps, graphs, and tables of your save and compete in a casual, evergreen leaderboard of EU4 achievement speed runs. Upload and share your save with the world.",
     image: social,
-  }),
-];
+  });
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -60,6 +58,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="color-scheme" content="light dark" />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
Consider the color-scheme as global metadata:
https://remix.run/docs/en/main/route/meta#global-meta

As currently pages like https://pdx.tools/eu4/achievements lack the color-scheme meta tag.

This was originally part of the tailwind v4 work: #371