### PR TITLE
Tile textures with single imagemagick call

### DIFF
--- a/src/pdx-assets/src/eu4/compiler.rs
+++ b/src/pdx-assets/src/eu4/compiler.rs
@@ -908,23 +908,21 @@ where
 
         let file_stem = Path::new(image).file_stem().unwrap();
 
-        for i in 1..=2 {
-            let mut end_filename = file_stem.to_os_string();
-            end_filename.push(format!("-{}.webp", i));
-            let out_path = base_imaging_dir.join(&end_filename);
-            let convert_request = crate::images::ConvertRequest {
-                input_path: file_handle.path.clone(),
-                output_path: out_path,
-                format: crate::images::OutputFormat::Webp {
-                    quality: crate::images::WebpQuality::Lossless,
-                },
-                operation: Some(crate::images::ImageOperation::Crop(
-                    crate::images::CropGeometry::new(2816, 2048, (i - 1) * 2816, 0),
-                )),
-            };
+        let mut end_filename = file_stem.to_os_string();
+        end_filename.push("-%d.webp");
+        let out_path = base_imaging_dir.join(&end_filename);
+        let convert_request = crate::images::ConvertRequest {
+            input_path: file_handle.path.clone(),
+            output_path: out_path,
+            format: crate::images::OutputFormat::Webp {
+                quality: crate::images::WebpQuality::Lossless,
+            },
+            operation: Some(crate::images::ImageOperation::Tile(
+                crate::images::TileGeometry::new(2, 1),
+            )),
+        };
 
-            imaging.convert(convert_request).context("convert failed")?;
-        }
+        imaging.convert(convert_request).context("convert failed")?;
     }
 
     // Process occupation terrain

--- a/src/pdx-assets/src/images.rs
+++ b/src/pdx-assets/src/images.rs
@@ -81,7 +81,20 @@ pub enum WebpQuality {
 }
 
 #[derive(Debug, Clone)]
+pub struct TileGeometry {
+    pub columns: u32,
+    pub rows: u32,
+}
+
+impl TileGeometry {
+    pub fn new(columns: u32, rows: u32) -> Self {
+        Self { columns, rows }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub enum ImageOperation {
     Resize(Geometry),
     Crop(CropGeometry),
+    Tile(TileGeometry),
 }

--- a/src/pdx-assets/src/images/imagemagick.rs
+++ b/src/pdx-assets/src/images/imagemagick.rs
@@ -70,6 +70,12 @@ impl ImageProcessor for ImageMagickProcessor {
                         crop.width, crop.height, crop.x_offset, crop.y_offset
                     ));
                 }
+                ImageOperation::Tile(tile) => {
+                    cmd.arg("-crop");
+                    cmd.arg(format!("{}x{}@", tile.columns, tile.rows));
+                    cmd.arg("-scene");
+                    cmd.arg("1");
+                }
             }
         }
 


### PR DESCRIPTION
Previously we were computing the crop offset manually. Turns out imagemagick can do this automatically.