### PR TITLE
Auto-detect Steam installation for asset compilation

### DIFF
--- a/src/pdx-assets/src/cli/compile.rs
+++ b/src/pdx-assets/src/cli/compile.rs
@@ -15,9 +15,9 @@ pub struct CompileArgs {
     #[clap(long)]
     minimal: bool,
 
-    /// Path to source (directory or zip file)
+    /// Path to game source (directory or zip file). If not provided, attempts to auto-detect Steam installation
     #[clap(value_parser)]
-    source_path: PathBuf,
+    source_path: Option<PathBuf>,
 
     /// Output directory for processed assets
     #[clap(long, short)]
@@ -25,6 +25,78 @@ pub struct CompileArgs {
 }
 
 impl CompileArgs {
+    /// Auto-detect Steam installation path and EU4 directory
+    fn detect_steam_eu4_path() -> Result<PathBuf> {
+        let steam_path =
+            Self::detect_steam_path().context("Failed to auto-detect Steam installation path")?;
+
+        let eu4_path = steam_path.join("steamapps/common/Europa Universalis IV");
+        anyhow::ensure!(
+            eu4_path.exists(),
+            "Europa Universalis IV not found in Steam library at expected path: {}",
+            eu4_path.display()
+        );
+
+        println!("Detected EU4 installation at: {}", eu4_path.display());
+        Ok(eu4_path)
+    }
+
+    /// Detect Steam installation path based on the current platform
+    fn detect_steam_path() -> Result<PathBuf> {
+        match std::env::consts::OS {
+            "windows" => Self::detect_steam_path_windows(),
+            "macos" => Self::detect_steam_path_macos(),
+            "linux" => Self::detect_steam_path_linux(),
+            os => anyhow::bail!(
+                "Steam auto-detection is not supported on platform '{}'. Please specify the source path manually.",
+                os
+            ),
+        }
+    }
+
+    /// Detect Steam installation path on Windows
+    fn detect_steam_path_windows() -> Result<PathBuf> {
+        let output = std::process::Command::new("powershell")
+            .arg("-Command")
+            .arg("(Get-ItemProperty -Path \"HKLM:\\SOFTWARE\\WOW6432Node\\Valve\\Steam\").InstallPath")
+            .output()
+            .context("Failed to execute PowerShell command. Is PowerShell available?")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("PowerShell command failed: {}", stderr);
+        }
+
+        let install_path = String::from_utf8(output.stdout)
+            .context("PowerShell output is not valid UTF-8")?
+            .trim()
+            .to_string();
+
+        Ok(PathBuf::from(install_path))
+    }
+
+    /// Detect Steam installation path on macOS
+    fn detect_steam_path_macos() -> Result<PathBuf> {
+        let steam_path = PathBuf::from("/Applications/Steam.app/Contents/MacOS");
+        Ok(steam_path)
+    }
+
+    /// Detect Steam installation path on Linux
+    fn detect_steam_path_linux() -> Result<PathBuf> {
+        let home = std::env::var("HOME").context("HOME environment variable not set")?;
+        let local = PathBuf::from(&home).join(".local/share/Steam");
+        if local.exists() {
+            return Ok(local);
+        }
+
+        let steam_path = PathBuf::from(&home).join(".steam/steam");
+        if steam_path.exists() {
+            return Ok(steam_path);
+        }
+
+        anyhow::bail!("Could not find Steam installation");
+    }
+
     pub fn run(&self) -> Result<ExitCode> {
         let output = self
             .output
@@ -35,13 +107,15 @@ impl CompileArgs {
         std::fs::create_dir_all(&output)
             .with_context(|| format!("Failed to create output directory: {}", output.display()))?;
 
+        // Get source path: use provided path or auto-detect
+        let source_path = match &self.source_path {
+            Some(path) => path.clone(),
+            None => Self::detect_steam_eu4_path()?,
+        };
+
         // Auto-detect source type and create appropriate provider
-        let provider = create_provider(&self.source_path).with_context(|| {
-            format!(
-                "Failed to create provider for: {}",
-                self.source_path.display()
-            )
-        })?;
+        let provider = create_provider(&source_path)
+            .with_context(|| format!("Failed to create provider for: {}", source_path.display()))?;
 
         let asset_compiler = Eu4AssetCompliler;
         let imaging = ImageMagickProcessor::create()?;

--- a/src/pdx-assets/src/images/imagemagick.rs
+++ b/src/pdx-assets/src/images/imagemagick.rs
@@ -167,7 +167,7 @@ impl ImageMagickProcessor {
             match entry.compression_method() {
                 rawzip::CompressionMethod::Store => {
                     output_file
-                        .write_all(&zip_entry.data())
+                        .write_all(zip_entry.data())
                         .context("Failed to write extracted file")?;
                 }
                 rawzip::CompressionMethod::Deflate => {


### PR DESCRIPTION
When writing docs on native windows development, I encountered an issue with mise that it is unable to accept arguments with spaces: https://github.com/jdx/mise/discussions/6119

```
mise run assets:compile 'D:\games\steam\steamapps\common\Europa Universalis IV'
```

Auto-detecting the EU4 installation when no argument is provided, side steps the issue.