### PR TITLE
Fix three mountain achievement detection

### DIFF
--- a/src/eu4game/tests/it/ironman.rs
+++ b/src/eu4game/tests/it/ironman.rs
@@ -555,3 +555,19 @@ fn test_i_dont_like_sand() {
         .collect();
     assert!(completed_ids.contains(&332));
 }
+
+#[test]
+fn test_three_mountains() {
+    let data = utils::request("three_mountains.eu4");
+    let Eu4SaveOutput { save, encoding, .. } = Eu4Parser::new().parse(&data).unwrap();
+    let game = Game::new(&save.meta.savegame_version);
+    let query = Query::from_save(save);
+    let achievements = AchievementHunter::new(encoding, &query, &game).unwrap();
+    let completed_ids: Vec<i32> = achievements
+        .achievements()
+        .iter()
+        .filter(|x| x.completed())
+        .map(|x| x.id)
+        .collect();
+    assert!(completed_ids.contains(&49));
+}


### PR DESCRIPTION
The detection was overly conservative by requiring the player to RYU, which is not required by the game.

The requirements are

```
The only existing countries are:
  - the player's country
  - Ryukyu and its subjects, but not tributary states.
```