### PR TITLE
Replace timelapse muxers with mediabunny

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,9 @@ importers:
       drizzle-orm:
         specifier: 0.36.2
         version: 0.36.2(@cloudflare/workers-types@4.20241112.0)(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)(@types/react@18.3.12)(postgres@3.4.5)(react@18.3.1)
-      mp4-muxer:
-        specifier: 5.1.3
-        version: 5.1.3
+      mediabunny:
+        specifier: 1.23.0
+        version: 1.23.0
       nanoid:
         specifier: 5.0.9
         version: 5.0.9
@@ -159,9 +159,6 @@ importers:
       sonner:
         specifier: 1.7.0
         version: 1.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      webm-muxer:
-        specifier: 5.0.2
-        version: 5.0.2
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -3942,6 +3939,12 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/dom-mediacapture-transform@0.1.11':
+    resolution: {integrity: sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==}
+
+  '@types/dom-webcodecs@0.1.13':
+    resolution: {integrity: sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==}
+
   '@types/dom-webcodecs@0.1.15':
     resolution: {integrity: sha512-omOlCPvTWyPm4ZE5bZUhlSvnHM2ZWM2U+1cPiYFL/e8aV5O9MouELp+L4dMKNTON0nTeHqEg+KWDfFQMY5Wkaw==}
 
@@ -4097,9 +4100,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/wicg-file-system-access@2020.9.8':
-    resolution: {integrity: sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==}
 
   '@types/wicg-file-system-access@2023.10.5':
     resolution: {integrity: sha512-e9kZO9kCdLqT2h9Tw38oGv9UNzBBWaR1MzuAavxPcsV/7FJ3tWbU6RI3uB+yKIDPGLkGVbplS52ub0AcRLvrhA==}
@@ -6982,6 +6982,9 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  mediabunny@1.23.0:
+    resolution: {integrity: sha512-mWdhhdRquePfTgZ+18DLCFWmqwO6oGP/YudmRU8Puh+whMUJ3VSb9KMAHPl2utim66ixKdZw+DbmdqBfBxRp0A==}
+
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -7333,9 +7336,6 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
-
-  mp4-muxer@5.1.3:
-    resolution: {integrity: sha512-artYS8Y7l9Cgqi1WyoNZtHW+pXOM0Tg75eupENoSEx59hMJlBqXxsTgJQ8T0ycrb6h9lw9iNKVB8cKEn7HjG2A==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -9685,9 +9685,6 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  webm-muxer@5.0.2:
-    resolution: {integrity: sha512-/1m0ZGOcx8TvEmqY+U7GromXTKtto4pi5ou+ZvaQXEjb+G/v1cln2ZbKK3T4fpWhLBYjKBeYWza/y1Nxccm5pg==}
 
   webpack-bundle-analyzer@4.10.2:
     resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
@@ -14297,6 +14294,12 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/dom-mediacapture-transform@0.1.11':
+    dependencies:
+      '@types/dom-webcodecs': 0.1.15
+
+  '@types/dom-webcodecs@0.1.13': {}
+
   '@types/dom-webcodecs@0.1.15': {}
 
   '@types/eslint-scope@3.7.7':
@@ -14482,8 +14485,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/wicg-file-system-access@2020.9.8': {}
 
   '@types/wicg-file-system-access@2023.10.5': {}
 
@@ -18042,6 +18043,11 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  mediabunny@1.23.0:
+    dependencies:
+      '@types/dom-mediacapture-transform': 0.1.11
+      '@types/dom-webcodecs': 0.1.13
+
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.0.6
@@ -18674,11 +18680,6 @@ snapshots:
   modern-ahocorasick@1.1.0: {}
 
   module-details-from-path@1.0.4: {}
-
-  mp4-muxer@5.1.3:
-    dependencies:
-      '@types/dom-webcodecs': 0.1.15
-      '@types/wicg-file-system-access': 2020.9.8
 
   mri@1.2.0: {}
 
@@ -21411,11 +21412,6 @@ snapshots:
   web-vitals@4.2.4: {}
 
   webidl-conversions@3.0.1: {}
-
-  webm-muxer@5.0.2:
-    dependencies:
-      '@types/dom-webcodecs': 0.1.15
-      '@types/wicg-file-system-access': 2020.9.8
 
   webpack-bundle-analyzer@4.10.2:
     dependencies:

--- a/src/app/app/features/eu4/features/settings/Timelapse.tsx
+++ b/src/app/app/features/eu4/features/settings/Timelapse.tsx
@@ -190,7 +190,7 @@ export const Timelapse = () => {
       encoderRef.current = encoder;
 
       await encoder.encodeTimelapse();
-      const blob = encoder.finish();
+      const blob = await encoder.finish();
 
       setIsRecording(false);
       restoreMapState();

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -60,7 +60,7 @@
     "d3-selection": "3.0.0",
     "dayjs": "1.11.13",
     "drizzle-orm": "0.36.2",
-    "mp4-muxer": "5.1.3",
+    "mediabunny": "1.23.0",
     "nanoid": "5.0.9",
     "postgres": "3.4.5",
     "posthog-js": "1.255.0",
@@ -68,7 +68,6 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "sonner": "1.7.0",
-    "webm-muxer": "5.0.2",
     "zod": "3.23.8",
     "zustand": "5.0.2"
   },

--- a/src/app/tsconfig.json
+++ b/src/app/tsconfig.json
@@ -34,5 +34,11 @@
 
     /* If your code runs in the DOM: */
     "lib": ["es2022", "dom", "dom.iterable"]
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "**/node_modules",
+    "**/dist",
+    "**/build"
+  ]
 }


### PR DESCRIPTION
The creator of mp4-muxer and webm-muxer has made a new library called mediabunny that combines both. This commit replaces the old libraries with mediabunny.