### PR TITLE
Add bumpalo serde support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,29 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bumpalo-serde"
+version = "0.1.0"
+dependencies = [
+ "bumpalo",
+ "bumpalo-serde-derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bumpalo-serde-derive"
+version = "0.1.0"
+dependencies = [
+ "bumpalo",
+ "quote",
+ "serde",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "bytemuck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "src/api",
     "src/applib",
+    "src/bumpalo-serde-derive",
+    "src/bumpalo-serde",
     "src/cli",
     "src/eu4game-data",
     "src/eu4game",
@@ -28,6 +30,8 @@ applib = { path = "src/applib", default-features = false }
 attohttpc = "0.29.0"
 axum = "0.8.4"
 base64 = "0.22"
+bumpalo = "3.19"
+bumpalo-serde-derive = { path = "src/bumpalo-serde-derive" }
 bytemuck = { version = "1.24" }
 ck3save = { git = "https://github.com/rakaly/ck3save.git" }
 clap = "4.5"
@@ -54,6 +58,7 @@ mimalloc = "0.1.43"
 pdx-assets = { path = "src/pdx-assets" }
 pdx-map = { path = "src/pdx-map", default-features = false }
 pdx-zstd = { path = "src/pdx-zstd", default-features = false }
+quote = "1.0.34"
 rand = "0.8"
 rawbmp = { path = "src/rawbmp" }
 rawzip = "0.4.1"
@@ -66,6 +71,7 @@ serde_json = "1.0.114"
 serde_path_to_error = "0.1"
 serde-wasm-bindgen = "0.6.5"
 specta = "1.0.4"
+syn = { version = "2.0.50", features = ["derive"] }
 tempfile = "3.3"
 thiserror = "2.0.0"
 tokio = "1.45.0"

--- a/src/bumpalo-serde-derive/Cargo.toml
+++ b/src/bumpalo-serde-derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bumpalo-serde-derive"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { workspace = true, features = ["derive"] }
+quote = { workspace = true }
+bumpalo = { workspace = true, features = ["collections"] }
+serde = { workspace = true }

--- a/src/bumpalo-serde-derive/src/lib.rs
+++ b/src/bumpalo-serde-derive/src/lib.rs
@@ -1,0 +1,744 @@
+use proc_macro::{Span, TokenStream};
+use quote::{format_ident, quote};
+use syn::{Data, DeriveInput, Fields, LifetimeParam, Lit, Meta, Type, parse_macro_input};
+
+#[proc_macro_derive(ArenaDeserialize, attributes(arena))]
+pub fn derive_arena_deserialize(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    match expand_arena_deserialize(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn expand_arena_deserialize(input: &DeriveInput) -> syn::Result<TokenStream> {
+    let name = &input.ident;
+    let data = &input.data;
+
+    // Determine the arena lifetime to use
+    let arena_lifetime = determine_arena_lifetime(&input.generics);
+
+    // Check if this is an owned type that should just forward to Deserialize
+    if is_owned_type(input, &arena_lifetime) {
+        return expand_owned_type_passthrough(name, &input.generics, &arena_lifetime);
+    }
+
+    match data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields) => expand_struct_with_named_fields(
+                name,
+                &input.generics,
+                &fields.named,
+                &arena_lifetime,
+            ),
+            Fields::Unnamed(fields) => expand_struct_with_unnamed_fields(
+                name,
+                &input.generics,
+                &fields.unnamed,
+                &arena_lifetime,
+            ),
+            Fields::Unit => expand_unit_struct(name, &input.generics, &arena_lifetime),
+        },
+        Data::Enum(_) => expand_enum(name, &input.generics, &arena_lifetime),
+        Data::Union(_) => Err(syn::Error::new_spanned(
+            input,
+            "ArenaDeserialize does not support unions",
+        )),
+    }
+}
+
+fn expand_struct_with_named_fields(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    fields: &syn::punctuated::Punctuated<syn::Field, syn::Token![,]>,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    let field_info: Vec<FieldInfo> = fields
+        .iter()
+        .map(|field| parse_field_attributes(field))
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    let visitor_name = format_ident!("{}Visitor", name);
+
+    // Generate field enum variants
+    let field_enums: Vec<_> = field_info
+        .iter()
+        .enumerate()
+        .map(|(i, _info)| {
+            let variant_name = format_ident!("Field{}", i);
+            quote! { #variant_name }
+        })
+        .collect();
+
+    // Generate field name array for deserialization
+    let field_names: Vec<_> = field_info.iter().map(|info| &info.name).collect();
+
+    // Generate field enum match patterns
+    let field_enum_match: Vec<_> = field_info
+        .iter()
+        .enumerate()
+        .flat_map(|(i, info)| {
+            let variant_name = format_ident!("Field{}", i);
+            let field_name = &info.name;
+            let mut matches = vec![quote! { #field_name => Ok(__Field::#variant_name) }];
+
+            // Add aliases
+            for alias in &info.aliases {
+                matches.push(quote! { #alias => Ok(__Field::#variant_name) });
+            }
+
+            matches
+        })
+        .collect();
+
+    // Generate field handling using enum variants
+    let field_handling: Vec<_> = field_info
+        .iter()
+        .enumerate()
+        .map(|(i, info)| {
+            let field_name = &info.ident;
+            let field_type = &info.ty;
+            let field_str = &info.name;
+            let variant_name = format_ident!("Field{}", i);
+
+            let deserialize_logic = if let Some(deserialize_with) = &info.deserialize_with {
+                quote! {
+                    #field_name = Some({
+                        struct CustomFieldSeed<'bump> {
+                            allocator: &'bump bumpalo::Bump,
+                        }
+
+                        impl<'de, 'bump> serde::de::DeserializeSeed<'de> for CustomFieldSeed<'bump> {
+                            type Value = #field_type;
+
+                            fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+                            where
+                                D: serde::Deserializer<'de>,
+                            {
+                                #deserialize_with(deserializer, self.allocator)
+                            }
+                        }
+
+                        map.next_value_seed(CustomFieldSeed { allocator })?
+                    });
+                }
+            } else if is_slice_reference(field_type, arena_lifetime) {
+                if let Some(element_type) = get_slice_element_type(field_type) {
+                    quote! {
+                        #field_name = Some(map.next_value_seed(
+                            arena_deserializer::SliceDeserializer::<#element_type>::new(allocator)
+                        )?);
+                    }
+                } else {
+                    quote! {
+                        #field_name = Some(map.next_value_seed(arena_deserializer::ArenaSeed::new(allocator))?);
+                    }
+                }
+            } else if is_arena_type(field_type, arena_lifetime) || is_option_with_arena_type(field_type, arena_lifetime) {
+                quote! {
+                    #field_name = Some(map.next_value_seed(arena_deserializer::ArenaSeed::new(allocator))?);
+                }
+            } else {
+                quote! {
+                    #field_name = Some(map.next_value()?);
+                }
+            };
+
+            quote! {
+                __Field::#variant_name => {
+                    if #field_name.is_some() {
+                        return Err(serde::de::Error::duplicate_field(#field_str));
+                    }
+                    #deserialize_logic
+                }
+            }
+        })
+        .collect();
+
+    // Generate field extraction with defaults
+    let field_extractions: Vec<_> = field_info
+        .iter()
+        .map(|info| {
+            let field_name = &info.ident;
+            if info.has_default {
+                quote! {
+                    let #field_name = #field_name.unwrap_or_default();
+                }
+            } else if is_option_type(&info.ty) {
+                // For Option types without default, None is a valid value
+                quote! {
+                    let #field_name = #field_name.unwrap_or(None);
+                }
+            } else {
+                quote! {
+                    let #field_name = #field_name.ok_or_else(|| serde::de::Error::missing_field(stringify!(#field_name)))?;
+                }
+            }
+        })
+        .collect();
+
+    // Generate struct construction
+    let field_assignments: Vec<_> = field_info
+        .iter()
+        .map(|info| {
+            let field_name = &info.ident;
+            quote! { #field_name }
+        })
+        .collect();
+
+    // Handle generics and lifetime
+    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+    let arena_lifetime_syn =
+        syn::Lifetime::new(&format!("'{}", arena_lifetime), Span::call_site().into());
+
+    // Create new generics with arena lifetime
+    let mut new_generics = generics.clone();
+    // Only add arena lifetime if it doesn't already exist
+    if !generics
+        .lifetimes()
+        .any(|lt| lt.lifetime.ident.to_string() == arena_lifetime)
+    {
+        new_generics.params.insert(
+            0,
+            syn::GenericParam::Lifetime(LifetimeParam::new(arena_lifetime_syn.clone())),
+        );
+    }
+    let (new_impl_generics, _, new_where_clause) = new_generics.split_for_impl();
+
+    let deser_request = quote! {
+        __deserializer.deserialize_identifier(__FieldVisitor)
+    };
+
+    let output = quote! {
+        impl #new_impl_generics arena_deserializer::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, allocator: &#arena_lifetime_syn bumpalo::Bump) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                #[allow(non_camel_case_types)]
+                enum __Field {
+                    #(#field_enums),* ,
+                    __ignore,
+                }
+
+                struct __FieldVisitor;
+                impl<'de> ::serde::de::Visitor<'de> for __FieldVisitor {
+                    type Value = __Field;
+                    fn expecting(
+                        &self,
+                        __formatter: &mut ::std::fmt::Formatter,
+                    ) -> ::std::fmt::Result {
+                        write!(__formatter, "field identifier")
+                    }
+                    fn visit_str<__E>(
+                        self,
+                        __value: &str,
+                    ) -> ::std::result::Result<Self::Value, __E>
+                    where
+                        __E: ::serde::de::Error,
+                    {
+                        match __value {
+                            #(#field_enum_match),* ,
+                            _ => Ok(__Field::__ignore),
+                        }
+                    }
+
+                }
+
+                impl<'de> serde::Deserialize<'de> for __Field {
+                    #[inline]
+                    fn deserialize<__D>(
+                        __deserializer: __D,
+                    ) -> std::result::Result<Self, __D::Error>
+                    where
+                        __D: ::serde::Deserializer<'de>,
+                    {
+                        #deser_request
+                    }
+                }
+
+                struct #visitor_name<#arena_lifetime_syn> {
+                    allocator: &#arena_lifetime_syn bumpalo::Bump,
+                }
+
+                impl<'de, #arena_lifetime_syn> serde::de::Visitor<'de> for #visitor_name<#arena_lifetime_syn> {
+                    type Value = #name #ty_generics;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        formatter.write_str(concat!("struct ", stringify!(#name)))
+                    }
+
+                    fn visit_map<V>(self, mut map: V) -> Result<#name #ty_generics, V::Error>
+                    where
+                        V: serde::de::MapAccess<'de>,
+                    {
+                        let allocator = self.allocator;
+                        #(
+                            let mut #field_assignments = None;
+                        )*
+
+                        while let Some(key) = map.next_key::<__Field>()? {
+                            match key {
+                                #(#field_handling)*
+                                __Field::__ignore => {
+                                    // Skip unknown fields
+                                    map.next_value::<serde::de::IgnoredAny>()?;
+                                }
+                            }
+                        }
+
+                        #(#field_extractions)*
+
+                        Ok(#name {
+                            #(#field_assignments,)*
+                        })
+                    }
+                }
+
+                const FIELDS: &'static [&'static str] = &[#(stringify!(#field_names)),*];
+                deserializer.deserialize_struct(
+                    stringify!(#name),
+                    FIELDS,
+                    #visitor_name { allocator }
+                )
+            }
+        }
+    };
+
+    Ok(output.into())
+}
+
+fn expand_struct_with_unnamed_fields(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    fields: &syn::punctuated::Punctuated<syn::Field, syn::Token![,]>,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    if fields.len() != 1 {
+        return Err(syn::Error::new_spanned(
+            fields,
+            "Tuple structs with multiple fields are not supported",
+        ));
+    }
+
+    let field = fields.first().unwrap();
+    let field_type = &field.ty;
+    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+    let arena_lifetime_syn =
+        syn::Lifetime::new(&format!("'{}", arena_lifetime), Span::call_site().into());
+
+    let mut new_generics = generics.clone();
+    // Only add arena lifetime if it doesn't already exist
+    if !generics
+        .lifetimes()
+        .any(|lt| lt.lifetime.ident.to_string() == arena_lifetime)
+    {
+        new_generics.params.insert(
+            0,
+            syn::GenericParam::Lifetime(LifetimeParam::new(arena_lifetime_syn.clone())),
+        );
+    }
+    let (new_impl_generics, _, new_where_clause) = new_generics.split_for_impl();
+
+    let deserialize_impl = if is_arena_type(field_type, arena_lifetime) {
+        quote! {
+            let inner = <arena_deserializer::ArenaSeed::<#field_type> as serde::de::DeserializeSeed>::deserialize(arena_deserializer::ArenaSeed::<#field_type>::new(allocator), deserializer)?;
+            Ok(#name(inner))
+        }
+    } else {
+        quote! {
+            let inner = serde::Deserialize::deserialize(deserializer)?;
+            Ok(#name(inner))
+        }
+    };
+
+    let output = quote! {
+            impl #new_impl_generics arena_deserializer::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, allocator: &#arena_lifetime_syn bumpalo::Bump) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                #deserialize_impl
+            }
+        }
+    };
+    Ok(output.into())
+}
+
+fn expand_unit_struct(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+    let arena_lifetime_syn =
+        syn::Lifetime::new(&format!("'{}", arena_lifetime), Span::call_site().into());
+
+    let mut new_generics = generics.clone();
+    // Only add arena lifetime if it doesn't already exist
+    if !generics
+        .lifetimes()
+        .any(|lt| lt.lifetime.ident.to_string() == arena_lifetime)
+    {
+        new_generics.params.insert(
+            0,
+            syn::GenericParam::Lifetime(LifetimeParam::new(arena_lifetime_syn.clone())),
+        );
+    }
+    let (new_impl_generics, _, new_where_clause) = new_generics.split_for_impl();
+
+    let output = quote! {
+        impl #new_impl_generics arena_deserializer::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, _allocator: &#arena_lifetime_syn bumpalo::Bump) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                serde::Deserialize::deserialize(deserializer).map(|_: ()| #name)
+            }
+        }
+    };
+
+    Ok(output.into())
+}
+
+fn expand_enum(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+    let arena_lifetime_syn =
+        syn::Lifetime::new(&format!("'{}", arena_lifetime), Span::call_site().into());
+
+    let mut new_generics = generics.clone();
+    // Only add arena lifetime if it doesn't already exist
+    if !generics
+        .lifetimes()
+        .any(|lt| lt.lifetime.ident.to_string() == arena_lifetime)
+    {
+        new_generics.params.insert(
+            0,
+            syn::GenericParam::Lifetime(LifetimeParam::new(arena_lifetime_syn.clone())),
+        );
+    }
+    let (new_impl_generics, _, new_where_clause) = new_generics.split_for_impl();
+
+    let output = quote! {
+        impl #new_impl_generics arena_deserializer::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, _allocator: &#arena_lifetime_syn bumpalo::Bump) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                // Enums don't need arena allocation, so we just pass through to serde
+                serde::Deserialize::deserialize(deserializer)
+            }
+        }
+    };
+
+    Ok(output.into())
+}
+
+struct FieldInfo {
+    ident: syn::Ident,
+    name: String,
+    ty: syn::Type,
+    aliases: Vec<String>,
+    has_default: bool,
+    deserialize_with: Option<syn::Path>,
+}
+
+fn parse_field_attributes(field: &syn::Field) -> syn::Result<FieldInfo> {
+    let ident = field.ident.as_ref().unwrap().clone();
+    let name = ident.to_string();
+    let ty = field.ty.clone();
+    let mut aliases = Vec::new();
+    let mut has_default = false;
+    let mut deserialize_with = None;
+
+    for attr in &field.attrs {
+        if attr.path().is_ident("arena") {
+            match &attr.meta {
+                Meta::List(meta_list) => {
+                    let nested = meta_list.parse_args_with(
+                        syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+                    )?;
+
+                    for meta in nested {
+                        match meta {
+                            Meta::NameValue(nv) if nv.path.is_ident("alias") => {
+                                if let syn::Expr::Lit(syn::ExprLit {
+                                    lit: Lit::Str(s), ..
+                                }) = &nv.value
+                                {
+                                    aliases.push(s.value());
+                                }
+                            }
+                            Meta::Path(path) if path.is_ident("default") => {
+                                has_default = true;
+                            }
+                            Meta::NameValue(nv) if nv.path.is_ident("deserialize_with") => {
+                                if let syn::Expr::Lit(syn::ExprLit {
+                                    lit: Lit::Str(s), ..
+                                }) = &nv.value
+                                {
+                                    deserialize_with =
+                                        Some(syn::parse_str::<syn::Path>(&s.value())?);
+                                }
+                            }
+                            _ => {
+                                return Err(syn::Error::new_spanned(
+                                    meta,
+                                    "Unknown arena attribute",
+                                ));
+                            }
+                        }
+                    }
+                }
+                Meta::Path(path) if path.is_ident("default") => {
+                    has_default = true;
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        attr,
+                        "Invalid arena attribute format",
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(FieldInfo {
+        ident,
+        name,
+        ty,
+        aliases,
+        has_default,
+        deserialize_with,
+    })
+}
+
+fn is_arena_type(ty: &Type, arena_lifetime: &str) -> bool {
+    match ty {
+        Type::Reference(type_ref) => {
+            // Check for &'arena T where arena_lifetime matches
+            if let Some(lifetime) = &type_ref.lifetime {
+                lifetime.ident.to_string() == arena_lifetime
+            } else {
+                false
+            }
+        }
+        Type::Path(type_path) => {
+            // Check for bumpalo collections or types with arena lifetime
+            if let Some(segment) = type_path.path.segments.first() {
+                if segment.ident == "bumpalo" {
+                    return true;
+                }
+
+                // Check if the type has generic parameters with arena lifetime
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    for arg in &args.args {
+                        if let syn::GenericArgument::Lifetime(lt) = arg {
+                            if lt.ident.to_string() == arena_lifetime {
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                // Check for types that might be custom structs/enums with ArenaDeserialize
+                // We'll assume any non-standard library type implements ArenaDeserialize
+                let type_name = segment.ident.to_string();
+                if !matches!(
+                    type_name.as_str(),
+                    "String"
+                        | "Vec"
+                        | "HashMap"
+                        | "HashSet"
+                        | "BTreeMap"
+                        | "BTreeSet"
+                        | "i8"
+                        | "i16"
+                        | "i32"
+                        | "i64"
+                        | "i128"
+                        | "isize"
+                        | "u8"
+                        | "u16"
+                        | "u32"
+                        | "u64"
+                        | "u128"
+                        | "usize"
+                        | "f32"
+                        | "f64"
+                        | "bool"
+                        | "char"
+                        | "Option"
+                        | "Result"
+                ) {
+                    return true; // Assume custom types implement ArenaDeserialize
+                }
+
+                // Handle the standard types that don't need arena
+                false
+            } else {
+                false
+            }
+        }
+        Type::Slice(_) => true, // Assume slice types need arena deserialization
+        _ => {
+            // Check if the type contains arena lifetime parameter
+            let type_str = quote!(#ty).to_string();
+            type_str.contains(&format!("'{}", arena_lifetime))
+        }
+    }
+}
+
+fn has_bump_lifetime(generics: &syn::Generics) -> bool {
+    generics.lifetimes().any(|lt| lt.lifetime.ident == "bump")
+}
+
+/// Determine the arena lifetime for the struct.
+/// Returns the lifetime identifier string (e.g., "bump", "a", "arena").
+///
+/// If the struct has existing lifetime parameters, uses the first one as the arena lifetime.
+/// Otherwise, creates and returns "bump".
+fn determine_arena_lifetime(generics: &syn::Generics) -> String {
+    // Check if there's an existing lifetime parameter
+    if let Some(lifetime_param) = generics.lifetimes().next() {
+        lifetime_param.lifetime.ident.to_string()
+    } else {
+        "bump".to_string()
+    }
+}
+
+fn is_option_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.last() {
+                segment.ident == "Option"
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn is_option_with_arena_type(ty: &Type, arena_lifetime: &str) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.last() {
+                if segment.ident == "Option" {
+                    // Check if the Option contains an arena type
+                    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                        if let Some(syn::GenericArgument::Type(inner_type)) = args.args.first() {
+                            return is_arena_type(inner_type, arena_lifetime);
+                        }
+                    }
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn is_slice_reference(ty: &Type, arena_lifetime: &str) -> bool {
+    match ty {
+        Type::Reference(type_ref) => {
+            // Check if it's a reference to a slice with arena lifetime
+            if let Some(lifetime) = &type_ref.lifetime {
+                if lifetime.ident.to_string() == arena_lifetime {
+                    matches!(*type_ref.elem, Type::Slice(_))
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn get_slice_element_type(ty: &Type) -> Option<&Type> {
+    match ty {
+        Type::Reference(type_ref) => {
+            if let Type::Slice(slice_type) = &*type_ref.elem {
+                Some(&*slice_type.elem)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_owned_type(input: &DeriveInput, arena_lifetime: &str) -> bool {
+    // Only consider types with no lifetime parameters as potentially owned
+    if has_bump_lifetime(&input.generics) {
+        return false;
+    }
+
+    match &input.data {
+        Data::Struct(data_struct) => {
+            match &data_struct.fields {
+                Fields::Named(fields) => {
+                    // Check if all fields are owned types (no arena types)
+                    fields
+                        .named
+                        .iter()
+                        .all(|field| !is_arena_type(&field.ty, arena_lifetime))
+                }
+                Fields::Unnamed(fields) => {
+                    // Check if all fields are owned types (no arena types)
+                    fields
+                        .unnamed
+                        .iter()
+                        .all(|field| !is_arena_type(&field.ty, arena_lifetime))
+                }
+                Fields::Unit => true, // Unit structs are always owned
+            }
+        }
+        Data::Enum(_) => true,   // Enums are typically owned
+        Data::Union(_) => false, // We don't support unions anyway
+    }
+}
+
+fn expand_owned_type_passthrough(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    arena_lifetime: &str,
+) -> syn::Result<TokenStream> {
+    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+    let arena_lifetime_syn =
+        syn::Lifetime::new(&format!("'{}", arena_lifetime), Span::call_site().into());
+
+    // Create new generics with arena lifetime
+    let mut new_generics = generics.clone();
+    // Only add arena lifetime if it doesn't already exist
+    if !generics
+        .lifetimes()
+        .any(|lt| lt.lifetime.ident.to_string() == arena_lifetime)
+    {
+        new_generics.params.insert(
+            0,
+            syn::GenericParam::Lifetime(LifetimeParam::new(arena_lifetime_syn.clone())),
+        );
+    }
+    let (new_impl_generics, _, new_where_clause) = new_generics.split_for_impl();
+
+    let output = quote! {
+        impl #new_impl_generics arena_deserializer::ArenaDeserialize<#arena_lifetime_syn> for #name #ty_generics #new_where_clause {
+            fn deserialize_in_arena<'de, D>(deserializer: D, _allocator: &#arena_lifetime_syn bumpalo::Bump) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Self::deserialize(deserializer)
+            }
+        }
+    };
+
+    Ok(output.into())
+}

--- a/src/bumpalo-serde/Cargo.toml
+++ b/src/bumpalo-serde/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bumpalo-serde"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bumpalo = { workspace = true, features = ["collections"] }
+serde = { workspace = true }
+bumpalo-serde-derive = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }

--- a/src/bumpalo-serde/README.md
+++ b/src/bumpalo-serde/README.md
@@ -1,0 +1,41 @@
+# Bumpalo serde
+
+Bumpalo serde extends [serde](https://serde.rs/)'s deserialization capabilities to work with [bumpalo](https://github.com/fitzgen/bumpalo). It provides an `ArenaDeserialize` trait, which is similar to serde's `Deserialize`, but allocates data into a provided bump allocator instead of using the global heap allocator.
+
+Bump allocators and deserialization are a natural fit:
+
+- A single drop for the deserialized model, means that no matter how many strings a model may have, it will always be constant time to free the data.
+- Bumpalo allows one to pre-allocate the capacity expected for deserialization
+- Amortizes allocation costs of many fields that require allocations
+- Minimizes the volatility of the system allocator. Especially well suited for Wasm where one may have minimal control of the underyling allocator.
+- Allows for efficient views into the underlying data without requiring the entire input to be kept around unlike borrowed deserialization
+- Less brittle in performance than serde's `deserialize_in_place`.
+
+This crate is highly experimental and is not published on crates.io, but can be once stabilized.
+
+The code for Bumpalo serde is licensed under MIT.
+
+## Quick Example
+
+```rust
+use arena_deserializer::{ArenaDeserialize, ArenaSeed};
+use bumpalo::Bump;
+use serde::de::DeserializeSeed;
+
+#[derive(ArenaDeserialize)]
+struct User<'bump> {
+    name: &'bump str,
+    tags: bumpalo::collections::Vec<'bump, &'bump str>,
+    id: u64,
+}
+
+let arena = Bump::new();
+let json = r#"{"name": "Alice", "email": "alice@example.com", "tags": ["admin", "verified"], "id": 42}"#;
+let mut deserializer = serde_json::Deserializer::from_str(json);
+
+let user: User = ArenaSeed::new(&arena)
+    .deserialize(&mut deserializer)
+    .unwrap();
+
+// All string data is allocated in the arena and freed when `arena` is dropped
+```

--- a/src/bumpalo-serde/src/lib.rs
+++ b/src/bumpalo-serde/src/lib.rs
@@ -1,0 +1,863 @@
+pub use bumpalo_serde_derive::ArenaDeserialize;
+
+use bumpalo::collections::{String as BumpString, Vec as BumpVec};
+use serde::de::{DeserializeSeed, Deserializer, SeqAccess, Visitor};
+use serde::{Deserialize, de};
+use std::marker::PhantomData;
+
+/// A trait for types that can be deserialized using a bump allocator.
+pub trait ArenaDeserialize<'bump>: Sized {
+    /// Deserialize this value from the given deserializer using the provided bump allocator.
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>;
+}
+
+/// A seed for deserializing values using a bump allocator.
+#[derive(Clone, Copy)]
+pub struct ArenaSeed<'bump, T> {
+    pub allocator: &'bump bumpalo::Bump,
+    pub marker: PhantomData<fn() -> T>,
+}
+
+impl<'bump, T> ArenaSeed<'bump, T> {
+    /// Create a new ArenaSeed with the given allocator.
+    pub fn new(allocator: &'bump bumpalo::Bump) -> Self {
+        Self {
+            allocator,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'de, 'bump, T> DeserializeSeed<'de> for ArenaSeed<'bump, T>
+where
+    T: ArenaDeserialize<'bump>,
+{
+    type Value = T;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize_in_arena(deserializer, self.allocator)
+    }
+}
+
+// Macro to generate ArenaDeserialize implementations for types that just use regular Deserialize
+macro_rules! impl_arena_deserialize_passthrough {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl<'bump> ArenaDeserialize<'bump> for $t {
+                fn deserialize_in_arena<'de, D>(deserializer: D, _allocator: &'bump bumpalo::Bump) -> Result<Self, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    Self::deserialize(deserializer)
+                }
+            }
+        )*
+    };
+}
+
+// Implement ArenaDeserialize for common types that don't need arena allocation
+impl_arena_deserialize_passthrough! {
+    String,
+    i8, i16, i32, i64, i128, isize,
+    u8, u16, u32, u64, u128, usize,
+    f32, f64,
+    bool,
+    char,
+}
+
+// Generic implementations for collections where the element types implement Deserialize
+impl<'bump, T> ArenaDeserialize<'bump> for Vec<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<T>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, K, V> ArenaDeserialize<'bump> for std::collections::HashMap<K, V>
+where
+    K: for<'de> Deserialize<'de> + Eq + std::hash::Hash,
+    V: for<'de> Deserialize<'de>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        std::collections::HashMap::<K, V>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, K, V> ArenaDeserialize<'bump> for std::collections::BTreeMap<K, V>
+where
+    K: for<'de> Deserialize<'de> + Ord,
+    V: for<'de> Deserialize<'de>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        std::collections::BTreeMap::<K, V>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, T> ArenaDeserialize<'bump> for std::collections::HashSet<T>
+where
+    T: for<'de> Deserialize<'de> + Eq + std::hash::Hash,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        std::collections::HashSet::<T>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, T> ArenaDeserialize<'bump> for std::collections::BTreeSet<T>
+where
+    T: for<'de> Deserialize<'de> + Ord,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        _allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        std::collections::BTreeSet::<T>::deserialize(deserializer)
+    }
+}
+
+impl<'bump, T> ArenaDeserialize<'bump> for Option<T>
+where
+    T: ArenaDeserialize<'bump>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OptionVisitor<'a, T> {
+            allocator: &'a bumpalo::Bump,
+            marker: PhantomData<T>,
+        }
+
+        impl<'de, 'a, T> Visitor<'de> for OptionVisitor<'a, T>
+        where
+            T: ArenaDeserialize<'a>,
+        {
+            type Value = Option<T>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("option")
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                T::deserialize_in_arena(deserializer, self.allocator).map(Some)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+        }
+
+        deserializer.deserialize_option(OptionVisitor {
+            allocator,
+            marker: PhantomData,
+        })
+    }
+}
+
+// Implementation for bumpalo::collections::String
+impl<'bump> ArenaDeserialize<'bump> for BumpString<'bump> {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StringVisitor<'a>(&'a bumpalo::Bump);
+
+        impl<'de, 'a> Visitor<'de> for StringVisitor<'a> {
+            type Value = BumpString<'a>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string for BumpString")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(BumpString::from_str_in(v, self.0))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(BumpString::from_str_in(&v, self.0))
+            }
+        }
+
+        deserializer.deserialize_string(StringVisitor(allocator))
+    }
+}
+
+// Implementation for &'bump str
+impl<'bump> ArenaDeserialize<'bump> for &'bump str {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StrVisitor<'a>(&'a bumpalo::Bump);
+
+        impl<'de, 'a> Visitor<'de> for StrVisitor<'a> {
+            type Value = &'a str;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string slice string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(self.0.alloc_str(v))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(self.0.alloc_str(&v))
+            }
+        }
+
+        deserializer.deserialize_str(StrVisitor(allocator))
+    }
+}
+
+// Implementation for &'bump [u8]
+impl<'bump> ArenaDeserialize<'bump> for &'bump [u8] {
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BytesVisitor<'a>(&'a bumpalo::Bump);
+
+        impl<'de, 'a> Visitor<'de> for BytesVisitor<'a> {
+            type Value = &'a [u8];
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("bytes")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(self.0.alloc_slice_copy(v))
+            }
+
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(self.0.alloc_slice_copy(&v))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut bytes = Vec::new();
+                while let Some(byte) = seq.next_element::<u8>()? {
+                    bytes.push(byte);
+                }
+                Ok(self.0.alloc_slice_copy(&bytes))
+            }
+        }
+
+        deserializer.deserialize_any(BytesVisitor(allocator))
+    }
+}
+
+// Implementation for bumpalo::collections::Vec
+impl<'bump, T> ArenaDeserialize<'bump> for BumpVec<'bump, T>
+where
+    T: ArenaDeserialize<'bump>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct VecVisitor<'a, T>(&'a bumpalo::Bump, PhantomData<T>);
+
+        impl<'de, 'a, T> Visitor<'de> for VecVisitor<'a, T>
+        where
+            T: ArenaDeserialize<'a> + 'a,
+        {
+            type Value = BumpVec<'a, T>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut vec = BumpVec::new_in(self.0);
+
+                while let Some(element) = seq.next_element_seed(ArenaSeed::new(self.0))? {
+                    vec.push(element);
+                }
+
+                Ok(vec)
+            }
+        }
+
+        deserializer.deserialize_seq(VecVisitor(allocator, PhantomData))
+    }
+}
+
+/// A generic deserializer seed for deserializing slices into bump-allocated memory.
+/// This is used by the derive macro to avoid generating duplicate code for each slice field.
+pub struct SliceDeserializer<'bump, T> {
+    allocator: &'bump bumpalo::Bump,
+    _phantom: PhantomData<T>,
+}
+
+impl<'bump, T> SliceDeserializer<'bump, T> {
+    /// Create a new SliceDeserializer with the given allocator.
+    pub fn new(allocator: &'bump bumpalo::Bump) -> Self {
+        Self {
+            allocator,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'de, 'bump, T> DeserializeSeed<'de> for SliceDeserializer<'bump, T>
+where
+    T: ArenaDeserialize<'bump> + 'bump,
+{
+    type Value = &'bump [T];
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SliceVisitor<'b, T> {
+            allocator: &'b bumpalo::Bump,
+            _phantom: PhantomData<T>,
+        }
+
+        impl<'de, 'b, T> Visitor<'de> for SliceVisitor<'b, T>
+        where
+            T: ArenaDeserialize<'b> + 'b,
+        {
+            type Value = &'b [T];
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut vec = BumpVec::new_in(self.allocator);
+
+                while let Some(element) =
+                    seq.next_element_seed(ArenaSeed::<T>::new(self.allocator))?
+                {
+                    vec.push(element);
+                }
+
+                Ok(vec.into_bump_slice())
+            }
+        }
+
+        deserializer.deserialize_seq(SliceVisitor {
+            allocator: self.allocator,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+// Implementation for tuples
+impl<'bump, A, B> ArenaDeserialize<'bump> for (A, B)
+where
+    A: ArenaDeserialize<'bump>,
+    B: ArenaDeserialize<'bump>,
+{
+    fn deserialize_in_arena<'de, D>(
+        deserializer: D,
+        allocator: &'bump bumpalo::Bump,
+    ) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TupleVisitor<'a, A, B>(&'a bumpalo::Bump, PhantomData<(A, B)>);
+
+        impl<'de, 'a, A, B> Visitor<'de> for TupleVisitor<'a, A, B>
+        where
+            A: ArenaDeserialize<'a>,
+            B: ArenaDeserialize<'a>,
+        {
+            type Value = (A, B);
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a tuple")
+            }
+
+            fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+            where
+                S: SeqAccess<'de>,
+            {
+                let first = seq
+                    .next_element_seed(ArenaSeed::new(self.0))?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let second = seq
+                    .next_element_seed(ArenaSeed::new(self.0))?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+                Ok((first, second))
+            }
+        }
+
+        deserializer.deserialize_tuple(2, TupleVisitor(allocator, PhantomData))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    // Provide arena_deserializer as an alias to crate for the derive macro in tests
+    use crate as arena_deserializer;
+
+    // Example custom deserializer function
+    fn deserialize_map_as_pair_seq<'de, 'bump, D>(
+        deserializer: D,
+        allocator: &'bump bumpalo::Bump,
+    ) -> Result<BumpVec<'bump, (u16, &'bump str)>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // This is a simplified version - in real implementation would parse map differently
+        // For demonstration, just return an empty vector
+        let _: serde::de::IgnoredAny = serde::Deserialize::deserialize(deserializer)?;
+        Ok(BumpVec::new_in(allocator))
+    }
+
+    #[derive(ArenaDeserialize)]
+    struct City<'bump> {
+        #[arena(alias = "n")]
+        name: bumpalo::collections::String<'bump>,
+        citizens: bumpalo::collections::Vec<'bump, Citizen<'bump>>,
+    }
+
+    #[derive(ArenaDeserialize)]
+    struct Citizen<'bump> {
+        first_name: &'bump str,
+        last_name: String, // Deserializing with global allocator
+        #[arena(default)] // Support for "default" field attribute
+        age: i16,
+        data: CitizenData<'bump>,
+        #[arena(deserialize_with = "deserialize_map_as_pair_seq")]
+        tags: bumpalo::collections::Vec<'bump, (u16, &'bump str)>,
+    }
+
+    #[derive(ArenaDeserialize)]
+    struct CitizenData<'bump>(&'bump [u8]);
+
+    #[test]
+    fn test_basic_struct_deserialization() {
+        let allocator = bumpalo::Bump::new();
+
+        let json = r#"{"first_name": "John", "last_name": "Doe", "age": 25, "data": [1, 2, 3], "tags": [[1, "tag1"], [2, "tag2"]]}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let citizen: Citizen =
+            Citizen::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(citizen.first_name, "John");
+        assert_eq!(citizen.last_name, "Doe");
+        assert_eq!(citizen.age, 25);
+        assert_eq!(citizen.data.0, &[1, 2, 3]);
+        assert_eq!(citizen.tags.len(), 0); // Empty tags array
+    }
+
+    #[test]
+    fn test_alias_support() {
+        let allocator = bumpalo::Bump::new();
+
+        let json = r#"{"n": "New York", "citizens": []}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let city: City = City::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(city.name.as_str(), "New York");
+    }
+
+    #[test]
+    fn test_default_field() {
+        let allocator = bumpalo::Bump::new();
+
+        let json = r#"{"first_name": "Jane", "last_name": "Smith", "data": [4, 5, 6], "tags": []}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let citizen: Citizen =
+            Citizen::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(citizen.first_name, "Jane");
+        assert_eq!(citizen.last_name, "Smith");
+        assert_eq!(citizen.age, 0); // Default value for i16
+        assert_eq!(citizen.data.0, &[4, 5, 6]);
+        assert_eq!(citizen.tags.len(), 0); // Empty tags array
+    }
+
+    #[test]
+    fn test_nested_structs() {
+        let allocator = bumpalo::Bump::new();
+
+        let json = r#"{
+            "name": "Boston",
+            "citizens": [
+                {"first_name": "Alice", "last_name": "Wonder", "age": 30, "data": [7, 8, 9], "tags": []},
+                {"first_name": "Bob", "last_name": "Builder", "data": [10, 11, 12], "tags": []}
+            ]
+        }"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let city: City = City::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(city.name.as_str(), "Boston");
+        assert_eq!(city.citizens.len(), 2);
+        assert_eq!(city.citizens[0].first_name, "Alice");
+        assert_eq!(city.citizens[0].age, 30);
+        assert_eq!(city.citizens[0].data.0, &[7, 8, 9]);
+        assert_eq!(city.citizens[0].tags.len(), 0);
+        assert_eq!(city.citizens[1].first_name, "Bob");
+        assert_eq!(city.citizens[1].age, 0); // Default value
+        assert_eq!(city.citizens[1].data.0, &[10, 11, 12]);
+        assert_eq!(city.citizens[1].tags.len(), 0);
+    }
+
+    #[test]
+    fn test_transparent_newtype() {
+        let allocator = bumpalo::Bump::new();
+
+        let json = r#"[1, 2, 3, 4, 5]"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let data: CitizenData =
+            CitizenData::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(data.0, &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_bumpalo_string() {
+        let allocator = bumpalo::Bump::new();
+
+        let json = r#""Hello, World!""#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let s: BumpString =
+            BumpString::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(s.as_str(), "Hello, World!");
+    }
+
+    #[test]
+    fn test_borrowed_str() {
+        let allocator = bumpalo::Bump::new();
+
+        let json = r#""Borrowed string""#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let s: &str = <&str>::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(s, "Borrowed string");
+    }
+
+    #[test]
+    fn test_bumpalo_vec() {
+        let allocator = bumpalo::Bump::new();
+
+        let json = r#"["one", "two", "three"]"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let v: BumpVec<&str> =
+            BumpVec::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[0], "one");
+        assert_eq!(v[1], "two");
+        assert_eq!(v[2], "three");
+    }
+
+    #[test]
+    fn test_generic_collections() {
+        let allocator = bumpalo::Bump::new();
+
+        // Test Vec<i32>
+        let json = r#"[1, 2, 3, 4, 5]"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let v: Vec<i32> = Vec::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(v, vec![1, 2, 3, 4, 5]);
+
+        // Test HashMap<String, i32>
+        let json = r#"{"a": 1, "b": 2, "c": 3}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let map: std::collections::HashMap<String, i32> =
+            std::collections::HashMap::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.get("a"), Some(&1));
+        assert_eq!(map.get("b"), Some(&2));
+        assert_eq!(map.get("c"), Some(&3));
+
+        // Test Option<String>
+        let json = r#""hello""#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let opt: Option<String> =
+            Option::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(opt, Some("hello".to_string()));
+
+        // Test None case
+        let json = r#"null"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let opt: Option<String> =
+            Option::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+        assert_eq!(opt, None);
+    }
+
+    #[test]
+    fn test_struct_with_generic_collections() {
+        let allocator = bumpalo::Bump::new();
+
+        #[derive(ArenaDeserialize)]
+        struct ComplexStruct<'bump> {
+            name: String,
+            scores: Vec<i32>,
+            metadata: std::collections::HashMap<String, String>,
+            arena_string: bumpalo::collections::String<'bump>,
+            optional_value: Option<i32>,
+        }
+
+        let json = r#"{
+            "name": "test",
+            "scores": [10, 20, 30],
+            "metadata": {"key1": "value1", "key2": "value2"},
+            "arena_string": "arena allocated",
+            "optional_value": 42
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+        let complex: ComplexStruct =
+            ComplexStruct::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(complex.name, "test");
+        assert_eq!(complex.scores, vec![10, 20, 30]);
+        assert_eq!(complex.metadata.len(), 2);
+        assert_eq!(complex.metadata.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(complex.metadata.get("key2"), Some(&"value2".to_string()));
+        assert_eq!(complex.arena_string.as_str(), "arena allocated");
+        assert_eq!(complex.optional_value, Some(42));
+    }
+
+    #[test]
+    fn test_owned_type_auto_forward() {
+        let allocator = bumpalo::Bump::new();
+
+        #[derive(ArenaDeserialize, serde::Deserialize, Debug, PartialEq)]
+        struct OwnedStruct {
+            id: u32,
+            name: String,
+            values: Vec<i32>,
+        }
+
+        let json = r#"{"id": 42, "name": "test", "values": [1, 2, 3]}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: OwnedStruct =
+            OwnedStruct::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.id, 42);
+        assert_eq!(result.name, "test");
+        assert_eq!(result.values, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_optional_fields_without_default() {
+        let allocator = bumpalo::Bump::new();
+
+        #[derive(ArenaDeserialize)]
+        struct StructWithOptionalFields<'bump> {
+            required_field: String,
+            optional_field1: Option<i32>,
+            optional_field2: Option<bumpalo::collections::String<'bump>>,
+            optional_field3: Option<Vec<String>>,
+        }
+
+        // Test with all optional fields present
+        let json_with_options = r#"{
+            "required_field": "required",
+            "optional_field1": 42,
+            "optional_field2": "arena string",
+            "optional_field3": ["item1", "item2"]
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json_with_options);
+        let result: StructWithOptionalFields =
+            StructWithOptionalFields::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.required_field, "required");
+        assert_eq!(result.optional_field1, Some(42));
+        assert_eq!(
+            result.optional_field2.as_ref().map(|s| s.as_str()),
+            Some("arena string")
+        );
+        assert_eq!(
+            result.optional_field3,
+            Some(vec!["item1".to_string(), "item2".to_string()])
+        );
+
+        // Test with optional fields missing (should be None)
+        let json_without_options = r#"{
+            "required_field": "required"
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json_without_options);
+        let result: StructWithOptionalFields =
+            StructWithOptionalFields::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.required_field, "required");
+        assert_eq!(result.optional_field1, None);
+        assert_eq!(result.optional_field2, None);
+        assert_eq!(result.optional_field3, None);
+
+        // Test with explicit null values
+        let json_with_nulls = r#"{
+            "required_field": "required",
+            "optional_field1": null,
+            "optional_field2": null,
+            "optional_field3": null
+        }"#;
+
+        let mut deserializer = serde_json::Deserializer::from_str(json_with_nulls);
+        let result: StructWithOptionalFields =
+            StructWithOptionalFields::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.required_field, "required");
+        assert_eq!(result.optional_field1, None);
+        assert_eq!(result.optional_field2, None);
+        assert_eq!(result.optional_field3, None);
+    }
+
+    #[test]
+    fn test_struct_with_custom_lifetime_a() {
+        let allocator = bumpalo::Bump::new();
+
+        #[derive(ArenaDeserialize)]
+        struct CustomLifetimeStruct<'a> {
+            data: &'a str,
+            items: bumpalo::collections::Vec<'a, i32>,
+        }
+
+        let json = r#"{"data": "hello", "items": [1, 2, 3]}"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: CustomLifetimeStruct =
+            CustomLifetimeStruct::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.data, "hello");
+        assert_eq!(result.items.len(), 3);
+        assert_eq!(result.items[0], 1);
+        assert_eq!(result.items[1], 2);
+        assert_eq!(result.items[2], 3);
+    }
+
+    /// Test nested structs with custom lifetime parameters
+    #[test]
+    fn test_nested_structs_with_custom_lifetimes() {
+        let allocator = bumpalo::Bump::new();
+
+        #[derive(ArenaDeserialize)]
+        struct Inner<'a> {
+            value: &'a str,
+            number: i32,
+        }
+
+        #[derive(ArenaDeserialize)]
+        struct Outer<'a> {
+            inner: Inner<'a>,
+            outer_data: &'a str,
+        }
+
+        let json = r#"{
+            "inner": {"value": "inner", "number": 42},
+            "outer_data": "outer"
+        }"#;
+        let mut deserializer = serde_json::Deserializer::from_str(json);
+
+        let result: Outer = Outer::deserialize_in_arena(&mut deserializer, &allocator).unwrap();
+
+        assert_eq!(result.inner.value, "inner");
+        assert_eq!(result.inner.number, 42);
+        assert_eq!(result.outer_data, "outer");
+    }
+}


### PR DESCRIPTION
Bumpalo serde extends serde's deserialization capabilities to work with bumpalo. It provides an ArenaDeserialize trait, which is similar to serde's Deserialize, but allocates data into a provided bump allocator instead of using the global heap allocator.

Bump allocators and deserialization are a natural fit:

- A single drop for the deserialized model, means that no matter how many strings a model may have, it will always be constant time to free the data.
- Bumpalo allows one to pre-allocate the capacity expected for deserialization
- Amortizes allocation costs of many fields that require allocations
- Minimizes the volatility of the system allocator. Especially well suited for Wasm where one may have minimal control of the underyling allocator.
- Allows for efficient views into the underlying data without requiring the entire input to be kept around unlike borrowed deserialization
- Less brittle in performance than serde's `deserialize_in_place`.

This crate is highly experimental and is not published on crates.io, but can be once stabilized.