### PR TITLE
Fix worker types and local dev server

### DIFF
--- a/src/app/app/features/ck3/worker/bridge.tsx
+++ b/src/app/app/features/ck3/worker/bridge.tsx
@@ -1,6 +1,4 @@
-import { expose, type Remote } from "comlink";
+import { expose } from "comlink";
 import * as Ck3Mod from "./module";
 
 expose(Ck3Mod);
-export type Ck3WorkerModule = typeof Ck3Mod;
-export type Ck3Worker = Remote<Ck3WorkerModule>;

--- a/src/app/app/features/ck3/worker/index.tsx
+++ b/src/app/app/features/ck3/worker/index.tsx
@@ -1,6 +1,6 @@
 import { wrap } from "comlink";
-import { type Ck3WorkerModule } from "./bridge";
-export { type Ck3Worker } from "./bridge";
+import { type Ck3WorkerModule } from "./types";
+export { type Ck3Worker } from "./types";
 
 function createWorker() {
   const rawWorker = new Worker(new URL("./bridge", import.meta.url), {

--- a/src/app/app/features/ck3/worker/types.ts
+++ b/src/app/app/features/ck3/worker/types.ts
@@ -1,4 +1,9 @@
+import type { Remote } from "comlink";
+
 export interface Ck3Metadata {
   version: string;
   isMeltable: boolean;
 }
+
+export type Ck3WorkerModule = typeof import("./module");
+export type Ck3Worker = Remote<Ck3WorkerModule>;

--- a/src/app/app/features/hoi4/hooks/useHoi4Worker.ts
+++ b/src/app/app/features/hoi4/hooks/useHoi4Worker.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { getErrorMessage } from "@/lib/getErrorMessage";
-import type { Hoi4Worker } from "../worker/bridge";
+import type { Hoi4Worker } from "../worker/types";
 import { getHoi4Worker } from "../worker";
 import { captureException } from "@/lib/captureException";
 

--- a/src/app/app/features/hoi4/worker/bridge.tsx
+++ b/src/app/app/features/hoi4/worker/bridge.tsx
@@ -1,6 +1,4 @@
-import { expose, type Remote } from "comlink";
+import { expose } from "comlink";
 import * as Hoi4Mod from "./module";
 
 expose(Hoi4Mod);
-export type Hoi4WorkerModule = typeof Hoi4Mod;
-export type Hoi4Worker = Remote<Hoi4WorkerModule>;

--- a/src/app/app/features/hoi4/worker/index.tsx
+++ b/src/app/app/features/hoi4/worker/index.tsx
@@ -1,5 +1,5 @@
 import { wrap } from "comlink";
-import type { Hoi4WorkerModule } from "./bridge";
+import type { Hoi4WorkerModule } from "./types";
 
 function createWorker() {
   const rawWorker = new Worker(new URL("./bridge", import.meta.url), {

--- a/src/app/app/features/hoi4/worker/types.ts
+++ b/src/app/app/features/hoi4/worker/types.ts
@@ -1,1 +1,5 @@
+import type { Remote } from "comlink";
+
 export type { Hoi4Metadata } from "@/wasm/wasm_hoi4";
+export type Hoi4WorkerModule = typeof import("./module");
+export type Hoi4Worker = Remote<Hoi4WorkerModule>;

--- a/src/app/app/features/imperator/worker/bridge.tsx
+++ b/src/app/app/features/imperator/worker/bridge.tsx
@@ -1,6 +1,4 @@
-import { expose, type Remote } from "comlink";
+import { expose } from "comlink";
 import * as ImperatorMod from "./module";
 
 expose(ImperatorMod);
-export type ImperatorWorkerModule = typeof ImperatorMod;
-export type ImperatorWorker = Remote<ImperatorWorkerModule>;

--- a/src/app/app/features/imperator/worker/index.tsx
+++ b/src/app/app/features/imperator/worker/index.tsx
@@ -1,6 +1,6 @@
 import { wrap } from "comlink";
-import { type ImperatorWorkerModule } from "./bridge";
-export { type ImperatorWorker } from "./bridge";
+import { type ImperatorWorkerModule } from "./types";
+export { type ImperatorWorker } from "./types";
 
 function createWorker() {
   const rawWorker = new Worker(new URL("./bridge", import.meta.url), {

--- a/src/app/app/features/imperator/worker/types.ts
+++ b/src/app/app/features/imperator/worker/types.ts
@@ -1,5 +1,10 @@
+import type { Remote } from "comlink";
+
 export interface ImperatorMetadata {
   date: string;
   version: string;
   isMeltable: boolean;
 }
+
+export type ImperatorWorkerModule = typeof import("./module");
+export type ImperatorWorker = Remote<ImperatorWorkerModule>;

--- a/src/app/app/features/vic3/worker/bridge.tsx
+++ b/src/app/app/features/vic3/worker/bridge.tsx
@@ -1,6 +1,4 @@
-import { expose, type Remote } from "comlink";
+import { expose } from "comlink";
 import * as Vic3Mod from "./module";
 
 expose(Vic3Mod);
-export type Vic3WorkerModule = typeof Vic3Mod;
-export type Vic3Worker = Remote<Vic3WorkerModule>;

--- a/src/app/app/features/vic3/worker/index.tsx
+++ b/src/app/app/features/vic3/worker/index.tsx
@@ -1,6 +1,6 @@
 import { wrap } from "comlink";
-import { type Vic3WorkerModule } from "./bridge";
-export { type Vic3Worker } from "./bridge";
+import { type Vic3WorkerModule } from "./types";
+export { type Vic3Worker } from "./types";
 
 function createWorker() {
   const rawWorker = new Worker(new URL("./bridge", import.meta.url), {

--- a/src/app/app/features/vic3/worker/types.ts
+++ b/src/app/app/features/vic3/worker/types.ts
@@ -1,1 +1,5 @@
+import type { Remote } from "comlink";
+
 export type * from "@/wasm/wasm_vic3";
+export type Vic3WorkerModule = typeof import("./module");
+export type Vic3Worker = Remote<Vic3WorkerModule>;

--- a/src/app/app/features/vic3/worker/useVic3Worker.ts
+++ b/src/app/app/features/vic3/worker/useVic3Worker.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import type { Vic3Worker } from "./bridge";
+import type { Vic3Worker } from "./types";
 import { getErrorMessage } from "@/lib/getErrorMessage";
 import { getVic3Worker } from ".";
 import { useVic3Meta } from "../store";


### PR DESCRIPTION
For some reason, the vite dev server update is borked by the worker type (it wanted to import comlink onto the server side rendering). Updating the other games to match EU4, fixed it.