### PR TITLE
Fix HMR dev server with consistent type imports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,20 @@
+{
+  "rules": {
+    // Consistent type imports is critical to avoid accidentally importing code
+    // referencing window in a web worker
+    "typescript/consistent-type-imports": ["error"]
+  },
+  "categories": {
+    "correctness": "error"
+  },
+  "plugins": [
+    "eslint",
+    "import",
+    "oxc",
+    "promise",
+    "react-perf",
+    "react",
+    "typescript",
+    "unicorn"
+  ]
+}

--- a/src/app/app/features/ck3/worker/types.ts
+++ b/src/app/app/features/ck3/worker/types.ts
@@ -1,9 +1,10 @@
 import type { Remote } from "comlink";
+import type * as Ck3WorkerModuleDefinition from "./module";
 
 export interface Ck3Metadata {
   version: string;
   isMeltable: boolean;
 }
 
-export type Ck3WorkerModule = typeof import("./module");
+export type Ck3WorkerModule = typeof Ck3WorkerModuleDefinition;
 export type Ck3Worker = Remote<Ck3WorkerModule>;

--- a/src/app/app/features/compress/compress-hooks.ts
+++ b/src/app/app/features/compress/compress-hooks.ts
@@ -1,8 +1,9 @@
 import { wrap, transfer, releaseProxy, proxy } from "comlink";
 import { useEffect, useMemo, useRef } from "react";
 import type { ProgressCb } from "./compress-worker";
+import type * as CompressWorkerModule from "./compress-worker";
 
-type CompressionWorker = typeof import("./compress-worker").obj;
+type CompressionWorker = typeof CompressWorkerModule.obj;
 export function createCompressionWorker() {
   const worker = new Worker(new URL("./compress-worker", import.meta.url), {
     type: "module",

--- a/src/app/app/features/eu4/features/charts/annual-ledger/AnnualLedger.tsx
+++ b/src/app/app/features/eu4/features/charts/annual-ledger/AnnualLedger.tsx
@@ -7,7 +7,7 @@ import {
 import { type LedgerDatum } from "@/features/eu4/types/models";
 import { createCsv } from "@/lib/csv";
 import { useCountryNameLookup } from "@/features/eu4/store";
-import { useLedgerData } from "./hooks";
+import type { useLedgerData } from "./hooks";
 import { Alert } from "@/components/Alert";
 import { isDarkMode } from "@/lib/dark";
 

--- a/src/app/app/features/eu4/features/map/resources.ts
+++ b/src/app/app/features/eu4/features/map/resources.ts
@@ -1,5 +1,6 @@
 import { gameVersion, resources } from "@/lib/game_gen";
-import { glContextOptions, WebGLMap } from "@pdx.tools/map";
+import type { WebGLMap } from "@pdx.tools/map";
+import { glContextOptions } from "@pdx.tools/map";
 import type { MapOnlyControls } from "../../types/map";
 import { fetchOk } from "@/lib/fetch";
 import mapVertex from "@pdx.tools/map/map.vert?url";

--- a/src/app/app/features/eu4/features/settings/TimelapseEncoder.tsx
+++ b/src/app/app/features/eu4/features/settings/TimelapseEncoder.tsx
@@ -7,7 +7,8 @@ import {
   EncodedPacket,
   type VideoCodec,
 } from "mediabunny";
-import { IMG_WIDTH, MapController, overlayDate } from "@pdx.tools/map";
+import type { MapController } from "@pdx.tools/map";
+import { IMG_WIDTH, overlayDate } from "@pdx.tools/map";
 import { type Eu4Worker, getEu4Worker } from "../../worker";
 import { type Eu4Store } from "../../store";
 import { log } from "@/lib/log";

--- a/src/app/app/features/eu4/store/eu4Store.tsx
+++ b/src/app/app/features/eu4/store/eu4Store.tsx
@@ -1,6 +1,6 @@
 import { compatibilityReport } from "@/lib/compatibility";
 import { check } from "@/lib/isPresent";
-import { MapController } from "@pdx.tools/map";
+import type { MapController } from "@pdx.tools/map";
 import { pdxApi } from "@/services/appApi";
 import { createContext, useContext, useMemo } from "react";
 import { type StoreApi, createStore, useStore } from "zustand";

--- a/src/app/app/features/eu4/worker/init.ts
+++ b/src/app/app/features/eu4/worker/init.ts
@@ -1,9 +1,9 @@
 import { timeSync } from "@/lib/timeit";
 import type { AchievementsScore } from "../types/models";
 import { wasm } from "./common";
-import * as mod from "@/wasm/wasm_eu4";
+import type * as mod from "@/wasm/wasm_eu4";
 import { fetchOk } from "@/lib/fetch";
-import { type Eu4SaveInput } from "../store";
+import type { Eu4SaveInput } from "../store";
 import { logMs } from "@/lib/log";
 import { captureException } from "@/lib/captureException";
 

--- a/src/app/app/features/eu4/worker/types.ts
+++ b/src/app/app/features/eu4/worker/types.ts
@@ -1,4 +1,5 @@
 import type { Remote } from "comlink";
+import type * as Eu4WorkerModuleDefinition from "./module";
 
-export type Eu4WorkerModule = typeof import("./module");
+export type Eu4WorkerModule = typeof Eu4WorkerModuleDefinition;
 export type Eu4Worker = Remote<Eu4WorkerModule>;

--- a/src/app/app/features/hoi4/worker/types.ts
+++ b/src/app/app/features/hoi4/worker/types.ts
@@ -1,5 +1,6 @@
 import type { Remote } from "comlink";
+import type * as Hoi4WorkerModuleDefinition from "./module";
 
 export type { Hoi4Metadata } from "@/wasm/wasm_hoi4";
-export type Hoi4WorkerModule = typeof import("./module");
+export type Hoi4WorkerModule = typeof Hoi4WorkerModuleDefinition;
 export type Hoi4Worker = Remote<Hoi4WorkerModule>;

--- a/src/app/app/features/imperator/worker/types.ts
+++ b/src/app/app/features/imperator/worker/types.ts
@@ -1,4 +1,5 @@
 import type { Remote } from "comlink";
+import type * as ImperatorWorkerModuleDefinition from "./module";
 
 export interface ImperatorMetadata {
   date: string;
@@ -6,5 +7,5 @@ export interface ImperatorMetadata {
   isMeltable: boolean;
 }
 
-export type ImperatorWorkerModule = typeof import("./module");
+export type ImperatorWorkerModule = typeof ImperatorWorkerModuleDefinition;
 export type ImperatorWorker = Remote<ImperatorWorkerModule>;

--- a/src/app/app/features/vic3/worker/types.ts
+++ b/src/app/app/features/vic3/worker/types.ts
@@ -1,5 +1,6 @@
 import type { Remote } from "comlink";
+import type * as Vic3WorkerModuleDefinition from "./module";
 
 export type * from "@/wasm/wasm_vic3";
-export type Vic3WorkerModule = typeof import("./module");
+export type Vic3WorkerModule = typeof Vic3WorkerModuleDefinition;
 export type Vic3Worker = Remote<Vic3WorkerModule>;

--- a/src/app/app/server-lib/og.ts
+++ b/src/app/app/server-lib/og.ts
@@ -1,7 +1,7 @@
 import { fetchOk } from "@/lib/fetch";
 import { log } from "./logging";
 import { timeit } from "@/lib/timeit";
-import { pdxS3 } from "./s3";
+import type { pdxS3 } from "./s3";
 import type { AppLoadContext } from "@remix-run/server-runtime";
 import { pdxFns } from "./functions";
 

--- a/src/app/app/services/appApi.ts
+++ b/src/app/app/services/appApi.ts
@@ -1,6 +1,6 @@
 import { fetchOk, fetchOkJson, sendJson } from "@/lib/fetch";
+import type { QueryClient } from "@tanstack/react-query";
 import {
-  QueryClient,
   useMutation,
   useQuery,
   useQueryClient,

--- a/src/map/src/MapShader.ts
+++ b/src/map/src/MapShader.ts
@@ -1,4 +1,4 @@
-import { GLResources } from "./glResources";
+import type { GLResources } from "./glResources";
 
 export class MapShader {
   private constructor(

--- a/src/map/src/XbrShader.ts
+++ b/src/map/src/XbrShader.ts
@@ -1,4 +1,4 @@
-import { GLResources } from "./glResources";
+import type { GLResources } from "./glResources";
 import { notNull } from "./nullcheck";
 
 export class XbrShader {

--- a/src/map/src/glResources.ts
+++ b/src/map/src/glResources.ts
@@ -1,6 +1,6 @@
 import type { StaticResources, TerrainOverlayResources } from "./types";
-import { MapShader } from "./MapShader";
-import { XbrShader } from "./XbrShader";
+import type { MapShader } from "./MapShader";
+import type { XbrShader } from "./XbrShader";
 import {
   IMG_WIDTH,
   IMG_HEIGHT,

--- a/src/map/src/map-worker-types.ts
+++ b/src/map/src/map-worker-types.ts
@@ -1,1 +1,3 @@
-export type MapWorker = typeof import("./map-worker");
+import type * as MapWorkerModule from "./map-worker";
+
+export type MapWorker = typeof MapWorkerModule;

--- a/src/map/src/map.ts
+++ b/src/map/src/map.ts
@@ -1,5 +1,6 @@
-import { GLResources, setupFramebufferTexture } from "./glResources";
-import { ProvinceFinder } from "./ProvinceFinder";
+import type { GLResources } from "./glResources";
+import { setupFramebufferTexture } from "./glResources";
+import type { ProvinceFinder } from "./ProvinceFinder";
 import type { TerrainOverlayResources } from "./types";
 
 export const IMG_HEIGHT = 2048;

--- a/src/pdx-map-playground/src/MapPlayground.ts
+++ b/src/pdx-map-playground/src/MapPlayground.ts
@@ -1,8 +1,9 @@
 import { wrap, type Remote, transfer } from "comlink";
-import { createMapEngine } from "./workers/map/map-module";
+import type { createMapEngine } from "./workers/map/map-module";
+import type * as PdxMapWorkerModuleDefinition from "./workers/map/map-module";
 import "./styles.css";
 
-export type PdxMapWorkerModule = typeof import("./workers/map/map-module");
+export type PdxMapWorkerModule = typeof PdxMapWorkerModuleDefinition;
 export type PdxMapWorker = Remote<PdxMapWorkerModule>;
 export type MapEngine = Remote<Awaited<ReturnType<typeof createMapEngine>>>;
 


### PR DESCRIPTION
Using `verbatimModuleSyntax` wasn't erasing some type imports, which was causing the dev HMR server to fail.

I don't want to debug this issue again, so enforcing consistent type imports via oxlint.