### PR TITLE
Update time function to log performance

### DIFF
--- a/src/app/app/features/ck3/Ck3Ui.tsx
+++ b/src/app/app/features/ck3/Ck3Ui.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useReducer } from "react";
-import { logMs } from "@/lib/log";
-import { timeit } from "@/lib/timeit";
+import { timeAsync } from "@/lib/timeit";
 import { getCk3Worker } from "./worker";
 import { MeltButton } from "@/components/MeltButton";
 import type { Ck3Metadata } from "./worker/types";
@@ -21,10 +20,7 @@ type Task<T> = {
 async function loadCk3Save(file: File, signal: AbortSignal) {
   const run = async <T,>({ fn, name }: Task<T>) => {
     signal.throwIfAborted();
-    const result = await timeit(fn).then((res) => {
-      logMs(res, name);
-      return res.data;
-    });
+    const result = await timeAsync(name, fn);
     signal.throwIfAborted();
     return result;
   };

--- a/src/app/app/features/engine/GameView.tsx
+++ b/src/app/app/features/engine/GameView.tsx
@@ -10,18 +10,17 @@ import type Ck3Ui from "@/features/ck3/Ck3Ui";
 import type Hoi4Ui from "@/features/hoi4/Hoi4Ui";
 import type ImperatorUi from "@/features/imperator/ImperatorUi";
 import type Vic3Ui from "@/features/vic3/vic3Ui";
-import { timeit } from "@/lib/timeit";
-import { logMs } from "@/lib/log";
+import { timeAsync } from "@/lib/timeit";
 import { useWindowMessageDrop } from "./hooks/useWindowMessageDrop";
 
 function timeModule<T>(fn: () => Promise<T>, module: string): () => Promise<T> {
-  return () =>
-    timeit(fn).then((x) => {
-      if (typeof window !== "undefined") {
-        logMs(x, `load ${module} module`);
-      }
-      return x.data;
-    });
+  return () => {
+    if (typeof window === "undefined") {
+      return fn();
+    }
+
+    return timeAsync(`load ${module} module`, fn);
+  };
 }
 
 const DynamicEu4: ComponentType<ComponentProps<typeof Eu4Ui>> = lazy(

--- a/src/app/app/features/eu4/features/upload/hooks.tsx
+++ b/src/app/app/features/eu4/features/upload/hooks.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { getEu4Worker } from "../../worker";
 import { useSaveFilename } from "../../store";
 import { pdxApi } from "@/services/appApi";
 
@@ -21,7 +20,6 @@ export const useFileUpload = () => {
       upload: (values: UploadFormValues) =>
         addEndpoint.mutate(
           {
-            worker: getEu4Worker(),
             dispatch: (x) => setProgress(x.progress),
             values: {
               ...values,

--- a/src/app/app/features/eu4/store/useLoadEu4.tsx
+++ b/src/app/app/features/eu4/store/useLoadEu4.tsx
@@ -1,9 +1,9 @@
 import { transfer, wrap } from "comlink";
 import { useIsomorphicLayoutEffect } from "@/hooks/useIsomorphicLayoutEffect";
 import { fetchOk } from "@/lib/fetch";
-import { log, logMs } from "@/lib/log";
+import { log } from "@/lib/log";
 import { emitEvent } from "@/lib/events";
-import { timeit } from "@/lib/timeit";
+import { timeAsync } from "@/lib/timeit";
 import { MapController, createMapWorker } from "@pdx.tools/map";
 import type { MapWorker, InitToken } from "@pdx.tools/map";
 import { useRef, useEffect, useReducer } from "react";
@@ -93,10 +93,9 @@ function runTask<T>(
   dispatch: Dispatch<Eu4LoadActions>,
   { fn, name, progress }: Task<T>,
 ) {
-  return timeit(fn).then((res) => {
-    logMs(res, name);
+  return timeAsync(name, fn).then((result) => {
     dispatch({ kind: "progress", value: progress });
-    return res.data;
+    return result;
   });
 }
 

--- a/src/app/app/features/eu4/worker/module.ts
+++ b/src/app/app/features/eu4/worker/module.ts
@@ -28,7 +28,6 @@ import type {
   Wars,
 } from "@/wasm/wasm_eu4";
 import { timeSync } from "@/lib/timeit";
-import { logMs } from "@/lib/log";
 import { createBudget } from "../features/country-details/budget";
 export * from "./init";
 
@@ -180,9 +179,9 @@ export function eu4GetCountrymana(tag: string) {
 }
 
 export function eu4GetCountryHistory(tag: string) {
-  const timed = timeSync(() => wasm.save.get_country_history(tag));
-  logMs(timed, "country history calculation");
-  return timed.data;
+  return timeSync("country history calculation", () =>
+    wasm.save.get_country_history(tag),
+  );
 }
 
 export function eu4GetCountryInstitutionPush(
@@ -191,7 +190,7 @@ export function eu4GetCountryInstitutionPush(
   expandInfrastructureCost: number,
   overrides: Map<number, number>,
 ) {
-  const timed = timeSync(() =>
+  return timeSync("country institution push calculation", () =>
     wasm.save.get_country_institutions(
       tag,
       countryDevelopmentModifier,
@@ -199,8 +198,6 @@ export function eu4GetCountryInstitutionPush(
       overrides,
     ),
   );
-  logMs(timed, "country institution push calculation");
-  return timed.data;
 }
 
 export function eu4GetCountryProvinceCulture(tag: string): CountryCulture[] {

--- a/src/app/app/features/hoi4/store/useLoadHoi4.ts
+++ b/src/app/app/features/hoi4/store/useLoadHoi4.ts
@@ -2,8 +2,7 @@ import { createHoi4Store } from "./hoi4Store";
 import type { Hoi4Store } from "./hoi4Store";
 import { useEffect, useReducer } from "react";
 import { pdxAbortController } from "@/lib/abortController";
-import { timeit } from "@/lib/timeit";
-import { logMs } from "@/lib/log";
+import { timeAsync } from "@/lib/timeit";
 import { getHoi4Worker } from "../worker";
 import { emitEvent } from "@/lib/events";
 import { captureException } from "@/lib/captureException";
@@ -89,10 +88,7 @@ export function useLoadHoi4(input: File) {
 async function loadHoi4Save(file: File, signal: AbortSignal) {
   const run = async <T>({ fn, name }: Task<T>) => {
     signal.throwIfAborted();
-    const result = await timeit(fn).then((res) => {
-      logMs(res, name);
-      return res.data;
-    });
+    const result = await timeAsync(name, fn);
     signal.throwIfAborted();
     return result;
   };

--- a/src/app/app/features/imperator/ImperatorUi.tsx
+++ b/src/app/app/features/imperator/ImperatorUi.tsx
@@ -1,6 +1,5 @@
 import { useReducer, useEffect } from "react";
-import { logMs } from "@/lib/log";
-import { timeit } from "@/lib/timeit";
+import { timeAsync } from "@/lib/timeit";
 import { getImperatorWorker } from "./worker";
 import { MeltButton } from "@/components/MeltButton";
 import type { ImperatorMetadata } from "./worker/types";
@@ -46,10 +45,7 @@ type Task<T> = {
 async function loadImperatorSave(file: File, signal: AbortSignal) {
   const run = async <T,>({ fn, name }: Task<T>) => {
     signal.throwIfAborted();
-    const result = await timeit(fn).then((res) => {
-      logMs(res, name);
-      return res.data;
-    });
+    const result = await timeAsync(name, fn);
     signal.throwIfAborted();
     return result;
   };

--- a/src/app/app/features/vic3/store/useLoadVic3.ts
+++ b/src/app/app/features/vic3/store/useLoadVic3.ts
@@ -1,6 +1,5 @@
-import { logMs } from "@/lib/log";
 import { emitEvent } from "@/lib/events";
-import { timeit } from "@/lib/timeit";
+import { timeAsync } from "@/lib/timeit";
 import { getVic3Worker } from "../worker";
 import { useEffect, useReducer } from "react";
 import { pdxAbortController } from "@/lib/abortController";
@@ -20,10 +19,7 @@ type Task<T> = {
 async function loadVic3Save(save: Vic3SaveInput, signal: AbortSignal) {
   const run = async <T>({ fn, name }: Task<T>) => {
     signal.throwIfAborted();
-    const result = await timeit(fn).then((res) => {
-      logMs(res, name);
-      return res.data;
-    });
+    const result = await timeAsync(name, fn);
     signal.throwIfAborted();
     return result;
   };

--- a/src/app/app/lib/log.ts
+++ b/src/app/app/lib/log.ts
@@ -1,16 +1,7 @@
 import { getIsDeveloper } from "@/lib/isDeveloper";
-import { formatInt } from "./format";
 
 export function log(...data: unknown[]) {
   console.log(`${new Date().toISOString()}:`, ...data);
-}
-
-export function logMs(
-  { elapsedMs }: { elapsedMs: number },
-  ...data: unknown[]
-) {
-  const ms = formatInt(elapsedMs).padStart(5, " ");
-  log(`[${ms}ms]`, ...data);
 }
 
 let cachedDeveloper: boolean | undefined;

--- a/src/app/app/lib/timeit.ts
+++ b/src/app/app/lib/timeit.ts
@@ -1,3 +1,6 @@
+import { formatInt } from "./format";
+import { log } from "./log";
+
 export async function timeit<T>(fn: () => T | Promise<T>) {
   const start = performance.now();
   const result = await Promise.resolve(fn());
@@ -5,9 +8,29 @@ export async function timeit<T>(fn: () => T | Promise<T>) {
   return { data: result, elapsedMs: end - start };
 }
 
-export function timeSync<T>(fn: () => T) {
+type TimeLabel<T> = string | ((result: T) => string);
+
+export function timeSync<T>(label: TimeLabel<T>, fn: () => T) {
   const start = performance.now();
   const result = fn();
   const end = performance.now();
-  return { data: result, elapsedMs: end - start };
+  logDuration(label, result, end - start);
+  return result;
+}
+
+export async function timeAsync<T>(
+  label: TimeLabel<T>,
+  fn: () => T | Promise<T>,
+) {
+  const start = performance.now();
+  const result = await Promise.resolve(fn());
+  const end = performance.now();
+  logDuration(label, result, end - start);
+  return result;
+}
+
+function logDuration<T>(label: TimeLabel<T>, result: T, elapsedMs: number) {
+  const resolvedLabel = typeof label === "function" ? label(result) : label;
+  const ms = formatInt(elapsedMs).padStart(5, " ");
+  log(`[${ms}ms] ${resolvedLabel}`);
 }

--- a/src/app/app/lib/wasm.ts
+++ b/src/app/app/lib/wasm.ts
@@ -1,8 +1,7 @@
 import { fetchOk } from "@/lib/fetch";
 import { check } from "@/lib/isPresent";
 import { transfer } from "comlink";
-import { timeit } from "./timeit";
-import { logMs } from "./log";
+import { timeAsync } from "./timeit";
 
 type Allocated = {
   free(): void;
@@ -115,17 +114,17 @@ export function createWasmGame<
       }
 
       async function poll() {
-        const file = await timeit(() => handle.getFile());
-        logMs(file, "poll file");
-        if (file.data.lastModified <= lastModified) {
+        const file = await timeAsync("poll file", () => handle.getFile());
+        if (file.lastModified <= lastModified) {
           return;
         }
 
-        lastModified = file.data.lastModified;
+        lastModified = file.lastModified;
         stashed = { kind: "handle", file: handle, lastModified };
-        const bytes = await timeit(() => file.data.arrayBuffer());
-        logMs(bytes, "read polled file");
-        await callback(new Uint8Array(bytes.data));
+        const bytes = await timeAsync("read polled file", () =>
+          file.arrayBuffer(),
+        );
+        await callback(new Uint8Array(bytes));
       }
 
       intervalCheck();

--- a/src/app/app/services/appApi.ts
+++ b/src/app/app/services/appApi.ts
@@ -8,7 +8,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import type { Achievement, Difficulty } from "@/wasm/wasm_app";
-import type { Eu4Worker } from "@/features/eu4/worker";
+import { getEu4Worker } from "@/features/eu4/worker";
 import type { SavePostResponse, UploadMetadaInput } from "@/server-lib/models";
 import { createCompressionWorker } from "@/features/compress";
 import type { PdxSession } from "@/server-lib/auth/session";
@@ -116,12 +116,10 @@ export const pdxApi = {
       return useMutation({
         onSuccess: invalidateSaves(queryClient),
         mutationFn: async ({
-          worker,
           dispatch,
           values,
           signal,
         }: {
-          worker: Eu4Worker;
           dispatch: (arg: { kind: "progress"; progress: number }) => void;
           values: { aar?: string; filename: string };
           signal?: AbortSignal;
@@ -132,6 +130,7 @@ export const pdxApi = {
             const data = new FormData();
             dispatch({ kind: "progress", progress: 5 });
 
+            const worker = getEu4Worker();
             const rawFileData = await worker.getRawData();
             dispatch({ kind: "progress", progress: 10 });
 


### PR DESCRIPTION
Instead of needing to call a separate function logMs.

This PR also fixes a react issue where the comlink worker was passed as an argument to tanstack query and it was causing a react error.