### PR TITLE
Remove `@react-router/cloudflare` dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,12 +99,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.2.8
         version: 1.2.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-router/cloudflare':
-        specifier: 7.9.4
-        version: 7.9.4(@cloudflare/workers-types@4.20241112.0)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
       '@sentry/cloudflare':
         specifier: 10.20.0
-        version: 10.20.0(@cloudflare/workers-types@4.20241112.0)
+        version: 10.20.0
       '@sentry/react-router':
         specifier: 10.20.0
         version: 10.20.0(@react-router/node@7.9.4(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
@@ -149,7 +146,7 @@ importers:
         version: 1.11.13
       drizzle-orm:
         specifier: 0.44.6
-        version: 0.44.6(@cloudflare/workers-types@4.20241112.0)(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(postgres@3.4.5)
+        version: 0.44.6(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(postgres@3.4.5)
       mediabunny:
         specifier: 1.23.0
         version: 1.23.0
@@ -185,14 +182,14 @@ importers:
         version: 5.0.2(@types/react@19.2.2)(immer@9.0.21)(react@19.2.0)(use-sync-external-store@1.5.0(react@19.2.0))
     devDependencies:
       '@cloudflare/vite-plugin':
-        specifier: ^1.13.13
-        version: 1.13.13(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(workerd@1.20251008.0)(wrangler@4.43.0(@cloudflare/workers-types@4.20241112.0))
+        specifier: 1.13.13
+        version: 1.13.13(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(workerd@1.20251008.0)(wrangler@4.43.0)
       '@react-router/dev':
         specifier: 7.9.4
-        version: 7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0(@cloudflare/workers-types@4.20241112.0))(yaml@2.8.0)
+        version: 7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0)(yaml@2.8.0)
       '@react-router/fs-routes':
         specifier: 7.9.4
-        version: 7.9.4(@react-router/dev@7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0(@cloudflare/workers-types@4.20241112.0))(yaml@2.8.0))(typescript@5.9.3)
+        version: 7.9.4(@react-router/dev@7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0)(yaml@2.8.0))(typescript@5.9.3)
       '@tailwindcss/vite':
         specifier: 4.1.14
         version: 4.1.14(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))
@@ -243,7 +240,7 @@ importers:
         version: 3.1.3(@types/debug@4.1.12)(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0)
       wrangler:
         specifier: 'catalog:'
-        version: 4.43.0(@cloudflare/workers-types@4.20241112.0)
+        version: 4.43.0
 
   src/docs:
     dependencies:
@@ -2806,17 +2803,6 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
-
-  '@react-router/cloudflare@7.9.4':
-    resolution: {integrity: sha512-vzmJVkElVuy9SR1S7gIpACAzpZ4lw+8v3oEUvDgbBaQkRc61dRLCbZozd/040aBJCGlnvJp2RyzNDnYvnTRP/w==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@cloudflare/workers-types': ^4.0.0
-      react-router: ^7.9.4
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@react-router/dev@7.9.4':
     resolution: {integrity: sha512-bLs6DjKMJExT7Y57EBx25hkeGGUla3pURxvOn15IN8Mmaw2+euDtBUX9+OFrAPsAzD1xIj6+2HNLXlFH/LB86Q==}
@@ -9664,7 +9650,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20251008.0
 
-  '@cloudflare/vite-plugin@1.13.13(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(workerd@1.20251008.0)(wrangler@4.43.0(@cloudflare/workers-types@4.20241112.0))':
+  '@cloudflare/vite-plugin@1.13.13(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(workerd@1.20251008.0)(wrangler@4.43.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20251008.0)
       '@remix-run/node-fetch-server': 0.8.1
@@ -9674,7 +9660,7 @@ snapshots:
       tinyglobby: 0.2.15
       unenv: 2.0.0-rc.21
       vite: 6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0)
-      wrangler: 4.43.0(@cloudflare/workers-types@4.20241112.0)
+      wrangler: 4.43.0
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -9696,7 +9682,8 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20251008.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20241112.0': {}
+  '@cloudflare/workers-types@4.20241112.0':
+    optional: true
 
   '@colors/colors@1.5.0':
     optional: true
@@ -11960,14 +11947,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-router/cloudflare@7.9.4(@cloudflare/workers-types@4.20241112.0)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)':
-    dependencies:
-      '@cloudflare/workers-types': 4.20241112.0
-      react-router: 7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-    optionalDependencies:
-      typescript: 5.9.3
-
-  '@react-router/dev@7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0(@cloudflare/workers-types@4.20241112.0))(yaml@2.8.0)':
+  '@react-router/dev@7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0)(yaml@2.8.0)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/generator': 7.28.3
@@ -12000,7 +11980,7 @@ snapshots:
       vite-node: 3.2.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0)
     optionalDependencies:
       typescript: 5.9.3
-      wrangler: 4.43.0(@cloudflare/workers-types@4.20241112.0)
+      wrangler: 4.43.0
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12017,9 +11997,9 @@ snapshots:
       - tsx
       - yaml
 
-  '@react-router/fs-routes@7.9.4(@react-router/dev@7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0(@cloudflare/workers-types@4.20241112.0))(yaml@2.8.0))(typescript@5.9.3)':
+  '@react-router/fs-routes@7.9.4(@react-router/dev@7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0)(yaml@2.8.0))(typescript@5.9.3)':
     dependencies:
-      '@react-router/dev': 7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0(@cloudflare/workers-types@4.20241112.0))(yaml@2.8.0)
+      '@react-router/dev': 7.9.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(terser@5.39.2)(typescript@5.9.3)(vite@6.4.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(wrangler@4.43.0)(yaml@2.8.0)
       minimatch: 9.0.5
     optionalDependencies:
       typescript: 5.9.3
@@ -12181,12 +12161,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/cloudflare@10.20.0(@cloudflare/workers-types@4.20241112.0)':
+  '@sentry/cloudflare@10.20.0':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@sentry/core': 10.20.0
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20241112.0
 
   '@sentry/core@10.20.0': {}
 
@@ -13920,9 +13898,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.6(@cloudflare/workers-types@4.20241112.0)(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(postgres@3.4.5):
+  drizzle-orm@0.44.6(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(postgres@3.4.5):
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20241112.0
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.15.5
       postgres: 3.4.5
@@ -18457,6 +18434,22 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20251008.0
       '@cloudflare/workerd-linux-arm64': 1.20251008.0
       '@cloudflare/workerd-windows-64': 1.20251008.0
+
+  wrangler@4.43.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.0
+      '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20251008.0)
+      blake3-wasm: 2.1.5
+      esbuild: 0.25.4
+      miniflare: 4.20251008.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.21
+      workerd: 1.20251008.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   wrangler@4.43.0(@cloudflare/workers-types@4.20241112.0):
     dependencies:

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -31,7 +31,6 @@
     "@radix-ui/react-tabs": "1.1.13",
     "@radix-ui/react-toggle-group": "1.1.11",
     "@radix-ui/react-tooltip": "1.2.8",
-    "@react-router/cloudflare": "7.9.4",
     "@sentry/cloudflare": "10.20.0",
     "@sentry/react-router": "10.20.0",
     "@sentry/vite-plugin": "4.4.0",
@@ -61,7 +60,7 @@
     "zustand": "5.0.2"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "^1.13.13",
+    "@cloudflare/vite-plugin": "1.13.13",
     "@react-router/dev": "7.9.4",
     "@react-router/fs-routes": "7.9.4",
     "@tailwindcss/vite": "4.1.14",


### PR DESCRIPTION
It was giving warnings about an unmet peer dependency of cloudflare types, but it turns out I don't think the dependency is even referenced anywhere.