### PR TITLE
Remove js import cycles

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,7 +3,8 @@
     // Consistent type imports is critical to avoid accidentally importing code
     // referencing window in a web worker
     "typescript/consistent-type-imports": "error",
-    "import/consistent-type-specifier-style": "error"
+    "import/consistent-type-specifier-style": "error",
+    "import/no-cycle": "error"
   },
   "categories": {
     "correctness": "error"

--- a/src/app/app/components/viz/Pie.tsx
+++ b/src/app/app/components/viz/Pie.tsx
@@ -1,0 +1,15 @@
+import React, { lazy, Suspense } from "react";
+import type { ComponentType } from "react";
+import type { PieConfig } from "@ant-design/plots";
+
+const LazyPie = lazy(() =>
+  import("@ant-design/plots").then((mod) => ({ default: mod.Pie })),
+);
+
+export const Pie: ComponentType<PieConfig> = React.memo((props) => (
+  <Suspense fallback={null}>
+    <LazyPie {...props} />
+  </Suspense>
+));
+
+export type { PieConfig };

--- a/src/app/app/components/viz/PieTable.tsx
+++ b/src/app/app/components/viz/PieTable.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from "react";
 import { formatFloat, formatInt } from "@/lib/format";
-import { LegendColor, Pie } from "@/components/viz";
-import type { PieConfig } from "@/components/viz";
+import { LegendColor } from "./LegendColor";
+import { Pie } from "./Pie";
+import type { PieConfig } from "./Pie";
 import { createColumnHelper } from "@tanstack/react-table";
 import { Table } from "@/components/Table";
 import { DataTable } from "@/components/DataTable";

--- a/src/app/app/components/viz/index.tsx
+++ b/src/app/app/components/viz/index.tsx
@@ -2,7 +2,6 @@ import React, { lazy, Suspense } from "react";
 import type { ComponentType } from "react";
 import type {
   LineConfig as LineConfigImpl,
-  PieConfig,
   BarConfig,
   Treemap as TreemapImpl,
   ScatterConfig,
@@ -29,15 +28,7 @@ export const Line = React.memo(({ ...props }: LineConfig) => (
   </Suspense>
 ));
 
-const LazyPie = lazy(() =>
-  import("@ant-design/plots").then((mod) => ({ default: mod.Pie })),
-);
-
-export const Pie: ComponentType<PieConfig> = React.memo((props) => (
-  <Suspense fallback={null}>
-    <LazyPie {...props} />
-  </Suspense>
-));
+export { Pie, type PieConfig } from "./Pie";
 
 const LazyBar = lazy(() =>
   import("@ant-design/plots").then((mod) => ({ default: mod.Bar })),
@@ -78,4 +69,4 @@ export {
 export * from "./LegendColor";
 export * from "./PieTable";
 
-export type { LineConfig, PieConfig, BarConfig, ScatterConfig };
+export type { LineConfig, BarConfig, ScatterConfig };

--- a/src/app/app/features/eu4/store/eu4Store.tsx
+++ b/src/app/app/features/eu4/store/eu4Store.tsx
@@ -14,7 +14,7 @@ import type {
   MapDate,
   CountryTag,
 } from "../types/models";
-import { getEu4Worker } from "../worker";
+import { getEu4Worker } from "../worker/getEu4Worker";
 import type {
   EnhancedMeta,
   FileObservationFrequency,

--- a/src/app/app/features/eu4/store/useLoadEu4.tsx
+++ b/src/app/app/features/eu4/store/useLoadEu4.tsx
@@ -13,7 +13,7 @@ import {
   fetchProvinceUniqueIndex,
   resourceUrls,
 } from "../features/map/resources";
-import { getEu4Worker } from "../worker";
+import { getEu4Worker } from "../worker/getEu4Worker";
 import {
   initialEu4CountryFilter,
   createEu4Store,

--- a/src/app/app/features/eu4/worker/getEu4Worker.ts
+++ b/src/app/app/features/eu4/worker/getEu4Worker.ts
@@ -1,0 +1,14 @@
+import { wrap } from "comlink";
+import type { Eu4Worker, Eu4WorkerModule } from "./types";
+
+function createWorker(): Eu4Worker {
+  const rawWorker = new Worker(new URL("./bridge", import.meta.url), {
+    type: "module",
+  });
+  return wrap<Eu4WorkerModule>(rawWorker);
+}
+
+let worker: undefined | Eu4Worker;
+export function getEu4Worker() {
+  return (worker ??= createWorker());
+}

--- a/src/app/app/features/eu4/worker/index.tsx
+++ b/src/app/app/features/eu4/worker/index.tsx
@@ -1,18 +1,5 @@
-import { wrap } from "comlink";
 export { useEu4Worker } from "./useEu4Worker";
 export { useAnalysisWorker } from "./useAnalysisWorker";
 export { type FileObservationFrequency } from "./init";
-import type { Eu4Worker, Eu4WorkerModule } from "./types";
 export * from "./types";
-
-function createWorker(): Eu4Worker {
-  const rawWorker = new Worker(new URL("./bridge", import.meta.url), {
-    type: "module",
-  });
-  return wrap<Eu4WorkerModule>(rawWorker);
-}
-
-let worker: undefined | Eu4Worker;
-export function getEu4Worker() {
-  return (worker ??= createWorker());
-}
+export { getEu4Worker } from "./getEu4Worker";

--- a/src/app/app/features/eu4/worker/useEu4Worker.ts
+++ b/src/app/app/features/eu4/worker/useEu4Worker.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { getEu4Worker } from "@/features/eu4/worker";
+import { getEu4Worker } from "./getEu4Worker";
 import type { Eu4Worker } from "@/features/eu4/worker";
 import { getErrorMessage } from "@/lib/getErrorMessage";
 import { useOnNewSave } from "./useOnNewSave";

--- a/src/app/app/routes/api.login.steam-callback.ts
+++ b/src/app/app/routes/api.login.steam-callback.ts
@@ -2,7 +2,7 @@ import { table } from "@/server-lib/db";
 import { sql } from "drizzle-orm";
 import { genId } from "@/server-lib/id";
 import { check } from "@/lib/isPresent";
-import { log } from "@/server-lib/logging";
+import { captureEvent } from "@/server-lib/posthog";
 import { withCore } from "@/server-lib/middleware";
 import type { AppLoadContext } from "react-router";
 import { withDb } from "@/server-lib/db/middleware";
@@ -38,7 +38,7 @@ export const loader = withCore(
       });
 
     const user = check(users.at(0), "expected user");
-    log.event({
+    captureEvent({
       userId: user.userId,
       event: user.inserted ? "User created" : "User updated",
     });

--- a/src/app/app/routes/api.saves.$saveId.ts
+++ b/src/app/app/routes/api.saves.$saveId.ts
@@ -4,7 +4,7 @@ import { saveView, table, toApiSave } from "@/server-lib/db";
 import type { DbConnection } from "@/server-lib/db/connection";
 import { withDb } from "@/server-lib/db/middleware";
 import { NotFoundError, ValidationError } from "@/server-lib/errors";
-import { log } from "@/server-lib/logging";
+import { captureEvent } from "@/server-lib/posthog";
 import { withCore } from "@/server-lib/middleware";
 import { pdxCloudflareS3, pdxS3 } from "@/server-lib/s3";
 import { eq } from "drizzle-orm";
@@ -79,7 +79,7 @@ export const action = withCore(
             ensurePermissions(session, "savefile:update", rows.at(0));
           });
 
-          log.event({
+          captureEvent({
             userId: session.id,
             event: "Save patched",
             key: params.saveId,
@@ -99,7 +99,7 @@ export const action = withCore(
               s3.deleteFile(s3.keys.preview(params.saveId)),
             ]);
           });
-          log.event({
+          captureEvent({
             userId: session.id,
             event: "Save deleted",
             key: params.saveId,

--- a/src/app/app/routes/api.saves.ts
+++ b/src/app/app/routes/api.saves.ts
@@ -10,6 +10,7 @@ import { ValidationError } from "@/server-lib/errors";
 import { pdxFns } from "@/server-lib/functions";
 import { genId } from "@/server-lib/id";
 import { log } from "@/server-lib/logging";
+import { captureEvent } from "@/server-lib/posthog";
 import { withCore } from "@/server-lib/middleware";
 import { headerMetadata, uploadMetadata } from "@/server-lib/models";
 import type { SavePostResponse } from "@/server-lib/models";
@@ -114,7 +115,7 @@ export const action = withCore(
         close();
       }
 
-      log.event({
+      captureEvent({
         userId: session.id,
         event: "Save created",
         key: saveId,

--- a/src/app/app/server-lib/logging.ts
+++ b/src/app/app/server-lib/logging.ts
@@ -1,5 +1,4 @@
 import { toErrorWithMessage } from "@/lib/getErrorMessage";
-import { captureEvent } from "./posthog";
 
 export type LogMessage = {
   [x: string]: unknown;
@@ -8,15 +7,6 @@ export type LogMessage = {
 class Log {
   private dateFmt(): string {
     return new Date().toJSON();
-  }
-
-  public event({
-    userId,
-    event,
-    ...rest
-  }: { userId: string; event: string } & LogMessage) {
-    captureEvent({ userId, event });
-    this.info({ event, user: userId, ...rest });
   }
 
   public info(data: LogMessage) {

--- a/src/app/app/server-lib/posthog.ts
+++ b/src/app/app/server-lib/posthog.ts
@@ -31,6 +31,7 @@ export function captureEvent({
   event,
   ...rest
 }: { userId: string; event: string } & Record<string, string>) {
+  log.info({ event, user: userId, ...rest });
   if (enabled) {
     getPostHogClient().capture({ distinctId: userId, event, properties: rest });
   }

--- a/src/app/app/services/appApi.ts
+++ b/src/app/app/services/appApi.ts
@@ -8,7 +8,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import type { Achievement, Difficulty } from "@/wasm/wasm_app";
-import { getEu4Worker } from "@/features/eu4/worker";
+import { getEu4Worker } from "@/features/eu4/worker/getEu4Worker";
 import type { SavePostResponse, UploadMetadaInput } from "@/server-lib/models";
 import { createCompressionWorker } from "@/features/compress";
 import type { PdxSession } from "@/server-lib/auth/session";

--- a/src/map/src/glResources.ts
+++ b/src/map/src/glResources.ts
@@ -6,7 +6,7 @@ import {
   IMG_HEIGHT,
   IMG_PADDED_WIDTH,
   SPLIT_IMG_PADDED_WIDTH,
-} from "./map";
+} from "./mapDimensions";
 import { notNull } from "./nullcheck";
 
 const MAX_TEXTURE_SIZE = 4096;

--- a/src/map/src/index.ts
+++ b/src/map/src/index.ts
@@ -1,5 +1,5 @@
 export { GLResources } from "./glResources";
-export { IMG_HEIGHT, IMG_WIDTH, WebGLMap, glContextOptions } from "./map";
+export { WebGLMap, glContextOptions } from "./map";
 export { MapShader } from "./MapShader";
 export { ProvinceFinder } from "./ProvinceFinder";
 export { compileShaders } from "./shaderCompiler";
@@ -10,6 +10,7 @@ export { type InitToken } from "./map-worker";
 export * from "./canvasOverlays";
 export * from "./map-worker-types";
 export { provinceIdToColorIndexInvert } from "./resources";
+export { IMG_HEIGHT, IMG_WIDTH } from "./mapDimensions";
 
 export function createMapWorker() {
   return new Worker(new URL("./map-worker-bridge", import.meta.url), {

--- a/src/map/src/map-worker.ts
+++ b/src/map/src/map-worker.ts
@@ -1,6 +1,6 @@
 import { overlayDate } from "./canvasOverlays";
 import { GLResources } from "./glResources";
-import { glContextOptions, IMG_HEIGHT, IMG_WIDTH, WebGLMap } from "./map";
+import { glContextOptions, WebGLMap } from "./map";
 import type {
   DrawEvent,
   MouseEvent,
@@ -8,6 +8,7 @@ import type {
   UserRect,
   WheelEvent,
 } from "./map";
+import { IMG_HEIGHT, IMG_WIDTH } from "./mapDimensions";
 import { MapShader } from "./MapShader";
 import { ProvinceFinder } from "./ProvinceFinder";
 import {

--- a/src/map/src/map.ts
+++ b/src/map/src/map.ts
@@ -2,11 +2,13 @@ import type { GLResources } from "./glResources";
 import { setupFramebufferTexture } from "./glResources";
 import type { ProvinceFinder } from "./ProvinceFinder";
 import type { TerrainOverlayResources } from "./types";
+import {
+  IMG_HEIGHT,
+  IMG_WIDTH,
+  IMG_PADDED_WIDTH,
+  SPLIT_IMG_PADDED_WIDTH,
+} from "./mapDimensions";
 
-export const IMG_HEIGHT = 2048;
-export const IMG_WIDTH = 5632;
-export const IMG_PADDED_WIDTH = 8192;
-export const SPLIT_IMG_PADDED_WIDTH = 4096;
 const IMG_ASPECT = IMG_WIDTH / IMG_HEIGHT;
 
 export interface MouseEvent {

--- a/src/map/src/mapDimensions.ts
+++ b/src/map/src/mapDimensions.ts
@@ -1,0 +1,4 @@
+export const IMG_HEIGHT = 2048;
+export const IMG_WIDTH = 5632;
+export const IMG_PADDED_WIDTH = 8192;
+export const SPLIT_IMG_PADDED_WIDTH = 4096;


### PR DESCRIPTION
I see in cloudflare logs that there is an exception about importing undefined and a quick search reveals that this is often due to import cycles (which posthog.ts and logging.ts) have.

This PR fixes up all import cycles and denies new ones via oxlint.