### PR TITLE
Avoid mise binary token caching

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -236,8 +236,6 @@ run = ["cargo run -p pdx-tools-api"]
 
 [tasks.tokenize]
 description = "Preprocess the ironman tokens for distribution"
-sources = ["./assets/tokens/*.txt"]
-outputs = ["./assets/tokens/*.bin"]
 run = "cargo run --package pdx-tokenize-cli -- ./assets/tokens"
 
 [tasks.pnpm-install]


### PR DESCRIPTION
In the event that the tokens are a symlink, mise is not able to detect when the input file has changed, so it will think the command doesn't need to run.