### PR TITLE
Fix bleed-thru on card components for eu5 errors

### DIFF
--- a/src/app/app/components/Card.tsx
+++ b/src/app/app/components/Card.tsx
@@ -7,7 +7,7 @@ const cardVariants = cva(
   {
     variants: {
       variant: {
-        default: "dark:bg-slate-800",
+        default: "bg-slate-50 dark:bg-slate-800",
         ghost: "",
       },
     },


### PR DESCRIPTION
<img width="592" height="258" alt="image" src="https://github.com/user-attachments/assets/782c08f0-2b04-47fe-9478-db01cf32cafd" />

<img width="620" height="277" alt="image" src="https://github.com/user-attachments/assets/57133b0b-bc86-460a-9d42-bc321017ce9d" />
