### PR TITLE
Support deserializing eu5 first_name object variant

### DIFF
--- a/src/eu5save/src/bin/debug_save.rs
+++ b/src/eu5save/src/bin/debug_save.rs
@@ -70,16 +70,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{:?}", save.countries.index(swe).data());
 
     for player in save.played_countries {
-        println!(
-            "{} {:?} {:?}",
-            player.name,
-            player.country,
-            save.countries
-                .get_entry(player.country)
-                .unwrap()
-                .tag()
-                .to_str()
-        );
+        match save.countries.get_entry(player.country) {
+            None => println!(
+                "Player country not found: {} {:?}",
+                player.name, player.country
+            ),
+            Some(country) => println!(
+                "Player country: {} {:?} - {:?}",
+                player.name,
+                player.country,
+                country.tag().to_str()
+            ),
+        }
 
         for dep in save.diplomacy_manager.dependencies() {
             if dep.first == player.country || dep.second == player.country {


### PR DESCRIPTION
A character first_name in eu5 can look like:
```
first_name="Margret Thatcher"
```
Or it can look like:
```
first_name={
    name="name_william"
    custom_name="Margret Thatcher"
}
```
I believe this fails to deserialize.