### PR TITLE
Add breadcrumb error paths to arena deserialization

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,13 @@ jobs:
       - run: rustup target add wasm32-unknown-unknown
       - run: rustup component add clippy
       - run: mise run lint
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@miri
+      - run: cargo miri setup
+      - run: cargo miri test -p bumpalo-serde
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance

--- a/src/bumpalo-serde/src/lib.rs
+++ b/src/bumpalo-serde/src/lib.rs
@@ -1,4 +1,7 @@
+pub use bumpalo::Bump;
 pub use bumpalo_serde_derive::ArenaDeserialize;
+
+pub mod tracked;
 
 use bumpalo::collections::{String as BumpString, Vec as BumpVec};
 use serde::de::{DeserializeSeed, Deserializer, SeqAccess, Visitor};

--- a/src/bumpalo-serde/src/tracked/de.rs
+++ b/src/bumpalo-serde/src/tracked/de.rs
@@ -1,0 +1,1537 @@
+use super::wrap::{Wrap, WrapVariant};
+use super::{Chain, Error, Track};
+use core::fmt;
+use serde::de::{self, Deserialize, DeserializeSeed, Visitor};
+
+/// Entry point for tracked deserialization.
+pub fn deserialize<'de, D, T>(deserializer: D, path_buf: &mut Vec<u8>) -> Result<T, Error<D::Error>>
+where
+    D: de::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let track = Track::new_with(path_buf);
+    match T::deserialize(Deserializer::new(deserializer, &track)) {
+        Ok(t) => Ok(t),
+        Err(err) => Err(Error {
+            path: track.path(),
+            original: err,
+        }),
+    }
+}
+
+/// Deserializer adapter that records path to deserialization errors.
+///
+/// # Example
+///
+/// When deserialization fails, the error includes the path to the field that caused the error:
+///
+/// ```
+/// use bumpalo_serde::tracked;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct MyType {
+///     count: i32,
+/// }
+///
+/// let json = r#"{"count": "not a number"}"#;
+/// let mut deserializer = serde_json::Deserializer::from_str(json);
+/// let mut path_buf = Vec::new();
+/// match tracked::deserialize::<_, MyType>(&mut deserializer, &mut path_buf) {
+///     Ok(_) => panic!("Expected deserialization to fail"),
+///     Err(err) => {
+///         let path = err.path().to_string();
+///         assert_eq!(path, "count");
+///     }
+/// }
+/// ```
+pub struct Deserializer<'a, 'b, 'buf, D> {
+    de: D,
+    chain: Chain<'a>,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, D> Deserializer<'a, 'b, 'buf, D> {
+    pub fn new(de: D, track: &'b Track<'buf>) -> Self {
+        Deserializer {
+            de,
+            chain: Chain::Root,
+            track,
+        }
+    }
+}
+
+// Plain old forwarding impl.
+impl<'a, 'b, 'buf, 'de, D> de::Deserializer<'de> for Deserializer<'a, 'b, 'buf, D>
+where
+    D: de::Deserializer<'de>,
+{
+    type Error = D::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_any(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_bool(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u8(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u16(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u32(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u64(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_u128(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i8(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i16(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i32(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i64(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_i128(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_f32(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_f64(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_char(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_str(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_string(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_bytes(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_byte_buf(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_option(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_unit(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_unit_struct(name, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_newtype_struct(name, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_seq(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_tuple(len, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_tuple_struct(name, len, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_map(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_struct(name, fields, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_enum(name, variants, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_ignored_any(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, D::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.de
+            .deserialize_identifier(Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.de.is_human_readable()
+    }
+}
+
+// Forwarding impl to preserve context.
+impl<'a, 'b, 'buf, 'de, X> Visitor<'de> for Wrap<'a, 'b, 'buf, X>
+where
+    X: Visitor<'de>,
+{
+    type Value = X::Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.delegate.expecting(formatter)
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_bool(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i8(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i16(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i32(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i64(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_i128(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u8(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u16(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u32(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u64(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_u128(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_f32(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_f64(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_char(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_str(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_borrowed_str(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_string(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_unit()
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_none()
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_some(Deserializer {
+                de: deserializer,
+                chain: Chain::Some { parent: chain },
+                track,
+            })
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_newtype_struct(Deserializer {
+                de: deserializer,
+                chain: Chain::NewtypeStruct { parent: chain },
+                track,
+            })
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_seq<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::SeqAccess<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_seq(SeqAccess::new(visitor, chain, track))
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_map<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::MapAccess<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_map(MapAccess::new(visitor, chain, track))
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_enum<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::EnumAccess<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_enum(Wrap::new(visitor, chain, track))
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_bytes(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_borrowed_bytes(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .visit_byte_buf(v)
+            .map_err(|err| track.trigger(chain, err))
+    }
+}
+
+// Forwarding impl to preserve context.
+impl<'a, 'b, 'buf, 'de, X> de::EnumAccess<'de> for Wrap<'a, 'b, 'buf, X>
+where
+    X: de::EnumAccess<'de> + 'a,
+{
+    type Error = X::Error;
+    type Variant = WrapVariant<'a, 'b, 'buf, X::Variant>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), X::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        let mut variant = None;
+        self.delegate
+            .variant_seed(CaptureKey::new(seed, &mut variant, track))
+            .map_err(|err| track.trigger(chain, err))
+            .map(move |(v, vis)| {
+                let chain = match variant {
+                    Some((start, len)) => Chain::Enum {
+                        parent: chain,
+                        start,
+                        len,
+                    },
+                    None => Chain::NonStringKey { parent: chain },
+                };
+                (v, WrapVariant::new(vis, chain, track))
+            })
+    }
+}
+
+// Forwarding impl to preserve context.
+impl<'a, 'b, 'buf, 'de, X> de::VariantAccess<'de> for WrapVariant<'a, 'b, 'buf, X>
+where
+    X: de::VariantAccess<'de>,
+{
+    type Error = X::Error;
+
+    fn unit_variant(self) -> Result<(), X::Error> {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .unit_variant()
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, X::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        let nested = Chain::NewtypeVariant { parent: &chain };
+        self.delegate
+            .newtype_variant_seed(TrackedSeed::new(seed, nested, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .tuple_variant(len, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.delegate
+            .struct_variant(fields, Wrap::new(visitor, &chain, track))
+            .map_err(|err| track.trigger(&chain, err))
+    }
+}
+
+// Seed that saves the string into the given optional during `visit_str` and
+// `visit_string`.
+struct CaptureKey<'a, 'b, 'buf, X> {
+    delegate: X,
+    key: &'a mut Option<(usize, u8)>,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> CaptureKey<'a, 'b, 'buf, X> {
+    fn new(delegate: X, key: &'a mut Option<(usize, u8)>, track: &'b Track<'buf>) -> Self {
+        CaptureKey {
+            delegate,
+            key,
+            track,
+        }
+    }
+
+    // Helper to push a string to the path buffer and return (start, len)
+    fn push_str(&self, s: &str) -> (usize, u8) {
+        self.track.push_bytes(s.as_bytes())
+    }
+}
+
+// Forwarding impl.
+impl<'a, 'b, 'buf, 'de, X> DeserializeSeed<'de> for CaptureKey<'a, 'b, 'buf, X>
+where
+    X: DeserializeSeed<'de>,
+{
+    type Value = X::Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<X::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        self.delegate
+            .deserialize(CaptureKey::new(deserializer, self.key, self.track))
+    }
+}
+
+// Forwarding impl.
+impl<'a, 'b, 'buf, 'de, X> de::Deserializer<'de> for CaptureKey<'a, 'b, 'buf, X>
+where
+    X: de::Deserializer<'de>,
+{
+    type Error = X::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_any(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_bool(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u8(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u16(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u32(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u64(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_u128(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i8(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i16(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i32(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i64(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_i128(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_f32(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_f64(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_char(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_str(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_string(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_bytes(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_byte_buf(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_option(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_unit(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_unit_struct(name, CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_newtype_struct(name, CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_seq(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_tuple(len, CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate.deserialize_tuple_struct(
+            name,
+            len,
+            CaptureKey::new(visitor, self.key, self.track),
+        )
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_map(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate.deserialize_struct(
+            name,
+            fields,
+            CaptureKey::new(visitor, self.key, self.track),
+        )
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate.deserialize_enum(
+            name,
+            variants,
+            CaptureKey::new(visitor, self.key, self.track),
+        )
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_ignored_any(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, X::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.delegate
+            .deserialize_identifier(CaptureKey::new(visitor, self.key, self.track))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.delegate.is_human_readable()
+    }
+}
+
+// Forwarding impl except `visit_str` and `visit_string` which save the string.
+impl<'a, 'b, 'buf, 'de, X> Visitor<'de> for CaptureKey<'a, 'b, 'buf, X>
+where
+    X: Visitor<'de>,
+{
+    type Value = X::Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.delegate.expecting(formatter)
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let string = if v { "true" } else { "false" };
+        *self.key = Some(self.push_str(string));
+        self.delegate.visit_bool(v)
+    }
+
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i8(v)
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i16(v)
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i32(v)
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i64(v)
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_i128(v)
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u8(v)
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u16(v)
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u32(v)
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u64(v)
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_u128(v)
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_f32(v)
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_f64(v)
+    }
+
+    fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_char(v)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        *self.key = Some(self.push_str(v));
+        self.delegate.visit_str(v)
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        *self.key = Some(self.push_str(v));
+        self.delegate.visit_borrowed_str(v)
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        *self.key = Some(self.push_str(&v));
+        self.delegate.visit_string(v)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_unit()
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_none()
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        self.delegate.visit_some(deserializer)
+    }
+
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        self.delegate.visit_newtype_struct(deserializer)
+    }
+
+    fn visit_seq<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::SeqAccess<'de>,
+    {
+        self.delegate.visit_seq(visitor)
+    }
+
+    fn visit_map<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::MapAccess<'de>,
+    {
+        self.delegate.visit_map(visitor)
+    }
+
+    fn visit_enum<V>(self, visitor: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::EnumAccess<'de>,
+    {
+        self.delegate.visit_enum(visitor)
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_bytes(v)
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_borrowed_bytes(v)
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.delegate.visit_byte_buf(v)
+    }
+}
+
+// Seed used for map values, sequence elements and newtype variants to track
+// their path.
+struct TrackedSeed<'a, 'b, 'buf, X> {
+    seed: X,
+    chain: Chain<'a>,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> TrackedSeed<'a, 'b, 'buf, X> {
+    fn new(seed: X, chain: Chain<'a>, track: &'b Track<'buf>) -> Self {
+        TrackedSeed { seed, chain, track }
+    }
+}
+
+impl<'a, 'b, 'buf, 'de, X> DeserializeSeed<'de> for TrackedSeed<'a, 'b, 'buf, X>
+where
+    X: DeserializeSeed<'de>,
+{
+    type Value = X::Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<X::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        self.seed
+            .deserialize(Deserializer {
+                de: deserializer,
+                chain: chain.clone(),
+                track,
+            })
+            .map_err(|err| track.trigger(&chain, err))
+    }
+}
+
+// Seq visitor that tracks the index of its elements.
+struct SeqAccess<'a, 'b, 'buf, X> {
+    delegate: X,
+    chain: &'a Chain<'a>,
+    index: usize,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> SeqAccess<'a, 'b, 'buf, X> {
+    fn new(delegate: X, chain: &'a Chain<'a>, track: &'b Track<'buf>) -> Self {
+        SeqAccess {
+            delegate,
+            chain,
+            index: 0,
+            track,
+        }
+    }
+}
+
+// Forwarding impl to preserve context.
+impl<'a, 'b, 'buf, 'de, X> de::SeqAccess<'de> for SeqAccess<'a, 'b, 'buf, X>
+where
+    X: de::SeqAccess<'de>,
+{
+    type Error = X::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, X::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let parent = self.chain;
+        let chain = Chain::Seq {
+            parent,
+            index: self.index,
+        };
+        let track = self.track;
+        self.index += 1;
+        self.delegate
+            .next_element_seed(TrackedSeed::new(seed, chain, track))
+            .map_err(|err| track.trigger(parent, err))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.delegate.size_hint()
+    }
+}
+
+// Map visitor that captures the string value of its keys and uses that to track
+// the path to its values.
+struct MapAccess<'a, 'b, 'buf, X> {
+    delegate: X,
+    chain: &'a Chain<'a>,
+    key: Option<(usize, u8)>,
+    track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> MapAccess<'a, 'b, 'buf, X> {
+    fn new(delegate: X, chain: &'a Chain<'a>, track: &'b Track<'buf>) -> Self {
+        MapAccess {
+            delegate,
+            chain,
+            key: None,
+            track,
+        }
+    }
+}
+
+impl<'a, 'b, 'buf, 'de, X> de::MapAccess<'de> for MapAccess<'a, 'b, 'buf, X>
+where
+    X: de::MapAccess<'de>,
+{
+    type Error = X::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, X::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        let chain = self.chain;
+        let track = self.track;
+        let key = &mut self.key;
+        self.delegate
+            .next_key_seed(CaptureKey::new(seed, key, track))
+            .map_err(|err| {
+                let chain = match key.take() {
+                    Some((start, len)) => Chain::Map {
+                        parent: chain,
+                        start,
+                        len,
+                    },
+                    None => Chain::NonStringKey { parent: chain },
+                };
+                track.trigger(&chain, err)
+            })
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, X::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let parent = self.chain;
+        let (chain, len_to_pop) = match self.key.take() {
+            Some((start, len)) => (Chain::Map { parent, start, len }, Some(len)),
+            None => (Chain::NonStringKey { parent }, None),
+        };
+        let track = self.track;
+        let result = self
+            .delegate
+            .next_value_seed(TrackedSeed::new(seed, chain, track))
+            .map_err(|err| track.trigger(parent, err));
+
+        // Pop the key bytes after deserialization completes (whether success or error)
+        if let Some(len) = len_to_pop {
+            track.pop_bytes(len);
+        }
+
+        result
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.delegate.size_hint()
+    }
+}

--- a/src/bumpalo-serde/src/tracked/mod.rs
+++ b/src/bumpalo-serde/src/tracked/mod.rs
@@ -1,0 +1,176 @@
+// Path tracking for arena deserialization errors.
+//
+// Ported from serde_path_to_error v0.1.20 with modified path tracking to use a
+// single buffer that amortizes allocations.
+
+mod de;
+mod path;
+mod wrap;
+
+pub use de::{Deserializer, deserialize};
+pub use path::{Path, Segment, Segments};
+
+use core::cell::Cell;
+use core::fmt::{self, Display};
+use serde::ser::StdError;
+
+/// Original deserializer error together with the path at which it occurred.
+#[derive(Clone, Debug)]
+pub struct Error<E> {
+    path: Path,
+    original: E,
+}
+
+impl<E> Error<E> {
+    pub fn new(path: Path, inner: E) -> Self {
+        Error {
+            path,
+            original: inner,
+        }
+    }
+
+    /// Element path at which this deserialization error occurred.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The Deserializer's underlying error that occurred.
+    pub fn into_inner(self) -> E {
+        self.original
+    }
+
+    /// Reference to the Deserializer's underlying error that occurred.
+    pub fn inner(&self) -> &E {
+        &self.original
+    }
+}
+
+impl<E: Display> Display for Error<E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if !self.path.is_only_unknown() {
+            write!(f, "{}: ", self.path)?;
+        }
+        write!(f, "{}", self.original)
+    }
+}
+
+impl<E: StdError> StdError for Error<E> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.original.source()
+    }
+}
+
+/// State for bookkeeping across nested deserializer calls.
+///
+/// Uses a mutable byte vector for efficient path tracking that truncates on backtrack.
+pub struct Track<'buf> {
+    path_buf: core::cell::UnsafeCell<&'buf mut Vec<u8>>,
+    path: Cell<Option<Path>>,
+}
+
+impl<'buf> Track<'buf> {
+    /// Create a new tracker with a mutable byte vector for path tracking.
+    pub fn new_with(buf: &'buf mut Vec<u8>) -> Self {
+        Track {
+            path_buf: core::cell::UnsafeCell::new(buf),
+            path: Cell::new(None),
+        }
+    }
+
+    /// Append bytes to the path buffer and return (start_position, length).
+    ///
+    /// Only pushes up to 255 bytes.
+    ///
+    /// # Safety
+    ///
+    /// This is safe to call from &self because the mutations follow a stack discipline:
+    /// bytes pushed during deserialization are popped when unwinding back up the tree.
+    pub fn push_bytes(&self, bytes: &[u8]) -> (usize, u8) {
+        unsafe {
+            let vec = &mut *self.path_buf.get();
+            let start = vec.len();
+            let bytes_to_push = bytes.len().min(u8::MAX as usize);
+            let len = bytes_to_push as u8;
+            vec.extend_from_slice(&bytes[..bytes_to_push]);
+            (start, len)
+        }
+    }
+
+    /// Remove `len` bytes from the end of the path buffer (used when unwinding).
+    ///
+    /// # Safety
+    ///
+    /// This is safe to call from &self because the mutations follow a stack discipline.
+    pub fn pop_bytes(&self, len: u8) {
+        unsafe {
+            let vec = &mut *self.path_buf.get();
+            let new_len = vec.len().saturating_sub(len as usize);
+            vec.truncate(new_len);
+        }
+    }
+
+    /// Get bytes from the path buffer at absolute position (start, len).
+    ///
+    /// Used during error path construction to read the bytes before they're popped.
+    pub fn get_bytes(&self, start: usize, len: u8) -> &[u8] {
+        unsafe {
+            let vec = &*self.path_buf.get();
+            let end = start + (len as usize);
+            if end <= vec.len() {
+                &vec[start..end]
+            } else {
+                &[] // Return empty slice if the bytes have been removed
+            }
+        }
+    }
+
+    /// Gets path at which the error occurred. Only meaningful after we know
+    /// that an error has occurred. Returns an empty path otherwise.
+    pub fn path(self) -> Path {
+        self.path.into_inner().unwrap_or_else(Path::empty)
+    }
+
+    #[inline]
+    pub(crate) fn trigger<'a, E>(&self, chain: &Chain<'a>, err: E) -> E {
+        self.trigger_impl(chain);
+        err
+    }
+
+    pub(crate) fn trigger_impl<'a>(&self, chain: &Chain<'a>) {
+        self.path.set(Some(match self.path.take() {
+            Some(already_set) => already_set,
+            None => Path::from_chain(chain, self),
+        }));
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum Chain<'a> {
+    Root,
+    Seq {
+        parent: &'a Chain<'a>,
+        index: usize,
+    },
+    Map {
+        parent: &'a Chain<'a>,
+        start: usize, // Absolute start position in path_buf
+        len: u8,      // Length of this key
+    },
+    Enum {
+        parent: &'a Chain<'a>,
+        start: usize, // Absolute start position in path_buf
+        len: u8,      // Length of this variant
+    },
+    Some {
+        parent: &'a Chain<'a>,
+    },
+    NewtypeStruct {
+        parent: &'a Chain<'a>,
+    },
+    NewtypeVariant {
+        parent: &'a Chain<'a>,
+    },
+    NonStringKey {
+        parent: &'a Chain<'a>,
+    },
+}

--- a/src/bumpalo-serde/src/tracked/path.rs
+++ b/src/bumpalo-serde/src/tracked/path.rs
@@ -1,0 +1,154 @@
+use super::Chain;
+use core::fmt::{self, Display};
+use core::slice;
+
+/// Path to the error value in the input, like `dependencies.serde.typo1`.
+///
+/// Use `path.to_string()` to get a string representation of the path with
+/// segments separated by periods, or use `path.iter()` to iterate over
+/// individual segments of the path.
+#[derive(Clone, Debug)]
+pub struct Path {
+    segments: Vec<Segment>,
+}
+
+/// Single segment of a path.
+#[derive(Clone, Debug)]
+pub enum Segment {
+    Seq { index: usize },
+    Map { key: String },
+    Enum { variant: String },
+    Unknown,
+}
+
+impl Path {
+    /// Returns an iterator with element type [`&Segment`][Segment].
+    pub fn iter(&self) -> Segments<'_> {
+        Segments {
+            iter: self.segments.iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Path {
+    type Item = &'a Segment;
+    type IntoIter = Segments<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over segments of a path.
+pub struct Segments<'a> {
+    iter: slice::Iter<'a, Segment>,
+}
+
+impl<'a> Iterator for Segments<'a> {
+    type Item = &'a Segment;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a> DoubleEndedIterator for Segments<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+}
+
+impl<'a> ExactSizeIterator for Segments<'a> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl Display for Path {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        if self.segments.is_empty() {
+            return formatter.write_str(".");
+        }
+
+        let mut separator = "";
+        for segment in self {
+            if !matches!(segment, Segment::Seq { .. }) {
+                formatter.write_str(separator)?;
+            }
+            write!(formatter, "{}", segment)?;
+            separator = ".";
+        }
+
+        Ok(())
+    }
+}
+
+impl Path {
+    pub(crate) fn empty() -> Self {
+        Path {
+            segments: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_chain<'a, 'buf>(mut chain: &Chain<'a>, track: &super::Track<'buf>) -> Self {
+        let mut segments = Vec::new();
+        loop {
+            match chain {
+                Chain::Root => break,
+                Chain::Seq { parent, index } => {
+                    segments.push(Segment::Seq { index: *index });
+                    chain = parent;
+                }
+                Chain::Map { parent, start, len } => {
+                    let bytes = track.get_bytes(*start, *len);
+                    let key = std::str::from_utf8(bytes).unwrap_or("?").to_string();
+                    segments.push(Segment::Map { key });
+                    chain = parent;
+                }
+                Chain::Enum { parent, start, len } => {
+                    let bytes = track.get_bytes(*start, *len);
+                    let variant = std::str::from_utf8(bytes).unwrap_or("?").to_string();
+                    segments.push(Segment::Enum { variant });
+                    chain = parent;
+                }
+                Chain::Some { parent }
+                | Chain::NewtypeStruct { parent }
+                | Chain::NewtypeVariant { parent } => {
+                    chain = parent;
+                }
+                Chain::NonStringKey { parent } => {
+                    segments.push(Segment::Unknown);
+                    chain = parent;
+                }
+            }
+        }
+        segments.reverse();
+        Path { segments }
+    }
+
+    pub(crate) fn is_only_unknown(&self) -> bool {
+        self.segments.iter().all(Segment::is_unknown)
+    }
+}
+
+impl Display for Segment {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Segment::Seq { index } => write!(formatter, "[{}]", index),
+            Segment::Map { key } | Segment::Enum { variant: key } => {
+                write!(formatter, "{}", key)
+            }
+            Segment::Unknown => formatter.write_str("?"),
+        }
+    }
+}
+
+impl Segment {
+    fn is_unknown(&self) -> bool {
+        matches!(self, Segment::Unknown)
+    }
+}

--- a/src/bumpalo-serde/src/tracked/wrap.rs
+++ b/src/bumpalo-serde/src/tracked/wrap.rs
@@ -1,0 +1,35 @@
+use super::{Chain, Track};
+
+// Wrapper that attaches context to a `Visitor`, `SeqAccess` or `EnumAccess`.
+pub struct Wrap<'a, 'b, 'buf, X> {
+    pub(crate) delegate: X,
+    pub(crate) chain: &'a Chain<'a>,
+    pub(crate) track: &'b Track<'buf>,
+}
+
+// Wrapper that attaches context to a `VariantAccess`.
+pub struct WrapVariant<'a, 'b, 'buf, X> {
+    pub(crate) delegate: X,
+    pub(crate) chain: Chain<'a>,
+    pub(crate) track: &'b Track<'buf>,
+}
+
+impl<'a, 'b, 'buf, X> Wrap<'a, 'b, 'buf, X> {
+    pub(crate) fn new(delegate: X, chain: &'a Chain<'a>, track: &'b Track<'buf>) -> Self {
+        Wrap {
+            delegate,
+            chain,
+            track,
+        }
+    }
+}
+
+impl<'a, 'b, 'buf, X> WrapVariant<'a, 'b, 'buf, X> {
+    pub(crate) fn new(delegate: X, chain: Chain<'a>, track: &'b Track<'buf>) -> Self {
+        WrapVariant {
+            delegate,
+            chain,
+            track,
+        }
+    }
+}

--- a/src/bumpalo-serde/tests/tracked_deserializer.rs
+++ b/src/bumpalo-serde/tests/tracked_deserializer.rs
@@ -1,0 +1,400 @@
+#![allow(dead_code)]
+use serde::Deserialize;
+
+/// Helper to run tracked deserialization with serde_json
+fn deserialize_tracked<T: for<'de> Deserialize<'de>>(json: &str) -> Result<T, String> {
+    let mut path_buf = Vec::new();
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    bumpalo_serde::tracked::deserialize(&mut deserializer, &mut path_buf)
+        .map_err(|err| err.path().to_string())
+}
+
+#[test]
+fn test_simple_field_error() {
+    #[derive(Deserialize, Debug)]
+    struct TestStruct {
+        name: String,
+    }
+
+    let json = r#"{"name": 123}"#; // Type error: expected string
+    let err = deserialize_tracked::<TestStruct>(json).unwrap_err();
+    assert_eq!(err, "name");
+}
+
+#[test]
+fn test_missing_required_field() {
+    #[derive(Deserialize, Debug)]
+    struct TestStruct {
+        name: String,
+    }
+
+    let json = r#"{}"#;
+    let err = deserialize_tracked::<TestStruct>(json).unwrap_err();
+    // Missing field error occurs at root level
+    assert_eq!(err, ".");
+}
+
+#[test]
+fn test_nested_struct_error() {
+    #[derive(Deserialize, Debug)]
+    struct Inner {
+        value: i32,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    let json = r#"{"inner": {"value": "not an int"}}"#;
+    let err = deserialize_tracked::<Outer>(json).unwrap_err();
+    assert_eq!(err, "inner.value");
+}
+
+#[test]
+fn test_deeply_nested_path() {
+    #[derive(Deserialize, Debug)]
+    struct L5 {
+        val: i32,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct L4 {
+        l5: L5,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct L3 {
+        l4: L4,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct L2 {
+        l3: L3,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct L1 {
+        l2: L2,
+    }
+
+    let json = r#"{"l2": {"l3": {"l4": {"l5": {"val": "wrong"}}}}}"#;
+    let err = deserialize_tracked::<L1>(json).unwrap_err();
+    assert_eq!(err, "l2.l3.l4.l5.val");
+}
+
+#[test]
+fn test_root_level_error() {
+    let json = r#""not a number""#;
+    let err = deserialize_tracked::<i32>(json).unwrap_err();
+    // Root level errors show as "."
+    assert_eq!(err, ".");
+}
+
+#[test]
+fn test_sequence_error() {
+    let json = r#"[1, 2, "three", 4]"#;
+    let err = deserialize_tracked::<Vec<i32>>(json).unwrap_err();
+    assert_eq!(err, "[2]");
+}
+
+#[test]
+fn test_sequence_nested_error() {
+    #[derive(Deserialize, Debug)]
+    struct Item {
+        id: i32,
+    }
+
+    let json = r#"[{"id": 1}, {"id": "wrong"}]"#;
+    let err = deserialize_tracked::<Vec<Item>>(json).unwrap_err();
+    assert_eq!(err, "[1].id");
+}
+
+#[test]
+fn test_empty_sequence() {
+    let vec: Vec<i32> = deserialize_tracked::<Vec<i32>>(r#"[]"#).unwrap();
+    assert!(vec.is_empty());
+}
+
+#[test]
+fn test_tuple_error() {
+    let json = r#"["string", 123, "not an int"]"#;
+    let err = deserialize_tracked::<(String, i32, i32)>(json).unwrap_err();
+    assert_eq!(err, "[2]");
+}
+
+#[test]
+fn test_map_error() {
+    let json = r#"{"key1": 10, "key2": "not an int"}"#;
+    let err = deserialize_tracked::<std::collections::HashMap<String, i32>>(json).unwrap_err();
+    assert_eq!(err, "key2");
+}
+
+#[test]
+fn test_struct_map_error() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        timeout: u32,
+        debug: bool,
+    }
+
+    let json = r#"{"timeout": 30, "debug": "not a bool"}"#;
+    let err = deserialize_tracked::<Config>(json).unwrap_err();
+    assert_eq!(err, "debug");
+}
+
+#[test]
+fn test_multiple_map_keys() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        host: String,
+        port: u16,
+        timeout: u32,
+    }
+
+    let json = r#"{"host": "localhost", "port": 8080, "timeout": "not an int"}"#;
+    let err = deserialize_tracked::<Config>(json).unwrap_err();
+    assert_eq!(err, "timeout");
+}
+
+#[test]
+fn test_enum_variant_error() {
+    #[derive(Deserialize, Debug)]
+    #[serde(tag = "type")]
+    enum Status {
+        Active { timestamp: i64 },
+        Inactive,
+    }
+
+    let json = r#"{"type": "Active", "timestamp": "not a number"}"#;
+    let err = deserialize_tracked::<Status>(json).unwrap_err();
+    assert_eq!(err, ".");
+}
+
+#[test]
+fn test_enum_newtype_variant() {
+    #[derive(Deserialize, Debug)]
+    enum Message {
+        #[serde(rename = "text")]
+        Text(String),
+        #[serde(rename = "number")]
+        Number(i32),
+    }
+
+    let json = r#"{"number": "not a number"}"#;
+    let err = deserialize_tracked::<Message>(json).unwrap_err();
+    assert_eq!(err, "number");
+}
+
+#[test]
+fn test_option_some_with_error() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        timeout: Option<i32>,
+    }
+
+    let json = r#"{"timeout": "not an int"}"#;
+    let err = deserialize_tracked::<Config>(json).unwrap_err();
+    assert_eq!(err, "timeout");
+}
+
+#[test]
+fn test_option_none() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        timeout: Option<i32>,
+    }
+
+    let config: Config = deserialize_tracked(r#"{"timeout": null}"#).unwrap();
+    assert_eq!(config.timeout, None);
+}
+
+#[test]
+fn test_option_missing() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        #[serde(default)]
+        timeout: Option<i32>,
+    }
+
+    let config: Config = deserialize_tracked(r#"{}"#).unwrap();
+    assert_eq!(config.timeout, None);
+}
+
+#[test]
+fn test_mixed_nesting_map_and_array() {
+    #[derive(Deserialize, Debug)]
+    struct Item {
+        id: i32,
+    }
+
+    let json = r#"{"items": [{"id": 1}, {"id": "wrong"}]}"#;
+    let err =
+        deserialize_tracked::<std::collections::HashMap<String, Vec<Item>>>(json).unwrap_err();
+    assert_eq!(err, "items[1].id");
+}
+
+#[test]
+fn test_mixed_nesting_array_and_map() {
+    let json = r#"[{"a": 1}, {"a": "wrong"}]"#;
+    let err = deserialize_tracked::<Vec<std::collections::HashMap<String, i32>>>(json).unwrap_err();
+    assert_eq!(err, "[1].a");
+}
+
+#[test]
+fn test_struct_with_vec_with_struct() {
+    #[derive(Deserialize, Debug)]
+    struct Point {
+        x: i32,
+        y: i32,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Shape {
+        points: Vec<Point>,
+    }
+
+    let json = r#"{"points": [{"x": 1, "y": 2}, {"x": "wrong", "y": 3}]}"#;
+    let err = deserialize_tracked::<Shape>(json).unwrap_err();
+    assert_eq!(err, "points[1].x");
+}
+
+#[test]
+fn test_long_key_name() {
+    // Test with a key longer than 255 bytes
+    // Keys are capped at u8::MAX (255 bytes) due to the length field being a u8
+    let long_key = "a".repeat(300);
+    let expected_key = "a".repeat(255); // Capped at u8::MAX
+    let json = format!(r#"{{"{}": "not an int"}}"#, long_key);
+    let err = deserialize_tracked::<std::collections::HashMap<String, i32>>(&json).unwrap_err();
+    // The error path contains the key, truncated to 255 bytes
+    assert_eq!(
+        err, expected_key,
+        "Keys longer than 255 bytes are truncated"
+    );
+}
+
+#[test]
+fn test_deeply_nested_arrays() {
+    let json = r#"[[[[[1, 2, "wrong"]]]]]]"#;
+    let err = deserialize_tracked::<Vec<Vec<Vec<Vec<Vec<i32>>>>>>(json).unwrap_err();
+    assert_eq!(err, "[0][0][0][0][2]");
+}
+
+#[test]
+fn test_newtype_struct() {
+    #[derive(Deserialize, Debug)]
+    struct UserId(i32);
+
+    #[derive(Deserialize, Debug)]
+    struct User {
+        id: UserId,
+    }
+
+    let json = r#"{"id": "not an int"}"#;
+    let err = deserialize_tracked::<User>(json).unwrap_err();
+    assert_eq!(err, "id");
+}
+
+#[test]
+fn test_tuple_struct() {
+    #[derive(Deserialize, Debug)]
+    struct Point(i32, i32, i32);
+
+    let json = r#"[1, 2, "wrong"]"#;
+    let err = deserialize_tracked::<Point>(json).unwrap_err();
+    assert_eq!(err, "[2]");
+}
+
+#[test]
+fn test_buffer_push_pop_symmetry() {
+    // This test exercises the stack discipline of push_bytes and pop_bytes
+    // by deserializing multiple sequential map entries
+    let json = r#"{
+        "first": 1,
+        "second": 2,
+        "third": "wrong"
+    }"#;
+
+    let err = deserialize_tracked::<std::collections::HashMap<String, i32>>(json).unwrap_err();
+    assert_eq!(err, "third");
+}
+
+#[test]
+fn test_sequential_arrays() {
+    // Tests buffer cleanup between array elements
+    let json = r#"[[1, 2], [3, 4], [5, "wrong"]]"#;
+    let err = deserialize_tracked::<Vec<Vec<i32>>>(json).unwrap_err();
+    assert_eq!(err, "[2][1]");
+}
+
+#[test]
+fn test_interleaved_maps_and_arrays() {
+    // Complex scenario testing buffer management
+    #[derive(Deserialize, Debug)]
+    struct Item {
+        id: i32,
+        tags: Vec<String>,
+    }
+
+    let json = r#"{
+        "items": [
+            {"id": 1, "tags": ["a", "b"]},
+            {"id": 2, "tags": ["c", "d"]},
+            {"id": "wrong", "tags": []}
+        ]
+    }"#;
+
+    let err =
+        deserialize_tracked::<std::collections::HashMap<String, Vec<Item>>>(json).unwrap_err();
+    assert_eq!(err, "items[2].id");
+}
+
+#[test]
+fn test_valid_simple_struct() {
+    #[derive(Deserialize, Debug)]
+    struct Config {
+        name: String,
+        count: i32,
+    }
+
+    let json = r#"{"name": "test", "count": 42}"#;
+    let config: Config = deserialize_tracked(json).unwrap();
+    assert_eq!(config.name, "test");
+    assert_eq!(config.count, 42);
+}
+
+#[test]
+fn test_valid_nested_structure() {
+    #[derive(Deserialize, Debug)]
+    struct Inner {
+        value: String,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Outer {
+        inner: Inner,
+        count: i32,
+    }
+
+    let json = r#"{"inner": {"value": "hello"}, "count": 10}"#;
+    let outer: Outer = deserialize_tracked(json).unwrap();
+    assert_eq!(outer.inner.value, "hello");
+    assert_eq!(outer.count, 10);
+}
+
+#[test]
+fn test_valid_array() {
+    let json = r#"[1, 2, 3, 4, 5]"#;
+    let vec: Vec<i32> = deserialize_tracked(json).unwrap();
+    assert_eq!(vec, vec![1, 2, 3, 4, 5]);
+}
+
+#[test]
+fn test_valid_map() {
+    let json = r#"{"a": 1, "b": 2, "c": 3}"#;
+    let map: std::collections::HashMap<String, i32> = deserialize_tracked(json).unwrap();
+    assert_eq!(map.get("a"), Some(&1));
+    assert_eq!(map.get("b"), Some(&2));
+    assert_eq!(map.get("c"), Some(&3));
+}


### PR DESCRIPTION
Implement path tracking for arena deserialization by porting serde_path_to_error and adapting it for bumpalo. This provides detailed error messages showing the field path where deserialization failures occur.

The performance penalty is around 10-20% when deserializing gamestate