### PR TITLE
Ship pdx-assets with imagemagick policy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,7 @@
       ]
     }
   },
-  "postCreateCommand": "mise trust && mise install --verbose --jobs 1",
+  "postCreateCommand": "sudo cp src/pdx-assets/policy.xml /etc/ImageMagick-6/policy.xml && mise trust && mise install --verbose --jobs 1",
   "postStartCommand": "mise install --verbose --jobs 1",
   "forwardPorts": [3001, 3003, 9000],
   "remoteUser": "vscode",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,8 @@ jobs:
           sudo apt-get install -y imagemagick
           convert -version
 
-          # For some reason imagemagick's path policy is set to none on github actions
-          # and we need it for sending hundreds of file paths to imagemagick.
-          sudo sed -i 's/rights="none"/rights="read|write"/gI' "/etc/ImageMagick-6/policy.xml"
-          identify -list policy
+          # Use bundled permissive policy.xml for file and large image processing
+          sudo cp src/pdx-assets/policy.xml /etc/ImageMagick-6/policy.xml
       - name: Install dependencies (macos)
         if: matrix.os == 'macos-15'
         run: |

--- a/src/pdx-assets/policy.xml
+++ b/src/pdx-assets/policy.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+  <!ELEMENT policymap (policy)*>
+  <!ATTLIST policymap xmlns CDATA #FIXED ''>
+  <!ELEMENT policy EMPTY>
+  <!ATTLIST policy xmlns CDATA #FIXED '' domain NMTOKEN #REQUIRED
+    name NMTOKEN #IMPLIED pattern CDATA #IMPLIED rights NMTOKEN #IMPLIED
+    stealth NMTOKEN #IMPLIED value CDATA #IMPLIED>
+]>
+<!--
+  ImageMagick policy configuration for pdx-assets.
+
+  This policy file is bundled with pdx-assets to ensure ImageMagick can process
+  large game asset files (particularly EU5 locations.png which is 16384x8192).
+
+  Resource limits are set to handle:
+  - EU5 locations.png: 16384x8192 pixels (134.2 MP)
+  - Large texture processing and tiling operations
+
+  Path rights are set to "read|write" to allow file list operations needed
+  for montage commands.
+-->
+<policymap>
+  <!-- Resource limits sized for EU5 map dimensions (16384x8192) -->
+  <policy domain="resource" name="memory" value="2GiB"/>
+  <policy domain="resource" name="map" value="4GiB"/>
+  <policy domain="resource" name="width" value="20KP"/>
+  <policy domain="resource" name="height" value="10KP"/>
+  <policy domain="resource" name="area" value="200MP"/>
+  <policy domain="resource" name="disk" value="8GiB"/>
+
+  <!-- Allow path operations for file lists (needed for montage with response files) -->
+  <policy domain="path" rights="read|write" pattern="@*"/>
+
+  <!-- Security: Disable potentially dangerous delegates and coders -->
+  <policy domain="delegate" rights="none" pattern="URL" />
+  <policy domain="delegate" rights="none" pattern="HTTPS" />
+  <policy domain="delegate" rights="none" pattern="HTTP" />
+  <policy domain="coder" rights="none" pattern="PS" />
+  <policy domain="coder" rights="none" pattern="PS2" />
+  <policy domain="coder" rights="none" pattern="PS3" />
+  <policy domain="coder" rights="none" pattern="EPS" />
+  <policy domain="coder" rights="none" pattern="PDF" />
+  <policy domain="coder" rights="none" pattern="XPS" />
+</policymap>

--- a/src/pdx-assets/src/images/imagemagick.rs
+++ b/src/pdx-assets/src/images/imagemagick.rs
@@ -89,23 +89,29 @@ impl ImageMagickProcessor {
     }
 
     fn get_command(&self, subcommand: &str) -> Result<Command> {
-        match &self.command_type {
+        let mut cmd = match &self.command_type {
             MagickCommand::Magick => {
                 let mut cmd = Command::new("magick");
                 if subcommand != "convert" {
                     cmd.arg(subcommand);
                 }
-                Ok(cmd)
+                cmd
             }
-            MagickCommand::Direct => Ok(Command::new(subcommand)),
+            MagickCommand::Direct => Command::new(subcommand),
             MagickCommand::Downloaded(path) => {
                 let mut cmd = Command::new(path);
                 if subcommand != "convert" {
                     cmd.arg(subcommand);
                 }
-                Ok(cmd)
+                cmd
             }
-        }
+        };
+
+        // Use bundled policy.xml to ensure adequate resource limits for large images
+        // (EU5 locations.png is 16384x8192) and to allow path operations for file lists
+        cmd.env("MAGICK_CONFIGURE_PATH", env!("CARGO_MANIFEST_DIR"));
+
+        Ok(cmd)
     }
 
     fn check_magick_command() -> bool {


### PR DESCRIPTION
Turns out eu5 locations.png may exceed some default imagemagick resource limits, and the returned error will be unhelpful.

By shipping with a custom policy we better insulate ourselves from the user's default imagemagick policy.