### PR TITLE
Add wasm tracing in sub-30 KB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "rstest",
  "serde",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
@@ -3218,6 +3219,7 @@ dependencies = [
  "schemas",
  "serde",
  "serde-wasm-bindgen",
+ "tracing",
  "tsify",
  "wasm-bindgen",
 ]

--- a/src/eu5app/Cargo.toml
+++ b/src/eu5app/Cargo.toml
@@ -22,6 +22,7 @@ postcard = { version = "1.1.3", default-features = false, features = ["use-std"]
 rawzip = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 regex = { workspace = true }

--- a/src/wasm-eu5/Cargo.toml
+++ b/src/wasm-eu5/Cargo.toml
@@ -26,5 +26,6 @@ pdx-zstd = { workspace = true }
 schemas = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde-wasm-bindgen = { workspace = true }
+tracing = { workspace = true }
 tsify = { workspace = true, default-features = false, features = ["js"] }
 wasm-bindgen = { workspace = true }

--- a/src/wasm-eu5/src/console_writer.rs
+++ b/src/wasm-eu5/src/console_writer.rs
@@ -1,0 +1,113 @@
+//! Minimal tracing subscriber for WASM console output
+use std::fmt::Write as FmtWrite;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Level, Metadata, Subscriber};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console, js_name = log)]
+    fn console_log(s: &str);
+    #[wasm_bindgen(js_namespace = console, js_name = debug)]
+    fn console_debug(s: &str);
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    fn console_warn(s: &str);
+    #[wasm_bindgen(js_namespace = console, js_name = error)]
+    fn console_error(s: &str);
+}
+
+/// Visitor that extracts fields into a formatted string
+struct FieldVisitor {
+    output: String,
+}
+
+impl FieldVisitor {
+    fn new() -> Self {
+        Self {
+            output: String::new(),
+        }
+    }
+}
+
+impl Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        // Special handling for the "message" field (the primary log message)
+        if field.name() == "message" {
+            write!(&mut self.output, "{:?}", value).unwrap();
+        } else {
+            // Include other fields as key=value pairs
+            if !self.output.is_empty() {
+                write!(&mut self.output, " ").unwrap();
+            }
+            write!(&mut self.output, "{}={:?}", field.name(), value).unwrap();
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.output.push_str(value);
+        } else {
+            if !self.output.is_empty() {
+                write!(&mut self.output, " ").unwrap();
+            }
+            write!(&mut self.output, "{}=\"{}\"", field.name(), value).unwrap();
+        }
+    }
+}
+
+pub struct ConsoleSubscriber {
+    max_level: Level,
+}
+
+impl ConsoleSubscriber {
+    pub fn new(max_level: Level) -> Self {
+        Self { max_level }
+    }
+}
+
+impl Subscriber for ConsoleSubscriber {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.level() <= &self.max_level
+    }
+
+    fn new_span(&self, _span: &Attributes<'_>) -> Id {
+        Id::from_u64(1) // Minimal span support - we don't track spans
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+    fn enter(&self, _span: &Id) {}
+    fn exit(&self, _span: &Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        let metadata = event.metadata();
+
+        // Extract fields using our visitor
+        let mut visitor = FieldVisitor::new();
+        event.record(&mut visitor);
+
+        // Format: "LEVEL message"
+        let level_str = match *metadata.level() {
+            Level::ERROR => "ERROR",
+            Level::WARN => "WARN",
+            Level::INFO => "INFO",
+            Level::DEBUG => "DEBUG",
+            Level::TRACE => "TRACE",
+        };
+
+        let msg = if visitor.output.is_empty() {
+            format!("{} {}", level_str, metadata.name())
+        } else {
+            format!("{} {}", level_str, visitor.output)
+        };
+
+        // Route to appropriate console method for visual distinction in DevTools
+        match *metadata.level() {
+            Level::ERROR => console_error(&msg),
+            Level::WARN => console_warn(&msg),
+            Level::DEBUG | Level::TRACE => console_debug(&msg),
+            Level::INFO => console_log(&msg),
+        }
+    }
+}

--- a/src/wasm-eu5/src/lib.rs
+++ b/src/wasm-eu5/src/lib.rs
@@ -60,6 +60,7 @@ impl From<Eu5MapMode> for MapMode {
 }
 
 mod console_error_panic_hook;
+mod console_writer;
 mod tokens;
 pub use tokens::set_tokens;
 
@@ -769,6 +770,11 @@ pub enum HoverDisplayData {
 #[wasm_bindgen]
 pub fn setup_eu5_wasm() {
     crate::console_error_panic_hook::set_once();
+
+    tracing::subscriber::set_global_default(console_writer::ConsoleSubscriber::new(
+        tracing::Level::DEBUG,
+    ))
+    .expect("setting tracing default failed");
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
This commit adds browser console logging via the `tracing` crate with a custom subscriber that adds ~29,000 bytes to the payload (uncompressed). Previously it was 129,000 bytes with the default `tracing-subscriber` formatter.