### PR TITLE
Demonstrate desktop EU5 map rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +40,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +60,33 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "android-activity"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+dependencies = [
+ "android-properties",
+ "bitflags 2.9.1",
+ "cc",
+ "cesu8",
+ "jni",
+ "jni-sys",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
@@ -115,10 +171,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ash"
@@ -139,6 +207,12 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
@@ -226,7 +300,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -267,6 +341,15 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -327,6 +410,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.9.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +451,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -459,6 +574,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +617,30 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
 
 [[package]]
 name = "core-graphics-types"
@@ -612,6 +770,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +809,18 @@ checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "either"
@@ -748,6 +939,7 @@ dependencies = [
 name = "eu5native"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bumpalo",
  "bumpalo-serde",
  "bytemuck",
@@ -755,10 +947,13 @@ dependencies = [
  "eu5app",
  "eu5save",
  "image",
+ "nu-ansi-term",
  "pdx-map",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wgpu",
+ "winit",
 ]
 
 [[package]]
@@ -933,6 +1128,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.0.7",
+ "windows-link",
 ]
 
 [[package]]
@@ -1383,6 +1588,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1719,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "redox_syscall 0.5.18",
+]
+
+[[package]]
 name = "libwebp-sys"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1747,12 @@ checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1604,6 +1842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "metal"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,7 +1858,7 @@ checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
  "bitflags 2.9.1",
  "block",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
  "log",
  "objc",
@@ -1708,6 +1955,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.9.1",
+ "jni-sys",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,12 +2023,237 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2",
+ "dispatch",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.9.1",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1829,12 +2322,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbclient"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad146e19b9437f8604c21f8652423595cf710ad108af40e77d3ae6e96b827"
+dependencies = [
+ "libredox",
+]
+
+[[package]]
 name = "ordered-float"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
 ]
 
 [[package]]
@@ -1855,7 +2366,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2006,6 +2517,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,6 +2593,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.5.1",
+ "pin-project-lite",
+ "rustix 1.0.7",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2138,6 +2683,15 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -2230,6 +2784,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2334,6 +2897,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -2341,7 +2917,7 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2395,10 +2971,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
 
 [[package]]
 name = "security-framework"
@@ -2567,6 +3162,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.9.1",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,6 +3258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,7 +3317,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -2752,6 +3387,31 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -2962,6 +3622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,6 +3644,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -3309,10 +3981,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.0.7",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
+dependencies = [
+ "bitflags 2.9.1",
+ "rustix 1.0.7",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.9.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
+dependencies = [
+ "rustix 1.0.7",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
+dependencies = [
+ "bitflags 2.9.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07a14257c077ab3279987c4f8bb987851bf57081b93710381daea94f2c2c032"
+dependencies = [
+ "bitflags 2.9.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
+dependencies = [
+ "bitflags 2.9.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3431,7 +4222,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
@@ -3495,7 +4286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3508,7 +4299,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3545,7 +4336,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3555,7 +4346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3564,7 +4364,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3573,7 +4373,31 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3582,15 +4406,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3600,9 +4430,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3618,9 +4460,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3630,15 +4484,79 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winit"
+version = "0.30.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.9.1",
+ "block2",
+ "bytemuck",
+ "calloop",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
 
 [[package]]
 name = "winnow"
@@ -3663,6 +4581,63 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.0.7",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.9.1",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ jomini = { version = "0.34", features = ["envelope"] }
 js-sys = "0.3.83"
 mathru = "0.15.3"
 mimalloc = "0.1.43"
+nu-ansi-term = "0.50.1"
 pdx-assets = { path = "src/pdx-assets" }
 pdx-map = { path = "src/pdx-map", default-features = false }
 pdx-zstd = { path = "src/pdx-zstd", default-features = false }
@@ -99,6 +100,7 @@ wasm-pdx-map = { path = "src/wasm-pdx-map" }
 web-sys = "0.3.83"
 webp = "0.3"
 wgpu = { version = "27.0" }
+winit = "0.30"
 zstd = { version = "0.13.0", default-features = false }
 
 [workspace.lints]

--- a/src/eu5native/Cargo.toml
+++ b/src/eu5native/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 bytemuck = { workspace = true, features = ["derive"] }
 bumpalo = { workspace = true, features = ["collections"] }
 bumpalo-serde = { workspace = true }
@@ -14,7 +15,10 @@ clap = { workspace = true, features = ["derive"] }
 eu5app = { workspace = true, default-features = false, features = ["game-install", "zstd_c"] }
 eu5save = { workspace = true }
 image = { workspace = true, features = ["png"] }
+nu-ansi-term = { workspace = true }
 pdx-map = { workspace = true, features = ["render", "tracing"] }
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+wgpu = { workspace = true }
+winit = { workspace = true }

--- a/src/eu5native/src/date_layer.rs
+++ b/src/eu5native/src/date_layer.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use bytemuck::{Pod, Zeroable};
 use pdx_map::wgpu::util::DeviceExt;
-use pdx_map::{RenderLayer, ViewportBounds, wgpu};
+use pdx_map::{RenderLayer, ViewportBounds};
 use tracing::instrument;
 
 const GLYPH_PATTERN_WIDTH: usize = 5;

--- a/src/eu5native/src/gui.rs
+++ b/src/eu5native/src/gui.rs
@@ -1,0 +1,483 @@
+use crate::{Args, date_layer::DateLayer};
+use anyhow::{Context, Result};
+use eu5app::{
+    Eu5LoadedSave, Eu5SaveLoader, Eu5Workspace, MapMode,
+    game_data::{GameData, TextureProvider, game_install::Eu5GameInstall},
+    should_highlight_individual_locations,
+};
+use eu5save::{BasicTokenResolver, Eu5File, models::Gamestate};
+use pdx_map::{
+    GpuSurfaceContext, LogicalPoint, LogicalSize, MapViewController, SurfaceMapRenderer, WorldPoint,
+};
+use std::{path::PathBuf, sync::Arc};
+use tokio::runtime::Runtime;
+use tracing::{error, info, instrument};
+use winit::{
+    application::ApplicationHandler,
+    event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent},
+    event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy},
+    window::{Window, WindowAttributes, WindowId},
+};
+
+enum GuiUserEvent {
+    TextureReady(TextureData),
+    SaveReady(Box<Eu5LoadedSave>),
+    GameDataReady(GameData),
+    WorkspaceReady(Box<WorkspaceBundle>),
+    LoadFailed(anyhow::Error),
+}
+
+struct WorkspaceBundle {
+    save: Eu5LoadedSave,
+    workspace: Eu5Workspace<'static>,
+}
+
+pub fn run_gui(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build multi-threaded Tokio runtime");
+
+    let event_loop = EventLoop::<GuiUserEvent>::with_user_event().build()?;
+    event_loop.set_control_flow(ControlFlow::Poll);
+
+    let proxy = event_loop.create_proxy();
+    let save_file = args.save_file.clone();
+    let tokens_file = args.tokens.clone();
+    let game_data = args.game_data.clone();
+
+    let save_proxy = proxy.clone();
+    rt.spawn_blocking(move || {
+        let event = match load_save(save_file, tokens_file) {
+            Ok(save) => GuiUserEvent::SaveReady(Box::new(save)),
+            Err(err) => GuiUserEvent::LoadFailed(err),
+        };
+
+        if save_proxy.send_event(event).is_err() {
+            error!("Failed to send save event to GUI thread");
+        }
+    });
+
+    let game_proxy = proxy.clone();
+    rt.spawn_blocking(move || match load_game_bundle(game_data) {
+        Ok((texture_data, game_data)) => {
+            if game_proxy
+                .send_event(GuiUserEvent::TextureReady(texture_data))
+                .is_err()
+            {
+                error!("Failed to send texture event to GUI thread");
+                return;
+            }
+
+            if game_proxy
+                .send_event(GuiUserEvent::GameDataReady(game_data))
+                .is_err()
+            {
+                error!("Failed to send game data event to GUI thread");
+            }
+        }
+        Err(err) => {
+            if game_proxy
+                .send_event(GuiUserEvent::LoadFailed(err))
+                .is_err()
+            {
+                error!("Failed to send game data failure to GUI thread");
+            }
+        }
+    });
+
+    let mut app = App {
+        rt,
+        proxy,
+        save: None,
+        game_data: None,
+        workspace: None,
+        texture_data: None,
+        pending_workspace: None,
+        workspace_building: false,
+        window: None,
+        gpu: None,
+        controller: None,
+        last_cursor_pos: None,
+        last_world_under_cursor: None,
+        is_dragging: false,
+        scale_factor: 1.0,
+    };
+
+    event_loop.run_app(&mut app)?;
+
+    Ok(())
+}
+
+fn load_save(save_file: PathBuf, tokens_file: PathBuf) -> Result<Eu5LoadedSave> {
+    info!("Using save file: {}", save_file.display());
+    let file = std::fs::File::open(&save_file)
+        .with_context(|| format!("Failed to open save file {}", save_file.display()))?;
+    let file = Eu5File::from_file(file)
+        .with_context(|| format!("Failed to read save file {}", save_file.display()))?;
+
+    info!("Using tokens file: {}", tokens_file.display());
+    let file_data = std::fs::read(&tokens_file)
+        .with_context(|| format!("Failed to read tokens file {}", tokens_file.display()))?;
+    let resolver = BasicTokenResolver::from_text_lines(file_data.as_slice())
+        .with_context(|| format!("Failed to parse tokens file {}", tokens_file.display()))?;
+
+    let parser = Eu5SaveLoader::open(file, resolver)
+        .with_context(|| format!("Failed to open save file {}", save_file.display()))?;
+
+    let save = parser
+        .parse()
+        .with_context(|| format!("Failed to parse save file {}", save_file.display()))?;
+
+    Ok(save)
+}
+
+fn load_game_bundle(game_data: PathBuf) -> Result<(TextureData, GameData)> {
+    let mut game_bundle = Eu5GameInstall::open(&game_data)
+        .with_context(|| format!("Failed to load game data {}", game_data.display()))?;
+    // Extract textures before workspace consumes the bundle
+    let west_texture = game_bundle
+        .load_west_texture(Vec::new())
+        .context("Failed to load west texture")?;
+    let east_texture = game_bundle
+        .load_east_texture(Vec::new())
+        .context("Failed to load east texture")?;
+
+    let texture_data = TextureData {
+        west: west_texture,
+        east: east_texture,
+    };
+
+    Ok((texture_data, game_bundle.into_game_data()))
+}
+
+/// Pre-extracted texture data to avoid re-opening game bundle
+struct TextureData {
+    west: Vec<u8>,
+    east: Vec<u8>,
+}
+
+struct App {
+    rt: Runtime,
+    proxy: EventLoopProxy<GuiUserEvent>,
+    save: Option<Box<Eu5LoadedSave>>,
+    game_data: Option<GameData>,
+    workspace: Option<Eu5Workspace<'static>>,
+    texture_data: Option<TextureData>,
+    pending_workspace: Option<Box<WorkspaceBundle>>,
+    workspace_building: bool,
+    window: Option<Arc<Window>>,
+    gpu: Option<GpuSurfaceContext>,
+    controller: Option<MapViewController>,
+    last_cursor_pos: Option<(f32, f32)>,
+    last_world_under_cursor: Option<WorldPoint<f32>>,
+    is_dragging: bool,
+    scale_factor: f64,
+}
+
+impl App {
+    fn try_initialize_renderer(&mut self) {
+        if self.controller.is_some() {
+            return;
+        }
+
+        let Some(window) = self.window.as_ref().cloned() else {
+            return;
+        };
+
+        let Some(gpu) = self.gpu.take() else {
+            return;
+        };
+
+        let Some(texture_data) = self.texture_data.take() else {
+            self.gpu = Some(gpu);
+            return;
+        };
+
+        let controller = init_renderer(&window, gpu, &texture_data);
+        self.controller = Some(controller);
+        window.request_redraw();
+        self.try_apply_workspace();
+    }
+
+    fn try_start_workspace_build(&mut self) {
+        if self.workspace.is_some() || self.workspace_building {
+            return;
+        }
+
+        let Some(save) = self.save.take() else {
+            return;
+        };
+
+        let Some(game_data) = self.game_data.take() else {
+            self.save = Some(save);
+            return;
+        };
+
+        self.workspace_building = true;
+        let proxy = self.proxy.clone();
+        self.rt.spawn_blocking(move || {
+            let event = match build_workspace(*save, game_data) {
+                Ok(bundle) => GuiUserEvent::WorkspaceReady(Box::new(bundle)),
+                Err(err) => GuiUserEvent::LoadFailed(err),
+            };
+
+            if proxy.send_event(event).is_err() {
+                error!("Failed to send workspace event to GUI thread");
+            }
+        });
+    }
+
+    fn try_apply_workspace(&mut self) {
+        let Some(controller) = &mut self.controller else {
+            return;
+        };
+
+        let Some(bundle) = self.pending_workspace.take() else {
+            return;
+        };
+
+        apply_workspace(controller, &bundle.workspace);
+        self.save = Some(Box::new(bundle.save));
+        self.workspace = Some(bundle.workspace);
+
+        if let Some(window) = &self.window {
+            window.request_redraw();
+        }
+    }
+}
+
+impl ApplicationHandler<GuiUserEvent> for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_some() {
+            return;
+        }
+
+        // Use logical (DPI-independent) sizes for map math; physical size is derived via scale_factor
+        let window_attrs = WindowAttributes::default()
+            .with_title("PDX.Tools")
+            .with_inner_size(winit::dpi::PhysicalSize::new(1920, 1080));
+
+        let window = Arc::new(
+            event_loop
+                .create_window(window_attrs)
+                .expect("Failed to create window"),
+        );
+        self.scale_factor = window.scale_factor();
+
+        // Initialize the GPU context, blocking while until ready it may seem
+        // weird to block here, but I guess this is considered idiomatic for
+        // winit + wgpu apps, as the window must be referenced on the main
+        // thread.
+        let gpu = self
+            .rt
+            .block_on(pdx_map::GpuSurfaceContext::new(window.clone()))
+            .expect("Failed to create GPU context");
+
+        self.window = Some(window);
+        self.gpu = Some(gpu);
+        self.try_initialize_renderer();
+    }
+
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: GuiUserEvent) {
+        match event {
+            GuiUserEvent::TextureReady(texture_data) => {
+                self.texture_data = Some(texture_data);
+                self.try_initialize_renderer();
+            }
+            GuiUserEvent::SaveReady(save) => {
+                self.save = Some(save);
+                self.try_start_workspace_build();
+            }
+            GuiUserEvent::GameDataReady(game_data) => {
+                self.game_data = Some(game_data);
+                self.try_start_workspace_build();
+            }
+            GuiUserEvent::WorkspaceReady(bundle) => {
+                self.workspace_building = false;
+                self.pending_workspace = Some(bundle);
+                self.try_apply_workspace();
+            }
+            GuiUserEvent::LoadFailed(err) => {
+                error!("Failed to load data: {err}");
+                event_loop.exit();
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(window) = self.window.as_ref().cloned() else {
+            return;
+        };
+
+        match event {
+            WindowEvent::CloseRequested => {
+                self.controller = None;
+                event_loop.exit();
+                return;
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                self.scale_factor = scale_factor;
+            }
+            _ => {}
+        }
+
+        let Some(controller) = &mut self.controller else {
+            return;
+        };
+
+        match event {
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                let size = window.inner_size();
+                let logical = size.to_logical::<f64>(scale_factor);
+                controller.resize(LogicalSize::new(
+                    logical.width.round() as u32,
+                    logical.height.round() as u32,
+                ));
+                window.request_redraw();
+            }
+            WindowEvent::Resized(new_size) => {
+                if new_size.width > 0 && new_size.height > 0 {
+                    let scale = self.scale_factor;
+                    let logical = new_size.to_logical::<f64>(scale);
+                    controller.resize(LogicalSize::new(
+                        logical.width.round() as u32,
+                        logical.height.round() as u32,
+                    ));
+                    window.request_redraw();
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                if let Err(e) = controller.render() {
+                    error!("Render error: {e}");
+                }
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                let scale = self.scale_factor as f32;
+                let cursor_x = (position.x as f32) / scale;
+                let cursor_y = (position.y as f32) / scale;
+                let previous_world = self.last_world_under_cursor;
+
+                if self.is_dragging
+                    && let Some(world_coords) = previous_world
+                {
+                    controller.set_world_point_under_cursor(
+                        world_coords,
+                        LogicalPoint::new(cursor_x, cursor_y),
+                    );
+                    window.request_redraw();
+                }
+
+                // Only update world-under-cursor when not dragging
+                if !self.is_dragging {
+                    self.last_world_under_cursor =
+                        Some(controller.canvas_to_world(cursor_x, cursor_y));
+                }
+                self.last_cursor_pos = Some((cursor_x, cursor_y));
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                if button == MouseButton::Left {
+                    self.is_dragging = state == ElementState::Pressed;
+                    if self.is_dragging {
+                        let (cursor_x, cursor_y) = self.last_cursor_pos.unwrap_or_else(|| {
+                            let size = window.inner_size();
+                            let logical = size.to_logical::<f64>(self.scale_factor);
+                            let center = (logical.width as f32 / 2.0, logical.height as f32 / 2.0);
+                            self.last_cursor_pos = Some(center);
+                            center
+                        });
+
+                        self.last_world_under_cursor =
+                            Some(controller.canvas_to_world(cursor_x, cursor_y));
+                    } else {
+                        self.last_world_under_cursor = None;
+                    }
+                }
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                let scroll_lines = match delta {
+                    MouseScrollDelta::LineDelta(_, y) => y,
+                    MouseScrollDelta::PixelDelta(pos) => pos.y as f32 / 120.0,
+                };
+
+                if scroll_lines.abs() > f32::EPSILON {
+                    let clamped = scroll_lines.clamp(-6.0, 6.0);
+                    let zoom_delta = 1.1_f32.powf(clamped);
+
+                    let (cursor_x, cursor_y) = self.last_cursor_pos.unwrap_or_else(|| {
+                        let size = window.inner_size();
+                        let logical = size.to_logical::<f64>(self.scale_factor);
+                        (logical.width as f32 / 2.0, logical.height as f32 / 2.0)
+                    });
+
+                    controller.zoom_at_point(cursor_x, cursor_y, zoom_delta);
+                    let show_location_borders =
+                        should_highlight_individual_locations(controller.get_zoom());
+                    controller
+                        .renderer_mut()
+                        .set_location_borders(show_location_borders);
+
+                    self.last_world_under_cursor =
+                        Some(controller.canvas_to_world(cursor_x, cursor_y));
+                    window.request_redraw();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {}
+}
+
+#[instrument(skip_all)]
+fn init_renderer(
+    window: &Window,
+    gpu_ctx: GpuSurfaceContext,
+    texture_data: &TextureData,
+) -> MapViewController {
+    let (tile_width, tile_height) = eu5app::tile_dimensions();
+    let west_texture = gpu_ctx.create_texture(&texture_data.west, tile_width, tile_height, "West");
+    let east_texture = gpu_ctx.create_texture(&texture_data.east, tile_width, tile_height, "East");
+
+    // Create surface pipeline
+    let size = window.inner_size();
+    let scale_factor = window.scale_factor();
+    let logical_size = size.to_logical::<f64>(scale_factor);
+    let logical = LogicalSize::new(
+        logical_size.width.round() as u32,
+        logical_size.height.round() as u32,
+    );
+    let physical = logical.to_physical(scale_factor as f32);
+
+    let renderer = SurfaceMapRenderer::new(gpu_ctx, west_texture, east_texture, physical);
+    MapViewController::new(renderer, logical, scale_factor as f32)
+}
+
+fn build_workspace(mut save: Eu5LoadedSave, game_data: GameData) -> Result<WorkspaceBundle> {
+    let gamestate = save.take_gamestate();
+    let gamestate = unsafe { std::mem::transmute::<Gamestate<'_>, Gamestate<'static>>(gamestate) };
+    let mut workspace =
+        Eu5Workspace::new(gamestate, game_data).context("Failed to initialize workspace")?;
+    workspace.set_map_mode(MapMode::Political);
+
+    Ok(WorkspaceBundle { save, workspace })
+}
+
+fn apply_workspace(controller: &mut MapViewController, workspace: &Eu5Workspace<'_>) {
+    let save_date = workspace.gamestate().metadata().date.date_fmt().to_string();
+    controller
+        .renderer_mut()
+        .add_layer(DateLayer::new(save_date, 4));
+    controller
+        .renderer_mut()
+        .update_locations(workspace.location_arrays());
+
+    if let Some((x, y)) = workspace.player_capital_coordinates() {
+        controller.center_at_world(WorldPoint::new(x as f32, y as f32));
+    }
+}

--- a/src/eu5native/src/headless.rs
+++ b/src/eu5native/src/headless.rs
@@ -1,0 +1,225 @@
+use std::path::PathBuf;
+
+use crate::{Args, date_layer::DateLayer};
+use eu5app::{
+    Eu5SaveLoader, Eu5Workspace, MapMode,
+    game_data::{TextureProvider, game_install::Eu5GameInstall},
+};
+use eu5save::{BasicTokenResolver, Eu5File};
+use pdx_map::{StitchedImage, ViewportBounds, WorldSize};
+use tracing::{info, info_span};
+
+/// Validate that width and height are both provided or both absent
+fn validate_dimensions(
+    width: Option<u32>,
+    height: Option<u32>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match (width, height) {
+        (Some(w), Some(h)) => {
+            if w == 0 || h == 0 {
+                return Err("Width and height must be greater than 0".into());
+            }
+            let (_, world_height) = eu5app::world_dimensions();
+            if h > world_height {
+                return Err(format!("Height {} exceeds world height {}", h, world_height).into());
+            }
+            Ok(())
+        }
+        (None, None) => Ok(()),
+        _ => Err("Both --width and --height must be specified together".into()),
+    }
+}
+
+/// Calculate viewport bounds centered on player's capital (or world center as fallback)
+/// Returns (x_offset, y_offset)
+fn calculate_viewport_bounds(map_app: &Eu5Workspace, width: u32, height: u32) -> (u32, u32) {
+    let (world_width, world_height) = eu5app::world_dimensions();
+
+    // Get player capital or fallback to world center
+    let (capital_x, capital_y) = map_app
+        .player_capital_coordinates()
+        .unwrap_or((world_width as u16 / 2, world_height as u16 / 2));
+
+    // Center horizontally with proper wraparound handling
+    let x_centered = capital_x as i32 - (width / 2) as i32;
+    let x = x_centered.rem_euclid(world_width as i32) as u32;
+
+    let y = (capital_y as i32 - (height / 2) as i32)
+        .max(0)
+        .min((world_height - height) as i32) as u32;
+
+    (x, y)
+}
+
+/// Calculate proportional text scale based on viewport height
+fn calculate_text_scale(viewport_height: u32) -> u32 {
+    // Scale formula: height / 400 gives good proportions
+    // Examples: 8192→20, 4096→10, 2048→5, 1024→2
+    (viewport_height / 400).max(2)
+}
+
+pub fn run_headless(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .expect("Failed to build single-threaded Tokio runtime");
+
+    rt.block_on(async { run_headless_async(args).await })
+}
+
+async fn run_headless_async(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Using save file: {}", args.save_file.display());
+    let file = std::fs::File::open(&args.save_file)?;
+    let file = Eu5File::from_file(file)?;
+
+    info!("Using tokens file: {}", args.tokens.display());
+    let file_data = std::fs::read(&args.tokens)?;
+    let resolver = BasicTokenResolver::from_text_lines(file_data.as_slice())?;
+
+    let parser = Eu5SaveLoader::open(file, resolver)?;
+
+    let mut save = parser.parse()?;
+
+    let mut game_bundle = Eu5GameInstall::open(&args.game_data)?;
+
+    let pipeline_components = pdx_map::GpuContext::new().await?;
+    let texture_data = game_bundle.load_west_texture(Vec::new())?;
+
+    let (tile_width, tile_height) = eu5app::tile_dimensions();
+    let west_view =
+        pipeline_components.create_texture(&texture_data, tile_width, tile_height, "West Texture");
+
+    let texture_data = game_bundle.load_east_texture(Vec::new())?;
+
+    let east_view =
+        pipeline_components.create_texture(&texture_data, tile_width, tile_height, "East Texture");
+
+    let map_app = Eu5Workspace::new(save.take_gamestate(), game_bundle.into_game_data())?;
+    let save_date = map_app.gamestate().metadata().date.date_fmt().to_string();
+
+    // Validate dimensions
+    validate_dimensions(args.width, args.height)?;
+
+    // Determine dimensions and centering
+    let (width, height, center_on_capital) = if let (Some(w), Some(h)) = (args.width, args.height) {
+        info!("Rendering custom viewport: {}×{}", w, h);
+        (w, h, true)
+    } else {
+        let (world_width, world_height) = eu5app::world_dimensions();
+        info!("Rendering full world: {}×{}", world_width, world_height);
+        (world_width, world_height, false)
+    };
+
+    render_viewport(
+        map_app,
+        &pipeline_components,
+        west_view,
+        east_view,
+        save_date,
+        width,
+        height,
+        center_on_capital,
+        &args.output.expect("output buf to be defined"),
+    )
+    .await
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn render_viewport(
+    mut map_app: Eu5Workspace<'_>,
+    pipeline_components: &'_ pdx_map::GpuContext,
+    west_view: pdx_map::MapTexture,
+    east_view: pdx_map::MapTexture,
+    save_date: String,
+    width: u32,
+    height: u32,
+    center_on_capital: bool,
+    output: &'_ PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Calculate viewport position
+    let (x_offset, y_offset) = if center_on_capital {
+        calculate_viewport_bounds(&map_app, width, height)
+    } else {
+        (0, 0) // Full world starts at origin
+    };
+
+    let (tile_width, _) = eu5app::tile_dimensions();
+
+    let viewport_width = if width > tile_width { width / 2 } else { width };
+
+    let mut viewport = ViewportBounds::new(WorldSize::new(viewport_width, height));
+    viewport.rect.origin.x = x_offset;
+    viewport.rect.origin.y = y_offset;
+
+    let mut renderer = pdx_map::HeadlessMapRenderer::new(
+        pipeline_components.clone(),
+        west_view,
+        east_view,
+        viewport.rect.size.width,
+        height,
+    )?;
+
+    map_app.set_map_mode(MapMode::Political);
+    renderer.update_locations(map_app.location_arrays());
+
+    let text_scale = calculate_text_scale(height);
+    let date_layer = renderer.add_layer(DateLayer::new(save_date, text_scale));
+
+    // For viewports wider than tile_width (8192), we need to stitch two renders together
+    let image_data = if width > tile_width {
+        assert!(
+            width <= tile_width * 2,
+            "viewport width exceeds maximum for stitching"
+        );
+
+        let mut stitched_data = StitchedImage::new(width, height);
+
+        // Render west half
+        let span = info_span!("readback_west");
+        let _enter = span.enter();
+        let viewport_data = renderer.capture_viewport(viewport).await?;
+        stitched_data.write_west(viewport_data.rows());
+        viewport_data.finish();
+        drop(_enter);
+
+        // Hide date layer for east half (only show once)
+        renderer.set_layer_visible(date_layer, false);
+
+        // Render east half
+        let span = info_span!("readback_east");
+        let _enter = span.enter();
+        viewport.rect.origin.x += viewport.rect.size.width;
+        let viewport_data = renderer.capture_viewport(viewport).await?;
+        stitched_data.write_east(viewport_data.rows());
+        viewport_data.finish();
+        stitched_data.into_inner()
+    } else {
+        let mut image_buffer = vec![0u8; (width * height * 4) as usize];
+
+        let span = info_span!("readback_viewport_data");
+        let _enter = span.enter();
+        let viewport_data = renderer.capture_viewport(viewport).await?;
+
+        for (src, dst) in viewport_data
+            .rows()
+            .zip(image_buffer.chunks_exact_mut(width as usize * 4))
+        {
+            dst.copy_from_slice(src);
+        }
+
+        viewport_data.finish();
+        image_buffer
+    };
+
+    let span = info_span!("RgbaImage::from_raw");
+    let _enter = span.enter();
+    let output_img = image::RgbaImage::from_raw(width, height, image_data)
+        .ok_or("Failed to create image from raw buffer")?;
+    drop(_enter);
+
+    let span = info_span!("RgbaImage::save", output = %output.display());
+    let _enter = span.enter();
+    output_img.save(output)?;
+    drop(_enter);
+
+    Ok(())
+}

--- a/src/eu5native/src/main.rs
+++ b/src/eu5native/src/main.rs
@@ -1,86 +1,26 @@
 use clap::Parser;
-use date_layer::DateLayer;
-use eu5app::{
-    Eu5SaveLoader, Eu5Workspace, MapMode,
-    game_data::{TextureProvider, game_install::Eu5GameInstall},
-};
-use eu5save::{BasicTokenResolver, Eu5File};
-use pdx_map::{StitchedImage, ViewportBounds};
 use std::{io::IsTerminal, path::PathBuf};
-use tracing::{info, info_span, level_filters::LevelFilter};
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
 mod date_layer;
 
-/// Validate that width and height are both provided or both absent
-fn validate_dimensions(
-    width: Option<u32>,
-    height: Option<u32>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    match (width, height) {
-        (Some(w), Some(h)) => {
-            if w == 0 || h == 0 {
-                return Err("Width and height must be greater than 0".into());
-            }
-            let (_, world_height) = eu5app::world_dimensions();
-            if h > world_height {
-                return Err(format!("Height {} exceeds world height {}", h, world_height).into());
-            }
-            Ok(())
-        }
-        (None, None) => Ok(()),
-        _ => Err("Both --width and --height must be specified together".into()),
-    }
-}
-
-/// Calculate viewport bounds centered on player's capital (or world center as fallback)
-/// Returns (x_offset, y_offset)
-fn calculate_viewport_bounds(map_app: &Eu5Workspace, width: u32, height: u32) -> (u32, u32) {
-    let (world_width, world_height) = eu5app::world_dimensions();
-
-    // Get player capital or fallback to world center
-    let (capital_x, capital_y) = map_app
-        .player_capital_coordinates()
-        .unwrap_or((world_width as u16 / 2, world_height as u16 / 2));
-
-    // Center horizontally with proper wraparound handling
-    let x_centered = capital_x as i32 - (width / 2) as i32;
-    let x = x_centered.rem_euclid(world_width as i32) as u32;
-
-    let y = (capital_y as i32 - (height / 2) as i32)
-        .max(0)
-        .min((world_height - height) as i32) as u32;
-
-    (x, y)
-}
-
-/// Calculate proportional text scale based on viewport height
-fn calculate_text_scale(viewport_height: u32) -> u32 {
-    // Scale formula: height / 400 gives good proportions
-    // Examples: 8192→20, 4096→10, 2048→5, 1024→2
-    (viewport_height / 400).max(2)
-}
-
 /// EU5 native map renderer - renders EU5 save files to PNG images
 #[derive(Parser, Debug)]
 #[command(name = "eu5native")]
-#[command(about = "Render EU5 save files to PNG images", long_about = None)]
-struct Args {
+#[command(about = "Render EU5 save files to PNG images or GUI window", long_about = None)]
+pub struct Args {
     /// Path to the EU5 save file
     #[arg(value_name = "SAVE_FILE")]
-    save_file: PathBuf,
+    pub save_file: PathBuf,
 
     /// Path to game data (directory, source bundle, or compiled bundle)
     #[arg(short = 'g', long, default_value = "assets")]
-    game_data: PathBuf,
+    pub game_data: PathBuf,
 
     /// Path to EU5 tokens file
     #[arg(short = 't', long, default_value = "assets/eu5.txt")]
-    tokens: PathBuf,
-
-    /// Output PNG file path
-    #[arg(short = 'o', long, default_value = "locations.png")]
-    output: PathBuf,
+    pub tokens: PathBuf,
 
     /// Optional width for custom viewport screenshot
     #[arg(short = 'w', long)]
@@ -89,182 +29,52 @@ struct Args {
     /// Optional height for custom viewport screenshot
     #[arg(short = 'h', long)]
     height: Option<u32>,
+
+    /// Output PNG file path (required when --gui is not set)
+    #[arg(short = 'o', long)]
+    pub output: Option<PathBuf>,
+
+    /// Launch GUI window instead of generating PNG
+    #[arg(long)]
+    pub gui: bool,
 }
 
+mod gui;
+mod headless;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let is_terminal = std::io::stdout().is_terminal();
+
+    #[cfg(windows)]
+    {
+        if is_terminal {
+            nu_ansi_term::enable_ansi_support().expect("Failed to enable ANSI support on Windows");
+        }
+    }
+
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();
 
     tracing_subscriber::fmt()
         .with_env_filter(env_filter)
-        .with_ansi(std::io::stdout().is_terminal())
+        .with_ansi(is_terminal)
         .with_span_events(FmtSpan::CLOSE)
         .init();
 
     let args = Args::parse();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .build()
-        .expect("Failed to build single-threaded Tokio runtime");
+    // Validate arguments
+    if !args.gui && args.output.is_none() {
+        eprintln!("--output is required when not using --gui mode");
+        std::process::exit(1);
+    }
 
-    rt.block_on(async { main_async(args).await })
-}
-
-async fn main_async(args: Args) -> Result<(), Box<dyn std::error::Error>> {
-    info!("Using save file: {}", args.save_file.display());
-    let file = std::fs::File::open(&args.save_file)?;
-    let file = Eu5File::from_file(file)?;
-
-    info!("Using tokens file: {}", args.tokens.display());
-    let file_data = std::fs::read(&args.tokens)?;
-    let resolver = BasicTokenResolver::from_text_lines(file_data.as_slice())?;
-
-    let parser = Eu5SaveLoader::open(file, resolver)?;
-
-    let mut save = parser.parse()?;
-
-    let mut game_bundle = Eu5GameInstall::open(&args.game_data)?;
-
-    let pipeline_components = pdx_map::GpuContext::new().await?;
-    let texture_data = game_bundle.load_west_texture(Vec::new())?;
-
-    let (tile_width, tile_height) = eu5app::tile_dimensions();
-    let west_view =
-        pipeline_components.create_texture(&texture_data, tile_width, tile_height, "West Texture");
-
-    let texture_data = game_bundle.load_east_texture(Vec::new())?;
-
-    let east_view =
-        pipeline_components.create_texture(&texture_data, tile_width, tile_height, "East Texture");
-
-    let map_app = Eu5Workspace::new(save.take_gamestate(), game_bundle.into_game_data())?;
-    let save_date = map_app.gamestate().metadata().date.date_fmt().to_string();
-
-    // Validate dimensions
-    validate_dimensions(args.width, args.height)?;
-
-    // Determine dimensions and centering
-    let (width, height, center_on_capital) = if let (Some(w), Some(h)) = (args.width, args.height) {
-        info!("Rendering custom viewport: {}×{}", w, h);
-        (w, h, true)
+    if args.gui {
+        gui::run_gui(args)?;
     } else {
-        let (world_width, world_height) = eu5app::world_dimensions();
-        info!("Rendering full world: {}×{}", world_width, world_height);
-        (world_width, world_height, false)
-    };
-
-    render_viewport(
-        map_app,
-        &pipeline_components,
-        west_view,
-        east_view,
-        save_date,
-        width,
-        height,
-        center_on_capital,
-        &args.output,
-    )
-    .await
-}
-
-#[expect(clippy::too_many_arguments)]
-async fn render_viewport(
-    mut map_app: Eu5Workspace<'_>,
-    pipeline_components: &'_ pdx_map::GpuContext,
-    west_view: pdx_map::MapTexture,
-    east_view: pdx_map::MapTexture,
-    save_date: String,
-    width: u32,
-    height: u32,
-    center_on_capital: bool,
-    output: &'_ PathBuf,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Calculate viewport position
-    let (x_offset, y_offset) = if center_on_capital {
-        calculate_viewport_bounds(&map_app, width, height)
-    } else {
-        (0, 0) // Full world starts at origin
-    };
-
-    let (tile_width, _) = eu5app::tile_dimensions();
-
-    let viewport_width = if width > tile_width { width / 2 } else { width };
-
-    let mut viewport = ViewportBounds::new(pdx_map::WorldSize::new(viewport_width, height));
-    viewport.rect.origin.x = x_offset;
-    viewport.rect.origin.y = y_offset;
-
-    let mut renderer = pdx_map::HeadlessMapRenderer::new(
-        pipeline_components.clone(),
-        west_view,
-        east_view,
-        viewport.rect.size.width,
-        height,
-    )?;
-
-    map_app.set_map_mode(MapMode::Political);
-    renderer.update_locations(map_app.location_arrays());
-
-    let text_scale = calculate_text_scale(height);
-    let date_layer = renderer.add_layer(DateLayer::new(save_date, text_scale));
-
-    // For viewports wider than tile_width (8192), we need to stitch two renders together
-    let image_data = if width > tile_width {
-        assert!(
-            width <= tile_width * 2,
-            "viewport width exceeds maximum for stitching"
-        );
-
-        let mut stitched_data = StitchedImage::new(width, height);
-
-        // Render west half
-        let span = info_span!("readback_west");
-        let _enter = span.enter();
-        let viewport_data = renderer.capture_viewport(viewport).await?;
-        stitched_data.write_west(viewport_data.rows());
-        viewport_data.finish();
-        drop(_enter);
-
-        // Hide date layer for east half (only show once)
-        renderer.set_layer_visible(date_layer, false);
-
-        // Render east half
-        let span = info_span!("readback_east");
-        let _enter = span.enter();
-        viewport.rect.origin.x += viewport.rect.size.width;
-        let viewport_data = renderer.capture_viewport(viewport).await?;
-        stitched_data.write_east(viewport_data.rows());
-        viewport_data.finish();
-        stitched_data.into_inner()
-    } else {
-        let mut image_buffer = vec![0u8; (width * height * 4) as usize];
-
-        let span = info_span!("readback_viewport_data");
-        let _enter = span.enter();
-        let viewport_data = renderer.capture_viewport(viewport).await?;
-
-        for (src, dst) in viewport_data
-            .rows()
-            .zip(image_buffer.chunks_exact_mut(width as usize * 4))
-        {
-            dst.copy_from_slice(src);
-        }
-
-        viewport_data.finish();
-        image_buffer
-    };
-
-    let span = info_span!("RgbaImage::from_raw");
-    let _enter = span.enter();
-    let output_img = image::RgbaImage::from_raw(width, height, image_data)
-        .ok_or("Failed to create image from raw buffer")?;
-    drop(_enter);
-
-    let span = info_span!("RgbaImage::save", output = %output.display());
-    let _enter = span.enter();
-    output_img.save(output)?;
-    drop(_enter);
+        headless::run_headless(args)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This is to capture the use case so that future refactoring doesn't break it.

<img width="1922" height="1118" alt="image" src="https://github.com/user-attachments/assets/11d6ff6d-b59b-4251-828a-dc05e5859d60" />

```
cargo build --release --package eu5native
```

```
.\target\release\eu5native.exe --gui   --tokens .\assets\tokens\eu5.txt   --game-data 'D:\games\steam\steamapps\common\Europa Universalis V'   "C:\Users\nick\Documents\Paradox Interactive\Europa Universalis V\save games\SP_ironman_cbfcf9da-8bf1-4330-9bee-53003182d02d.eu5"
```
At some point the tokens and steam directory can be autodetected