### PR TITLE
Optimize avoid split textures hanging around

### DIFF
--- a/src/eu5app/src/game_data.rs
+++ b/src/eu5app/src/game_data.rs
@@ -58,11 +58,13 @@ impl std::fmt::Debug for GameData {
 
 /// Provides access to map textures.
 pub trait TextureProvider {
-    /// Load west hemisphere texture into provided buffer.
-    fn load_west_texture(&self, dst: &mut [u8]) -> Result<(), GameDataError>;
+    /// Load west hemisphere texture, returning owned data.
+    /// Pass an empty Vec for new allocation, or pass existing Vec to reuse buffer.
+    fn load_west_texture(&mut self, dst: Vec<u8>) -> Result<Vec<u8>, GameDataError>;
 
-    /// Load east hemisphere texture into provided buffer.
-    fn load_east_texture(&self, dst: &mut [u8]) -> Result<(), GameDataError>;
+    /// Load east hemisphere texture, returning owned data.
+    /// Pass an empty Vec for new allocation, or pass existing Vec to reuse buffer.
+    fn load_east_texture(&mut self, dst: Vec<u8>) -> Result<Vec<u8>, GameDataError>;
 
     /// Get expected size of west texture.
     fn west_texture_size(&self) -> usize;

--- a/src/eu5app/src/game_data/game_install.rs
+++ b/src/eu5app/src/game_data/game_install.rs
@@ -28,11 +28,9 @@ impl Eu5GameInstall {
 
             if let Ok(game_data) = OptimizedGameBundle::open(&data) {
                 let game_data = game_data.into_game_data()?;
-                let textures = OptimizedTextureBundle::open(&data)?;
-                let mut west_data = vec![0u8; textures.west_texture_size()];
-                let mut east_data = vec![0u8; textures.east_texture_size()];
-                textures.load_west_texture(&mut west_data)?;
-                textures.load_east_texture(&mut east_data)?;
+                let mut textures = OptimizedTextureBundle::open(&data)?;
+                let west_data = textures.load_west_texture(Vec::new())?;
+                let east_data = textures.load_east_texture(Vec::new())?;
                 let textures = GameTextureBundle::new(west_data, east_data);
                 return Ok(Self {
                     textures,
@@ -80,11 +78,11 @@ impl GameDataProvider for Eu5GameInstall {
 }
 
 impl TextureProvider for Eu5GameInstall {
-    fn load_west_texture(&self, dst: &mut [u8]) -> Result<(), GameDataError> {
+    fn load_west_texture(&mut self, dst: Vec<u8>) -> Result<Vec<u8>, GameDataError> {
         self.textures.load_west_texture(dst)
     }
 
-    fn load_east_texture(&self, dst: &mut [u8]) -> Result<(), GameDataError> {
+    fn load_east_texture(&mut self, dst: Vec<u8>) -> Result<Vec<u8>, GameDataError> {
         self.textures.load_east_texture(dst)
     }
 

--- a/src/eu5app/src/game_data/game_install/raw.rs
+++ b/src/eu5app/src/game_data/game_install/raw.rs
@@ -77,14 +77,14 @@ impl GameTextureBundle {
 }
 
 impl TextureProvider for GameTextureBundle {
-    fn load_west_texture(&self, dst: &mut [u8]) -> Result<(), GameDataError> {
-        dst.copy_from_slice(&self.west_texture);
-        Ok(())
+    fn load_west_texture(&mut self, mut dst: Vec<u8>) -> Result<Vec<u8>, GameDataError> {
+        std::mem::swap(&mut dst, &mut self.west_texture);
+        Ok(dst)
     }
 
-    fn load_east_texture(&self, dst: &mut [u8]) -> Result<(), GameDataError> {
-        dst.copy_from_slice(&self.east_texture);
-        Ok(())
+    fn load_east_texture(&mut self, mut dst: Vec<u8>) -> Result<Vec<u8>, GameDataError> {
+        std::mem::swap(&mut dst, &mut self.east_texture);
+        Ok(dst)
     }
 
     fn west_texture_size(&self) -> usize {

--- a/src/eu5app/src/game_data/optimized.rs
+++ b/src/eu5app/src/game_data/optimized.rs
@@ -142,12 +142,22 @@ impl<R> TextureProvider for OptimizedTextureBundle<R>
 where
     R: AsRef<[u8]>,
 {
-    fn load_west_texture(&self, dst: &mut [u8]) -> Result<(), GameDataError> {
-        self.read_entry(self.west_texture.1, dst)
+    fn load_west_texture(&mut self, mut dst: Vec<u8>) -> Result<Vec<u8>, GameDataError> {
+        let size = self.west_texture_size();
+        if dst.len() != size {
+            dst = vec![0u8; size];
+        }
+        self.read_entry(self.west_texture.1, &mut dst)?;
+        Ok(dst)
     }
 
-    fn load_east_texture(&self, dst: &mut [u8]) -> Result<(), GameDataError> {
-        self.read_entry(self.east_texture.1, dst)
+    fn load_east_texture(&mut self, mut dst: Vec<u8>) -> Result<Vec<u8>, GameDataError> {
+        let size = self.east_texture_size();
+        if dst.len() != size {
+            dst = vec![0u8; size];
+        }
+        self.read_entry(self.east_texture.1, &mut dst)?;
+        Ok(dst)
     }
 
     fn west_texture_size(&self) -> usize {

--- a/src/eu5native/src/main.rs
+++ b/src/eu5native/src/main.rs
@@ -54,7 +54,7 @@ async fn main_async(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     println!("Parsed save file in {}ms", start.elapsed().as_millis());
 
     println!("Using game data: {}", args.game_data.display());
-    let game_bundle = Eu5GameInstall::open(&args.game_data)?;
+    let mut game_bundle = Eu5GameInstall::open(&args.game_data)?;
 
     let start = std::time::Instant::now();
     let pipeline_components = pdx_map::GpuContext::new().await?;
@@ -63,11 +63,8 @@ async fn main_async(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         start.elapsed().as_millis()
     );
 
-    let texture_size = eu5app::texture_buffer_size();
-    let mut texture_data = vec![0u8; texture_size];
-
     let start = std::time::Instant::now();
-    game_bundle.load_west_texture(&mut texture_data)?;
+    let mut texture_data = game_bundle.load_west_texture(Vec::new())?;
     println!("Read west texture in {}ms", start.elapsed().as_millis());
 
     let (tile_width, tile_height) = eu5app::tile_dimensions();
@@ -80,7 +77,7 @@ async fn main_async(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let start = std::time::Instant::now();
-    game_bundle.load_east_texture(&mut texture_data)?;
+    texture_data = game_bundle.load_east_texture(texture_data)?;
     println!("Read east texture in {}ms", start.elapsed().as_millis());
 
     let start = std::time::Instant::now();

--- a/src/wasm-eu5-map/src/lib.rs
+++ b/src/wasm-eu5-map/src/lib.rs
@@ -1,6 +1,6 @@
 use eu5app::{
     game_data::{TextureProvider, optimized::OptimizedTextureBundle},
-    should_highlight_individual_locations, texture_buffer_size, tile_dimensions,
+    should_highlight_individual_locations, tile_dimensions,
 };
 use pdx_map::{
     CanvasDimensions, GpuLocationIdx, GpuSurfaceContext, LocationArrays, LocationFlags,
@@ -287,24 +287,24 @@ impl Eu5WasmGameBundle {
     }
 
     #[wasm_bindgen]
-    pub fn west_texture_data(&self) -> Result<Eu5WasmTextureData, JsError> {
-        let size = texture_buffer_size();
-        let mut data = vec![0u8; size];
-        self.textures
-            .load_west_texture(&mut data)
+    pub fn west_texture_data(&mut self) -> Result<Eu5WasmTextureData, JsError> {
+        let data = self
+            .textures
+            .load_west_texture(Vec::new())
             .map_err(|e| JsError::new(&format!("Failed to get west texture data: {e}")))?;
         Ok(Eu5WasmTextureData { data })
     }
 
     #[wasm_bindgen]
     pub fn east_texture_data(
-        &self,
-        mut data: Eu5WasmTextureData,
+        &mut self,
+        data: Eu5WasmTextureData,
     ) -> Result<Eu5WasmTextureData, JsError> {
-        self.textures
-            .load_east_texture(&mut data.data)
+        let data = self
+            .textures
+            .load_east_texture(data.data)
             .map_err(|e| JsError::new(&format!("Failed to get east texture data: {e}")))?;
-        Ok(Eu5WasmTextureData { data: data.data })
+        Ok(Eu5WasmTextureData { data })
     }
 }
 


### PR DESCRIPTION
When the game data splits the image, it's unnecessary to keep the pixel data around after uploading to the gpu.