### PR TITLE
Fix incorrect texture format selection

### DIFF
--- a/src/pdx-map/src/lib.rs
+++ b/src/pdx-map/src/lib.rs
@@ -49,3 +49,17 @@ impl CanvasDimensions {
         (self.canvas_height as f32 * self.scale_factor) as u32
     }
 }
+
+impl std::fmt::Display for CanvasDimensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}x{} @ {:.2}x = {}x{}",
+            self.canvas_width,
+            self.canvas_height,
+            self.scale_factor,
+            self.physical_width(),
+            self.physical_height()
+        )
+    }
+}


### PR DESCRIPTION
For web this doesn't make a difference, but on desktop this would wash out the colors. "Double gamma correction" is what I think this is called