### PR TITLE
Add layer visibility control

### DIFF
--- a/src/eu5native/src/date_layer.rs
+++ b/src/eu5native/src/date_layer.rs
@@ -272,14 +272,9 @@ impl RenderLayer for DateLayer {
     fn draw<'a>(
         &'a self,
         pass: &mut wgpu::RenderPass<'a>,
-        viewport: &ViewportBounds,
+        _viewport: &ViewportBounds,
         _canvas_size: CanvasDimensions,
     ) {
-        // Only draw on the western hemisphere
-        if viewport.x != 0 {
-            return;
-        }
-
         if self.pending_upload.is_some() {
             return;
         }

--- a/src/eu5native/src/main.rs
+++ b/src/eu5native/src/main.rs
@@ -94,7 +94,7 @@ async fn main_async(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     map_app.set_map_mode(MapMode::Political)?;
     renderer.update_locations(map_app.location_arrays());
 
-    renderer.add_layer(DateLayer::new(save_date, 20));
+    let date_layer = renderer.add_layer(DateLayer::new(save_date, 20));
 
     let (full_width, full_height) = eu5app::world_dimensions();
     let mut combined_buffer = vec![0u8; (full_width * full_height * 4) as usize];
@@ -105,6 +105,11 @@ async fn main_async(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     screenshot_renderer
         .readback_west(&mut combined_buffer)
         .await?;
+
+    // No need to render date on east tile
+    screenshot_renderer
+        .renderer_mut()
+        .set_layer_visible(date_layer, false);
 
     // Render east tile and copy to right half of buffer
     screenshot_renderer

--- a/src/pdx-map/src/controller.rs
+++ b/src/pdx-map/src/controller.rs
@@ -230,6 +230,10 @@ impl ScreenshotRenderer<HeadlessMapRenderer> {
         }
     }
 
+    pub fn renderer_mut(&mut self) -> &mut HeadlessMapRenderer {
+        &mut self.renderer
+    }
+
     /// Render and read back the western tile
     pub async fn readback_west(&mut self, buffer: &mut [u8]) -> Result<(), RenderError> {
         self.renderer


### PR DESCRIPTION
Being able to cheaply toggle the layer exposes more control. For instance for west / east screenshots we want to only render the date on the west side. But for a single viewport we may want to always show the date -- and the layer visibility mechanics allow this.