### PR TITLE
Admin ability to disqualify leaderboard participation for disputed saves

### DIFF
--- a/src/app/app/lib/auth.ts
+++ b/src/app/app/lib/auth.ts
@@ -34,6 +34,9 @@ type PdxPermissions =
     }
   | {
       kind: "leaderboard:rebalance";
+    }
+  | {
+      kind: "savefile:leaderboard-qualification";
     };
 
 type PermissionFunction<K> = K extends { data: infer D }
@@ -57,6 +60,7 @@ const ROLES: RolePermissionsMapping = {
     "savefile:reprocess": true,
     "leaderboard:rebalance": true,
     "savefile:og-request": true,
+    "savefile:leaderboard-qualification": true,
   },
   user: {
     "savefile:create": true,

--- a/src/app/app/server-lib/db/index.ts
+++ b/src/app/app/server-lib/db/index.ts
@@ -32,6 +32,7 @@ export function saveView<S, U>(opts?: { save?: S; user?: U }) {
     patch: sql<string>`CONCAT(${table.saves.saveVersionFirst}, '.', ${table.saves.saveVersionSecond}, '.', ${table.saves.saveVersionThird}, '.', ${table.saves.saveVersionFourth})`,
     difficulty: table.saves.gameDifficulty,
     achievements: table.saves.achieveIds,
+    leaderboard_qualified: table.saves.leaderboardQualified,
     ...opts?.save,
   } as const;
 
@@ -183,6 +184,7 @@ export async function getAchievementDb(
       and(
         sql`${table.saves.achieveIds} @> Array[${[achievement.id]}]::int[]`,
         isNotNull(table.saves.scoreDays),
+        eq(table.saves.leaderboardQualified, true),
       ),
     )
     .as("ranked");

--- a/src/app/app/server-lib/db/schema.ts
+++ b/src/app/app/server-lib/db/schema.ts
@@ -71,6 +71,9 @@ export const saves = pgTable(
     gameDifficulty: gameDifficulty("game_difficulty").notNull(),
     aar: text("aar"),
     playthroughId: text("playthrough_id").notNull(),
+    leaderboardQualified: boolean("leaderboard_qualified")
+      .notNull()
+      .default(true),
   },
   (saves) => [
     index("idx_save_achieve_ids").on(saves.achieveIds),

--- a/src/app/app/services/appApi.ts
+++ b/src/app/app/services/appApi.ts
@@ -34,6 +34,7 @@ export type SavePatchProps = {
   id: string;
   aar?: string;
   filename?: string;
+  leaderboard_qualified?: boolean;
 };
 
 export const pdxKeys = {
@@ -238,8 +239,13 @@ export const pdxApi = {
       return useMutation({
         mutationFn: ({ id, ...rest }: SavePatchProps) =>
           sendJson(`/api/saves/${id}`, { body: rest, method: "PATCH" }),
-        onSuccess: (_, { id }) => {
+        onSuccess: (_, { id, leaderboard_qualified }) => {
           queryClient.invalidateQueries({ queryKey: pdxKeys.save(id) });
+
+          // Refresh leaderboards if qualification status changed
+          if (leaderboard_qualified !== undefined) {
+            queryClient.invalidateQueries({ queryKey: pdxKeys.achievements() });
+          }
         },
       });
     },

--- a/src/app/drizzle-kit.config.ts
+++ b/src/app/drizzle-kit.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
   dialect: "postgresql",
-  schema: "./src/server-lib/db/schema.ts",
+  schema: "./app/server-lib/db/schema.ts",
   out: "./migrations",
 });

--- a/src/app/migrations/0005_stormy_silver_samurai.sql
+++ b/src/app/migrations/0005_stormy_silver_samurai.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "saves" ADD COLUMN "leaderboard_qualified" boolean DEFAULT true NOT NULL;

--- a/src/app/migrations/meta/0005_snapshot.json
+++ b/src/app/migrations/meta/0005_snapshot.json
@@ -1,0 +1,364 @@
+{
+  "id": "490e564d-0313-4960-a513-71375e2ca200",
+  "prevId": "baf3886b-8255-41b0-9722-15e1e14f0f8d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.saves": {
+      "name": "saves",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked": {
+          "name": "locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days": {
+          "name": "days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_days": {
+          "name": "score_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_tag": {
+          "name": "player_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_tag_name": {
+          "name": "player_tag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "save_version_first": {
+          "name": "save_version_first",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "save_version_second": {
+          "name": "save_version_second",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "save_version_third": {
+          "name": "save_version_third",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "save_version_fourth": {
+          "name": "save_version_fourth",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achieve_ids": {
+          "name": "achieve_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "players": {
+          "name": "players",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_start_tag": {
+          "name": "player_start_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_start_tag_name": {
+          "name": "player_start_tag_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_difficulty": {
+          "name": "game_difficulty",
+          "type": "game_difficulty",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aar": {
+          "name": "aar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playthrough_id": {
+          "name": "playthrough_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaderboard_qualified": {
+          "name": "leaderboard_qualified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_save_achieve_ids": {
+          "name": "idx_save_achieve_ids",
+          "columns": [
+            {
+              "expression": "achieve_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_save_creation": {
+          "name": "idx_save_creation",
+          "columns": [
+            {
+              "expression": "created_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_save_hash": {
+          "name": "idx_save_hash",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_save_players": {
+          "name": "idx_save_players",
+          "columns": [
+            {
+              "expression": "players",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_saves_playthrough_id": {
+          "name": "idx_saves_playthrough_id",
+          "columns": [
+            {
+              "expression": "playthrough_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saves_user_id_users_user_id_fk": {
+          "name": "saves_user_id_users_user_id_fk",
+          "tableFrom": "saves",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_name": {
+          "name": "steam_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account": {
+          "name": "account",
+          "type": "account",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "display": {
+          "name": "display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_steam_id": {
+          "name": "idx_users_steam_id",
+          "columns": [
+            {
+              "expression": "steam_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account": {
+      "name": "account",
+      "schema": "public",
+      "values": [
+        "free",
+        "admin"
+      ]
+    },
+    "public.game_difficulty": {
+      "name": "game_difficulty",
+      "schema": "public",
+      "values": [
+        "very_easy",
+        "easy",
+        "normal",
+        "hard",
+        "very_hard"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/app/migrations/meta/_journal.json
+++ b/src/app/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1723586927105,
       "tag": "0004_amusing_penance",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1765915085968,
+      "tag": "0005_stormy_silver_samurai",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Instead of deleting a save, which can break permalinks -- add the ability to disqualify a save from the leaderboard so that it remains accessible but does not impact leaderboard rankings.