### PR TITLE
Fix perf and frame drops on firefox with CPU location lookups

### DIFF
--- a/src/pdx-map/src/controller.rs
+++ b/src/pdx-map/src/controller.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CanvasDimensions, MapViewport, RenderError, SurfaceMapRenderer,
+    CanvasDimensions, MapViewport, RenderError, SurfaceMapRenderer, WorldCoordinates,
     renderer::{ColorIdReadback, QueuedWorkFuture},
 };
 
@@ -24,7 +24,7 @@ impl MapViewController {
         self.viewport.zoom_level()
     }
 
-    pub fn canvas_to_world(&self, canvas_x: f32, canvas_y: f32) -> (f32, f32) {
+    pub fn canvas_to_world(&self, canvas_x: f32, canvas_y: f32) -> WorldCoordinates {
         self.viewport.canvas_to_world(canvas_x, canvas_y)
     }
 
@@ -113,10 +113,10 @@ impl MapViewController {
         canvas_y: f32,
     ) -> Result<ColorIdReadback, RenderError> {
         // Convert canvas coordinates to world coordinates
-        let (world_x, world_y) = self.canvas_to_world(canvas_x, canvas_y);
+        let world_coords = self.canvas_to_world(canvas_x, canvas_y);
         let readback = self
             .renderer
-            .create_color_id_readback_at(world_x as i32, world_y as i32)?;
+            .create_color_id_readback_at(world_coords.x as i32, world_coords.y as i32)?;
 
         Ok(readback)
     }

--- a/src/pdx-map/src/lib.rs
+++ b/src/pdx-map/src/lib.rs
@@ -1,6 +1,7 @@
 mod color;
 mod image;
 mod loc_arrays;
+mod picker;
 mod viewport;
 
 #[cfg(feature = "render")]
@@ -13,6 +14,7 @@ mod renderer;
 pub use color::GpuColor;
 pub use image::*;
 pub use loc_arrays::*;
+pub use picker::*;
 pub use viewport::*;
 
 #[cfg(feature = "render")]

--- a/src/pdx-map/src/picker.rs
+++ b/src/pdx-map/src/picker.rs
@@ -1,0 +1,133 @@
+use crate::GpuLocationIdx;
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct WorldCoordinates {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl WorldCoordinates {
+    pub fn new(x: f32, y: f32) -> Self {
+        WorldCoordinates { x, y }
+    }
+}
+
+#[derive(Debug)]
+pub struct MapPickerSingle {
+    west: Vec<u8>,
+    east: Vec<u8>,
+    world_width: u32, // Width of the world in pixels (no padding)
+}
+
+impl MapPickerSingle {
+    pub fn new(west: Vec<u8>, east: Vec<u8>, world_width: u32) -> Self {
+        assert_eq!(
+            west.len(),
+            east.len(),
+            "west and east hemispheres must be the same length"
+        );
+        assert_eq!(
+            west.len() % 2,
+            0,
+            "west and east hemispheres must have an even number of bytes"
+        );
+        assert!(world_width > 0, "world_width must be greater than 0");
+        assert_eq!(
+            west.len() % (world_width as usize),
+            0,
+            "west and east hemispheres must have a length that is a multiple of the world width"
+        );
+
+        MapPickerSingle {
+            west,
+            east,
+            world_width,
+        }
+    }
+
+    pub fn pick(&self, world_coords: WorldCoordinates) -> GpuLocationIdx {
+        let half_width = self.world_width / 2;
+        assert_ne!(half_width, 0);
+
+        let bytes_per_row = (half_width as usize).saturating_mul(2);
+
+        let height = self.west.len() / bytes_per_row;
+        let x = world_coords.x.floor() as i32;
+        let y = world_coords.y.floor() as i32;
+        let y = y.clamp(0, height as i32 - 1);
+        let world_width = self.world_width as i32;
+
+        let wrapped_x = ((x % world_width) + world_width) % world_width;
+        let (data, col) = if wrapped_x < half_width as i32 {
+            (&self.west, wrapped_x as usize)
+        } else {
+            (
+                &self.east,
+                (wrapped_x as usize).saturating_sub(half_width as usize),
+            )
+        };
+
+        let offset = (y as usize).saturating_mul(bytes_per_row) + col.saturating_mul(2);
+        let bytes = [data[offset], data[offset + 1]];
+        GpuLocationIdx::new(u16::from_le_bytes(bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pack_r16(values: &[u16]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(values.len() * 2);
+        for value in values {
+            data.extend_from_slice(&value.to_le_bytes());
+        }
+        data
+    }
+
+    #[test]
+    pub fn test_map_picker_single_basic_west_east() {
+        // 4x2 world split into 2x2 west/east halves.
+        let west = pack_r16(&[10, 11, 12, 13]);
+        let east = pack_r16(&[20, 21, 22, 23]);
+        let map_picker = MapPickerSingle::new(west, east, 4);
+
+        let cases = [
+            (0.0, 0.0, 10),
+            (1.0, 0.0, 11),
+            (2.0, 0.0, 20),
+            (3.0, 0.0, 21),
+            (0.0, 1.0, 12),
+            (3.0, 1.0, 23),
+        ];
+
+        for (x, y, expected) in cases {
+            let world_coords = WorldCoordinates { x, y };
+            let location_idx = map_picker.pick(world_coords);
+            assert_eq!(location_idx, GpuLocationIdx::new(expected));
+        }
+    }
+
+    #[test]
+    pub fn test_map_picker_single_wraps_x() {
+        let west = pack_r16(&[1, 2]);
+        let east = pack_r16(&[3, 4]);
+        let map_picker = MapPickerSingle::new(west, east, 4);
+
+        let left_wrap = WorldCoordinates { x: -1.0, y: 0.0 };
+        let right_wrap = WorldCoordinates { x: 4.0, y: 0.0 };
+
+        assert_eq!(map_picker.pick(left_wrap), GpuLocationIdx::new(4));
+        assert_eq!(map_picker.pick(right_wrap), GpuLocationIdx::new(1));
+    }
+
+    #[test]
+    pub fn test_map_picker_single_out_of_bounds_y() {
+        let west = pack_r16(&[1, 2]);
+        let east = pack_r16(&[3, 4]);
+        let map_picker = MapPickerSingle::new(west, east, 4);
+
+        let world_coords = WorldCoordinates { x: 0.0, y: 1.0 };
+        assert_eq!(map_picker.pick(world_coords), GpuLocationIdx::new(1));
+    }
+}

--- a/src/pdx-map/src/renderer.rs
+++ b/src/pdx-map/src/renderer.rs
@@ -581,7 +581,7 @@ impl MapResources {
 
     /// Update storage buffers from location arrays
     pub fn update(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, arrays: &LocationArrays) {
-        if arrays.len() >= (self.owner_colors.size() as usize / std::mem::size_of::<u32>()) {
+        if arrays.len() > (self.owner_colors.size() as usize / std::mem::size_of::<u32>()) {
             let [primary_colors, owner_colors, secondary_colors, states] =
                 Self::location_buffers(device, arrays.len() as u64);
             self.primary_colors = primary_colors;

--- a/src/pdx-map/src/viewport.rs
+++ b/src/pdx-map/src/viewport.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::WorldCoordinates;
+
 /// Represents the bounds of the current viewport in world coordinates
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ViewportBounds {
@@ -200,7 +202,7 @@ impl MapViewport {
     ///
     /// # Returns
     /// World coordinates (x, y) as a tuple
-    pub fn canvas_to_world(&self, canvas_x: f32, canvas_y: f32) -> (f32, f32) {
+    pub fn canvas_to_world(&self, canvas_x: f32, canvas_y: f32) -> WorldCoordinates {
         let world_width = self.canvas_width as f32 / self.zoom_level;
         let world_height = self.canvas_height as f32 / self.zoom_level;
 
@@ -210,7 +212,7 @@ impl MapViewport {
         let world_x = self.viewport_x as f32 + canvas_ratio_x * world_width;
         let world_y = self.viewport_y as f32 + canvas_ratio_y * world_height;
 
-        (world_x, world_y)
+        WorldCoordinates::new(world_x, world_y)
     }
 
     /// Position a world point under a specific canvas cursor position
@@ -309,16 +311,16 @@ mod tests {
         let mut controller = MapViewport::new(1024, 768, 8192, 8192);
 
         // Get world coordinates of center of canvas
-        let (world_x, world_y) = controller.canvas_to_world(512.0, 384.0);
+        let world_coords = controller.canvas_to_world(512.0, 384.0);
 
         // Move that world point to upper-left corner of canvas
-        controller.set_world_point_under_cursor(world_x, world_y, 100.0, 100.0);
+        controller.set_world_point_under_cursor(world_coords.x, world_coords.y, 100.0, 100.0);
 
         // Now that world point should appear at (100, 100) on canvas
-        let (new_world_x, new_world_y) = controller.canvas_to_world(100.0, 100.0);
+        let new_world_coords = controller.canvas_to_world(100.0, 100.0);
 
         // Should be approximately the same world coordinates (within floating point precision)
-        assert!((new_world_x - world_x).abs() < 1.0);
-        assert!((new_world_y - world_y).abs() < 1.0);
+        assert!((new_world_coords.x - world_coords.x).abs() < 1.0);
+        assert!((new_world_coords.y - world_coords.y).abs() < 1.0);
     }
 }

--- a/src/wasm-pdx-map/src/lib.rs
+++ b/src/wasm-pdx-map/src/lib.rs
@@ -129,8 +129,8 @@ impl PdxMapRenderer {
 
     #[wasm_bindgen]
     pub fn canvas_to_world(&self, canvas_x: f32, canvas_y: f32) -> Vec<f32> {
-        let (world_x, world_y) = self.app.canvas_to_world(canvas_x, canvas_y);
-        vec![world_x, world_y]
+        let world_coords = self.app.canvas_to_world(canvas_x, canvas_y);
+        vec![world_coords.x, world_coords.y]
     }
 
     /// Position a world point under a specific canvas cursor position


### PR DESCRIPTION
- Implement location picking on the CPU side, by keeping the complete R16 texture in memory and doing O(1) world lookups. Previously this involved a GPU readback, which was fast on Chrome but slow on firefox. The downside of this approach is that this essentially doubles the memory usage on the CPU map side.
  - This does open the door for more advanced selections like click and dragging by computing location AABB
- The frame drops in firefox (eg: the clear color bleeding through) were fixed by always continuously rendering every frame. Firefox may have some optimization that if a canvas doesn't render every frame then it is put to sleep, so we keep it "warm" by always rendering.