### PR TITLE
Switch to mise github backend from ubi

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -2,13 +2,13 @@
 "aqua:pnpm" = { version = "10.11.0" }
 "node" = { version = "22.18.0" }
 "rust" = { version = "1.92" } # update in rust-toolchain.toml too!
-"ubi:cargo-bins/cargo-binstall" = { version = "1.12.5" }
-"ubi:docker/compose" = { version = "2.33.1", rename_exe = "docker-compose" }
-"ubi:google/flatbuffers" = { version = "25.2.10", matching = "clang", exe = "flatc" }
-"ubi:llvm/llvm-project" = { version = "llvmorg-19.1.7", matching = "LLVM-", extract_all = "true", bin_path = "bin", os = ["macos"] }
-"ubi:rclone/rclone" = { version = "1.70.3" }
-"ubi:rustwasm/wasm-bindgen" = { version = "0.2.118", extract_all = "true" }
-"ubi:WebAssembly/binaryen" = { version = "version_129", extract_all = "true", bin_path = "bin" }
+"github:cargo-bins/cargo-binstall" = { version = "1.12.5" }
+"github:docker/compose" = { version = "2.33.1", rename_exe = "docker-compose" }
+"github:google/flatbuffers" = { version = "25.2.10", matching = "clang", exe = "flatc" }
+"github:llvm/llvm-project" = { version = "llvmorg-19.1.7", matching = "LLVM-", strip_components = 1, bin_path = "bin", os = ["macos"] }
+"github:rclone/rclone" = { version = "1.70.3" }
+"github:rustwasm/wasm-bindgen" = { version = "0.2.118", extract_all = "true" }
+"github:WebAssembly/binaryen" = { version = "version_129", strip_components = 1, bin_path = "bin" }
 
 [settings]
 idiomatic_version_file_enable_tools = ["rust"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
 
 USER vscode
 
-RUN curl https://mise.run | MISE_VERSION=v2025.10.0  sh && \
+RUN curl https://mise.run | MISE_VERSION=v2026.4.5 sh && \
     /bin/bash -c 'echo "eval \"\$(~/.local/bin/mise activate bash --shims)\"" >> ~/.bashrc'
 
 EXPOSE 3001 3003


### PR DESCRIPTION
With ubi backend deprecated, might as well switch to the github backend.

Likely blocked by https://github.com/jdx/mise/discussions/7462