### PR TITLE
Enable react router optimize deps option

### DIFF
--- a/src/app/react-router.config.ts
+++ b/src/app/react-router.config.ts
@@ -3,6 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   ssr: true,
   future: {
+    unstable_optimizeDeps: true,
     v8_viteEnvironmentApi: true,
   },
 } satisfies Config;


### PR DESCRIPTION
I think this should get rid of the annoying "504 Outdated Dependency" errors: https://v2.remix.run/docs/guides/dependency-optimization