### PR TITLE
Replace AABB SpatialIndex with Range-Encoded Tile Grid

### DIFF
--- a/src/bench/src/benchmarks/map.rs
+++ b/src/bench/src/benchmarks/map.rs
@@ -1,4 +1,7 @@
-use pdx_map::{Aabb, R16, R16Palette, SpatialIndex, TopologyIndex, World, WorldLength, WorldPoint};
+use pdx_map::{
+    Aabb, LocationBitset, R16, R16Palette, SpatialIndex, TopologyIndex, World, WorldLength,
+    WorldPoint,
+};
 use std::path::{Path, PathBuf};
 
 pub const PROVINCES_WIDTH: u32 = 5632;
@@ -45,6 +48,7 @@ fn sampled_neighbor_count(adjacency: &TopologyIndex) -> usize {
 pub struct SpatialQueryInput {
     pub index: SpatialIndex,
     pub query: Aabb,
+    pub scratch: LocationBitset,
 }
 
 pub fn setup_small_query(asset_name: &str) -> SpatialQueryInput {
@@ -79,7 +83,11 @@ fn setup_query(asset_name: &str, small: bool) -> SpatialQueryInput {
         Aabb::new(WorldPoint::new(0, 0), WorldPoint::new(max_x, max_y))
     };
 
-    SpatialQueryInput { index, query }
+    SpatialQueryInput {
+        index,
+        query,
+        scratch: LocationBitset::new(),
+    }
 }
 
 fn from_rgb8(rgb_data: &[u8]) -> (World, pdx_map::R16Palette) {
@@ -90,8 +98,9 @@ fn aabb_index_build(world: &World) -> SpatialIndex {
     world.build_spatial_index()
 }
 
-fn aabb_index_query(input: &SpatialQueryInput) -> usize {
-    input.index.query(input.query).count()
+fn aabb_index_query(input: &mut SpatialQueryInput) -> usize {
+    input.index.query(&[input.query], &mut input.scratch);
+    input.scratch.count()
 }
 
 fn adjacency_build(world: &World) -> TopologyIndex {
@@ -122,18 +131,18 @@ pub mod criterion {
 
     pub fn map_aabb_index_benchmark(c: &mut Criterion) {
         let world = super::setup_world(super::PROVINCES_ASSET);
-        let small_query = super::setup_small_query(super::PROVINCES_ASSET);
-        let large_query = super::setup_large_query(super::PROVINCES_ASSET);
+        let mut small_query = super::setup_small_query(super::PROVINCES_ASSET);
+        let mut large_query = super::setup_large_query(super::PROVINCES_ASSET);
 
         let mut group = c.benchmark_group("map/aabb");
         group.bench_function("build", |b| {
             b.iter(|| black_box(super::aabb_index_build(&world)))
         });
         group.bench_function("query_small", |b| {
-            b.iter(|| black_box(super::aabb_index_query(&small_query)))
+            b.iter(|| black_box(super::aabb_index_query(&mut small_query)))
         });
         group.bench_function("query_large", |b| {
-            b.iter(|| black_box(super::aabb_index_query(&large_query)))
+            b.iter(|| black_box(super::aabb_index_query(&mut large_query)))
         });
         group.finish();
     }
@@ -181,8 +190,8 @@ pub mod gungraun {
     #[library_benchmark]
     #[bench::query_small(args = (crate::benchmarks::map::PROVINCES_ASSET), setup = crate::benchmarks::map::setup_small_query)]
     #[bench::query_large(args = (crate::benchmarks::map::PROVINCES_ASSET), setup = crate::benchmarks::map::setup_large_query)]
-    fn aabb_index_query_benchmark(input: crate::benchmarks::map::SpatialQueryInput) -> usize {
-        crate::benchmarks::map::aabb_index_query(&input)
+    fn aabb_index_query_benchmark(mut input: crate::benchmarks::map::SpatialQueryInput) -> usize {
+        crate::benchmarks::map::aabb_index_query(&mut input)
     }
 
     #[library_benchmark(setup = crate::benchmarks::map::setup_world)]

--- a/src/pdx-map/src/lib.rs
+++ b/src/pdx-map/src/lib.rs
@@ -22,7 +22,7 @@ pub use loc_arrays::*;
 pub use pixel::{R16, R16Palette, R16SecondaryMap, Rgb};
 pub use units::*;
 pub use viewport::{MapViewport, PanTarget, ViewportBounds, ViewportInsets};
-pub use world::{Aabb, Hemisphere, SpatialIndex, TopologyIndex, World};
+pub use world::{Aabb, Hemisphere, LocationBitset, SpatialIndex, TopologyIndex, World};
 
 #[cfg(feature = "render")]
 pub use controller::MapViewController;

--- a/src/pdx-map/src/world.rs
+++ b/src/pdx-map/src/world.rs
@@ -4,7 +4,7 @@ mod spatial;
 mod topology;
 
 pub use hemisphere::Hemisphere;
-pub use spatial::{Aabb, SpatialIndex};
+pub use spatial::{Aabb, LocationBitset, SpatialIndex};
 pub use topology::TopologyIndex;
 
 use crate::{R16, R16Palette, WorldLength, WorldPoint, WorldSize};

--- a/src/pdx-map/src/world/ingest.rs
+++ b/src/pdx-map/src/world/ingest.rs
@@ -111,7 +111,32 @@ fn index_rgb<const SRC_DEPTH: usize>(img: &[u8], width: WorldLength<u32>) -> (Wo
 
     let world = world_builder.build();
 
+    #[cfg(debug_assertions)]
+    assert_scan_order_assignment(&world);
+
     (world, R16Palette::new(palette))
+}
+
+#[cfg(debug_assertions)]
+fn assert_scan_order_assignment(world: &World) {
+    let mut seen = vec![false; world.location_capacity()];
+    let mut next = 0u16;
+
+    for row in world.rows() {
+        for &r16 in row {
+            let value = r16.value();
+            if !seen[value as usize] {
+                assert_eq!(
+                    value, next,
+                    "R16 values must be assigned in first-pixel scan order"
+                );
+                seen[value as usize] = true;
+                next = next
+                    .checked_add(1)
+                    .expect("R16 scan-order assertion overflowed");
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/pdx-map/src/world/spatial.rs
+++ b/src/pdx-map/src/world/spatial.rs
@@ -19,13 +19,6 @@ impl Aabb {
         Self { min, max }
     }
 
-    fn expand_to(&mut self, start_x: u16, end_x: u16, y: u16) {
-        self.min.x = self.min.x.min(start_x);
-        self.min.y = self.min.y.min(y);
-        self.max.x = self.max.x.max(end_x);
-        self.max.y = self.max.y.max(y);
-    }
-
     #[inline]
     pub fn min(&self) -> WorldPoint<u16> {
         self.min
@@ -51,86 +44,364 @@ impl Display for Aabb {
     }
 }
 
+// Divide the world into 64x64 tiles and group locations that occur in each
+// time.
+const TILE_SIZE: u16 = 64;
+
+#[derive(Debug, Clone, Copy)]
+struct Span {
+    y: u16,
+    x_start: u16,
+    x_end: u16,
+}
+
 #[derive(Debug)]
 pub struct SpatialIndex {
-    aabbs: Vec<Aabb>,
+    tiles_wide: u16,
+    tiles_tall: u16,
+    tile_offsets: Vec<u32>,
+    tile_ranges: Vec<(R16, R16)>,
+    span_offsets: Vec<u32>,
+    spans: Vec<Span>,
 }
 
 impl SpatialIndex {
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "pdx-map.spatial-index.build", skip_all, level = "info")
+    )]
     pub fn from_world(world: &World) -> Self {
-        let hemisphere_width = world.west().size().width as usize;
+        let hemisphere_width = world.west().size().width as u16;
+        let world_width = hemisphere_width * 2;
+        let world_height = world.size().height as u16;
+        let tiles_wide = world_width.div_ceil(TILE_SIZE);
+        let tiles_tall = world_height.div_ceil(TILE_SIZE);
+        let tile_count = tiles_wide as usize * tiles_tall as usize;
         let location_capacity = world.location_capacity();
 
-        let mut bounds = vec![Aabb::empty(); location_capacity];
-        for (row, chunk) in world.west().rows().enumerate() {
-            let y = row as u16;
-            let Some((run_id, rest)) = chunk.split_first() else {
-                continue;
-            };
+        let mut counts = vec![0u32; tile_count];
+        let mut span_counts = vec![0u32; location_capacity];
 
-            let mut run_id = *run_id;
-            let mut run_start = 0u16;
-            for (col, &r16) in rest.iter().enumerate() {
-                if r16 != run_id {
-                    let end_x = col as u16;
-                    bounds[run_id.value() as usize].expand_to(run_start, end_x, y);
-                    run_id = r16;
-                    run_start = (col + 1) as u16;
-                }
+        // Pass 1: count every tile touched by each horizontal run and count
+        // the exact per-location row spans.
+        walk_runs(world, |run_id, start_x, end_x, y| {
+            let li = run_id.value() as usize;
+            span_counts[li] += 1;
+            let ty = y / TILE_SIZE;
+            let tx_start = start_x / TILE_SIZE;
+            let tx_end = end_x / TILE_SIZE;
+            let row_base = ty as usize * tiles_wide as usize;
+            for tx in tx_start..=tx_end {
+                counts[row_base + tx as usize] += 1;
             }
+        });
 
-            let end_x = (hemisphere_width - 1) as u16;
-            bounds[run_id.value() as usize].expand_to(run_start, end_x, y);
+        // Per-location span storage is also CSR encoded. The offset slice lets
+        // query_exact() jump directly to one candidate location's row spans.
+        let mut span_offsets = Vec::with_capacity(location_capacity + 1);
+        let mut span_acc = 0u32;
+        span_offsets.push(0);
+        for count in &span_counts {
+            span_acc += count;
+            span_offsets.push(span_acc);
         }
 
-        for (row, chunk) in world.east().rows().enumerate() {
-            let y = row as u16;
-            let Some((run_id, rest)) = chunk.split_first() else {
-                continue;
-            };
-
-            let x_offset = hemisphere_width as u16;
-            let mut run_id = *run_id;
-            let mut run_start = x_offset;
-            for (col, &r16) in rest.iter().enumerate() {
-                if r16 != run_id {
-                    let end_x = x_offset + (col as u16);
-                    bounds[run_id.value() as usize].expand_to(run_start, end_x, y);
-                    run_id = r16;
-                    run_start = x_offset + (col + 1) as u16;
-                }
-            }
-
-            let end_x = x_offset + (hemisphere_width as u16) - 1;
-            bounds[run_id.value() as usize].expand_to(run_start, end_x, y);
+        // Turn per-tile touch counts into provisional CSR offsets. These
+        // offsets address the temporary flat R16 entries before dedup/ranging.
+        let mut prov_offsets = Vec::with_capacity(tile_count + 1);
+        let mut acc = 0u32;
+        prov_offsets.push(0);
+        for count in &counts {
+            acc += count;
+            prov_offsets.push(acc);
         }
 
-        Self { aabbs: bounds }
-    }
+        let mut entries = vec![R16::new(0); acc as usize];
+        let mut cursors = prov_offsets[..tile_count].to_vec();
+        let mut spans = vec![
+            Span {
+                y: 0,
+                x_start: 0,
+                x_end: 0,
+            };
+            span_acc as usize
+        ];
+        let mut span_cursors = span_offsets[..location_capacity].to_vec();
 
-    pub fn query(&self, query_aabb: Aabb) -> impl Iterator<Item = R16> + '_ {
-        self.aabbs
-            .iter()
-            .enumerate()
-            .filter_map(move |(idx, aabb)| {
-                if aabb.intersects(&query_aabb) {
-                    Some(R16::new(idx as u16))
-                } else {
-                    None
+        // Pass 2: fill each tile's provisional slice and each location's exact
+        // spans. A location can appear multiple times in the same tile when it
+        // has several runs there.
+        walk_runs(world, |run_id, start_x, end_x, y| {
+            let li = run_id.value() as usize;
+            let span_slot = &mut span_cursors[li];
+            spans[*span_slot as usize] = Span {
+                y,
+                x_start: start_x,
+                x_end: end_x,
+            };
+            *span_slot += 1;
+
+            let ty = y / TILE_SIZE;
+            let tx_start = start_x / TILE_SIZE;
+            let tx_end = end_x / TILE_SIZE;
+            let row_base = ty as usize * tiles_wide as usize;
+            for tx in tx_start..=tx_end {
+                let slot = &mut cursors[row_base + tx as usize];
+                entries[*slot as usize] = run_id;
+                *slot += 1;
+            }
+        });
+
+        #[cfg(debug_assertions)]
+        assert_spans_sorted(&span_offsets, &spans);
+
+        // Pass 3: sort each tile independently so duplicates and consecutive
+        // location IDs can be collapsed into compact inclusive ranges.
+        for tile in 0..tile_count {
+            let lo = prov_offsets[tile] as usize;
+            let hi = prov_offsets[tile + 1] as usize;
+            entries[lo..hi].sort_unstable();
+        }
+
+        let mut tile_ranges = Vec::new();
+        let mut tile_offsets = Vec::with_capacity(tile_count + 1);
+        tile_offsets.push(0);
+
+        // Pass 4: build the final CSR payload. Equal IDs are deduplicated, and
+        // adjacent IDs become a single range because R16 assignment is usually
+        // spatially coherent.
+        for tile in 0..tile_count {
+            let lo = prov_offsets[tile] as usize;
+            let hi = prov_offsets[tile + 1] as usize;
+            let slice = &entries[lo..hi];
+            let mut i = 0;
+            while i < slice.len() {
+                let start = slice[i];
+                let mut end = start;
+                let mut j = i + 1;
+
+                while j < slice.len() && slice[j].value() <= end.value().saturating_add(1) {
+                    if slice[j].value() == end.value().saturating_add(1) {
+                        end = slice[j];
+                    }
+                    j += 1;
                 }
-            })
+
+                tile_ranges.push((start, end));
+                i = j;
+            }
+            tile_offsets.push(tile_ranges.len() as u32);
+        }
+
+        Self {
+            tiles_wide,
+            tiles_tall,
+            tile_offsets,
+            tile_ranges,
+            span_offsets,
+            spans,
+        }
     }
 
-    pub fn aabb_of(&self, loc: R16) -> Aabb {
-        self.aabbs[loc.value() as usize]
+    /// Coarse query: union of tile hits across all `rects`. Clears `out`
+    /// before writing.
+    pub fn query(&self, rects: &[Aabb], out: &mut LocationBitset) {
+        out.reset(self.len());
+        for rect in rects {
+            self.fill_coarse(*rect, &mut out.words);
+        }
+    }
+
+    /// Like [`query`](Self::query), then clears any bit whose spans don't
+    /// intersect at least one of the rects.
+    pub fn query_exact(&self, rects: &[Aabb], out: &mut LocationBitset) {
+        self.query(rects, out);
+
+        for word_idx in 0..out.words.len() {
+            let mut word = out.words[word_idx];
+            while word != 0 {
+                let bit = word.trailing_zeros() as usize;
+                let bit_mask = 1u64 << bit;
+                word &= !bit_mask;
+
+                let loc = word_idx * 64 + bit;
+                let lo = self.span_offsets[loc] as usize;
+                let hi = self.span_offsets[loc + 1] as usize;
+                let spans = &self.spans[lo..hi];
+                if !rects.iter().any(|r| spans_intersect_rect(spans, *r)) {
+                    out.words[word_idx] &= !bit_mask;
+                }
+            }
+        }
+    }
+
+    fn fill_coarse(&self, query_aabb: Aabb, bitset: &mut [u64]) {
+        let qmin = query_aabb.min();
+        let qmax = query_aabb.max();
+        let tx_start = qmin.x / TILE_SIZE;
+        let ty_start = qmin.y / TILE_SIZE;
+        let tx_end = (qmax.x / TILE_SIZE).min(self.tiles_wide.saturating_sub(1));
+        let ty_end = (qmax.y / TILE_SIZE).min(self.tiles_tall.saturating_sub(1));
+
+        if tx_start > tx_end || ty_start > ty_end {
+            return;
+        }
+
+        for ty in ty_start..=ty_end {
+            for tx in tx_start..=tx_end {
+                let idx = ty as usize * self.tiles_wide as usize + tx as usize;
+                let lo = self.tile_offsets[idx] as usize;
+                let hi = self.tile_offsets[idx + 1] as usize;
+                for &(start, end) in &self.tile_ranges[lo..hi] {
+                    set_bitrange(bitset, start.value() as usize, end.value() as usize);
+                }
+            }
+        }
+    }
+
+    /// Returns the first pixel encountered in scan order that belongs to `loc`.
+    pub fn point_of(&self, loc: R16) -> WorldPoint<u16> {
+        let idx = loc.value() as usize;
+        let first = self.spans[self.span_offsets[idx] as usize];
+        WorldPoint::new(first.x_start, first.y)
     }
 
     pub fn len(&self) -> usize {
-        self.aabbs.len()
+        self.span_offsets.len().saturating_sub(1)
     }
 
     pub fn is_empty(&self) -> bool {
-        self.aabbs.is_empty()
+        self.len() == 0
+    }
+}
+
+fn walk_runs<F: FnMut(R16, u16, u16, u16)>(world: &World, mut visit: F) {
+    // This exposes each maximal horizontal R16 run in full-world row-major
+    // order: west half, then east half, for each row.
+    let hemisphere_width = world.west().size().width as u16;
+
+    for (row, (west, east)) in world.west().rows().zip(world.east().rows()).enumerate() {
+        let y = row as u16;
+        walk_row_runs(west, 0, y, &mut visit);
+        walk_row_runs(east, hemisphere_width, y, &mut visit);
+    }
+}
+
+fn walk_row_runs<F: FnMut(R16, u16, u16, u16)>(row: &[R16], mut x: u16, y: u16, visit: &mut F) {
+    for group in row.chunk_by(|a, b| a == b) {
+        let end = x + group.len() as u16 - 1;
+        visit(group[0], x, end, y);
+        x += group.len() as u16;
+    }
+}
+
+fn spans_intersect_rect(spans: &[Span], rect: Aabb) -> bool {
+    let y_min = rect.min().y;
+    let y_max = rect.max().y;
+    let x_min = rect.min().x;
+    let x_max = rect.max().x;
+
+    let start = spans.partition_point(|span| span.y < y_min);
+    for span in &spans[start..] {
+        if span.y > y_max {
+            break;
+        }
+        if span.x_end >= x_min && span.x_start <= x_max {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(debug_assertions)]
+fn assert_spans_sorted(span_offsets: &[u32], spans: &[Span]) {
+    for loc in 0..span_offsets.len().saturating_sub(1) {
+        let lo = span_offsets[loc] as usize;
+        let hi = span_offsets[loc + 1] as usize;
+        for window in spans[lo..hi].windows(2) {
+            debug_assert!(
+                (window[0].y, window[0].x_start) < (window[1].y, window[1].x_start),
+                "spans must be sorted by (y, x_start) for location {loc}"
+            );
+        }
+    }
+}
+
+/// Reusable scratch buffer for [`SpatialIndex`] queries. Construct once and
+/// pass into [`SpatialIndex::query`] / [`SpatialIndex::query_exact`] to avoid
+/// per-call allocations on hot paths.
+#[derive(Debug, Default)]
+pub struct LocationBitset {
+    words: Vec<u64>,
+}
+
+impl LocationBitset {
+    pub fn new() -> Self {
+        Self { words: Vec::new() }
+    }
+
+    pub fn drain(&mut self) -> Drain<'_> {
+        Drain {
+            words: &mut self.words,
+            word_idx: 0,
+        }
+    }
+
+    pub fn count(&self) -> usize {
+        self.words.iter().map(|w| w.count_ones() as usize).sum()
+    }
+
+    fn reset(&mut self, len: usize) {
+        let words = len.div_ceil(64);
+        self.words.clear();
+        self.words.resize(words, 0);
+    }
+}
+
+pub struct Drain<'a> {
+    words: &'a mut [u64],
+    word_idx: usize,
+}
+
+impl<'a> Iterator for Drain<'a> {
+    type Item = R16;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.word_idx < self.words.len() {
+            let word = self.words[self.word_idx];
+            if word != 0 {
+                let bit = word.trailing_zeros() as usize;
+                self.words[self.word_idx] = word & (word - 1);
+                return Some(R16::new((self.word_idx * 64 + bit) as u16));
+            }
+            self.word_idx += 1;
+        }
+        None
+    }
+
+    fn count(self) -> usize {
+        self.words[self.word_idx..]
+            .iter()
+            .map(|w| w.count_ones() as usize)
+            .sum()
+    }
+}
+
+#[inline]
+fn set_bitrange(bitset: &mut [u64], start: usize, end: usize) {
+    let lo_word = start >> 6;
+    let hi_word = end >> 6;
+    let lo_bit = start & 63;
+    let hi_bit = end & 63;
+    if lo_word == hi_word {
+        bitset[lo_word] |= (!0u64 >> (63 - hi_bit)) & (!0u64 << lo_bit);
+    } else {
+        bitset[lo_word] |= !0u64 << lo_bit;
+        for word in bitset.iter_mut().take(hi_word).skip(lo_word + 1) {
+            *word = !0u64;
+        }
+        bitset[hi_word] |= !0u64 >> (63 - hi_bit);
     }
 }
 
@@ -139,6 +410,18 @@ mod tests {
     use super::*;
     use crate::{Hemisphere, units::HemisphereLength};
 
+    fn coarse(index: &SpatialIndex, rect: Aabb) -> Vec<R16> {
+        let mut out = LocationBitset::new();
+        index.query(&[rect], &mut out);
+        out.drain().collect()
+    }
+
+    fn exact(index: &SpatialIndex, rect: Aabb) -> Vec<R16> {
+        let mut out = LocationBitset::new();
+        index.query_exact(&[rect], &mut out);
+        out.drain().collect()
+    }
+
     fn world_from_halves(west: Vec<u16>, east: Vec<u16>, hemisphere_width: u32) -> World {
         let west = west.into_iter().map(R16::new).collect::<Vec<_>>();
         let east = east.into_iter().map(R16::new).collect::<Vec<_>>();
@@ -146,6 +429,35 @@ mod tests {
         World::builder(
             Hemisphere::new(west, HemisphereLength::new(hemisphere_width)),
             Hemisphere::new(east, HemisphereLength::new(hemisphere_width)),
+        )
+        .build()
+    }
+
+    fn world_from_grid(grid: Vec<u16>, world_width: u16) -> World {
+        assert!(world_width.is_multiple_of(2));
+        let hemisphere_width = world_width / 2;
+        let height = grid.len() / world_width as usize;
+        let mut west = Vec::with_capacity(hemisphere_width as usize * height);
+        let mut east = Vec::with_capacity(hemisphere_width as usize * height);
+
+        for row in grid.chunks_exact(world_width as usize) {
+            west.extend(
+                row[..hemisphere_width as usize]
+                    .iter()
+                    .copied()
+                    .map(R16::new),
+            );
+            east.extend(
+                row[hemisphere_width as usize..]
+                    .iter()
+                    .copied()
+                    .map(R16::new),
+            );
+        }
+
+        World::builder(
+            Hemisphere::new(west, HemisphereLength::new(hemisphere_width as u32)),
+            Hemisphere::new(east, HemisphereLength::new(hemisphere_width as u32)),
         )
         .build()
     }
@@ -188,53 +500,318 @@ mod tests {
     }
 
     #[test]
-    fn test_aabb_index_construction() {
+    fn test_spatial_index_construction() {
         let world = world_from_halves(vec![0, 1, 2, 3], vec![4, 5, 6, 7], 2);
         let index = world.build_spatial_index();
 
         assert_eq!(index.len(), 8);
 
-        let aabb = index.aabb_of(R16::new(0));
-        assert_eq!(aabb.min(), WorldPoint::new(0, 0));
-        assert_eq!(aabb.max(), WorldPoint::new(0, 0));
+        assert_eq!(index.point_of(R16::new(0)), WorldPoint::new(0, 0));
+        assert_eq!(index.point_of(R16::new(1)), WorldPoint::new(1, 0));
+        assert_eq!(index.point_of(R16::new(4)), WorldPoint::new(2, 0));
+    }
 
-        let aabb = index.aabb_of(R16::new(1));
-        assert_eq!(aabb.min(), WorldPoint::new(1, 0));
-        assert_eq!(aabb.max(), WorldPoint::new(1, 0));
+    #[test]
+    fn point_of_returns_a_pixel_belonging_to_the_location() {
+        let world = world_from_halves(vec![0, 0, 1, 1], vec![2, 2, 3, 3], 2);
+        let index = world.build_spatial_index();
 
-        let aabb = index.aabb_of(R16::new(4));
-        assert_eq!(aabb.min(), WorldPoint::new(2, 0));
-        assert_eq!(aabb.max(), WorldPoint::new(2, 0));
+        let point = index.point_of(R16::new(0));
+        assert_eq!(
+            world.at(WorldPoint::new(point.x as f32, point.y as f32)),
+            R16::new(0)
+        );
     }
 
     #[test]
     fn test_aabb_index_query() {
-        let world = world_from_halves(vec![0, 1, 2, 3], vec![4, 5, 6, 7], 2);
+        let world = world_from_halves(
+            vec![0; TILE_SIZE as usize],
+            vec![1; TILE_SIZE as usize],
+            TILE_SIZE as u32,
+        );
         let index = world.build_spatial_index();
 
-        let query = Aabb::new(WorldPoint::new(0, 0), WorldPoint::new(1, 1));
-        let results = index.query(query).collect::<Vec<_>>();
+        let query = Aabb::new(WorldPoint::new(0, 0), WorldPoint::new(TILE_SIZE - 1, 0));
+        let results = coarse(&index, query);
 
         assert!(results.contains(&R16::new(0)));
-        assert!(results.contains(&R16::new(1)));
-        assert!(results.contains(&R16::new(2)));
-        assert!(results.contains(&R16::new(3)));
 
-        assert!(!results.contains(&R16::new(4)));
-        assert!(!results.contains(&R16::new(5)));
+        assert!(!results.contains(&R16::new(1)));
     }
 
     #[test]
-    fn test_aabb_index_multi_pixel_locations() {
-        let world = world_from_halves(vec![0, 0, 0, 0], vec![1, 1, 1, 1], 2);
-        let index = world.build_spatial_index();
+    fn wrapping_location_not_matched_in_middle() {
+        let width = TILE_SIZE * 4;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+        grid[0] = 0;
+        grid[width as usize - 1] = 0;
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
 
-        let aabb = index.aabb_of(R16::new(0));
-        assert_eq!(aabb.min(), WorldPoint::new(0, 0));
-        assert_eq!(aabb.max(), WorldPoint::new(1, 1));
+        let mid = Aabb::new(
+            WorldPoint::new(TILE_SIZE * 2, 0),
+            WorldPoint::new(TILE_SIZE * 2, 0),
+        );
+        let results = coarse(&index, mid);
 
-        let aabb = index.aabb_of(R16::new(1));
-        assert_eq!(aabb.min(), WorldPoint::new(2, 0));
-        assert_eq!(aabb.max(), WorldPoint::new(3, 1));
+        assert!(!results.contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn point_of_handles_wrapping_location() {
+        let width = TILE_SIZE * 4;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+        grid[0] = 0;
+        grid[width as usize - 1] = 0;
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+
+        let point = index.point_of(R16::new(0));
+        assert_eq!(
+            world.at(WorldPoint::new(point.x as f32, point.y as f32)),
+            R16::new(0)
+        );
+    }
+
+    #[test]
+    fn wrapping_location_matched_at_either_edge() {
+        let width = TILE_SIZE * 4;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+        grid[0] = 0;
+        grid[width as usize - 1] = 0;
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+
+        let left = Aabb::new(WorldPoint::new(0, 0), WorldPoint::new(0, 0));
+        assert!(coarse(&index, left).contains(&R16::new(0)));
+
+        let right_x = world.size().width as u16 - 1;
+        let right = Aabb::new(WorldPoint::new(right_x, 0), WorldPoint::new(right_x, 0));
+        assert!(coarse(&index, right).contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn concave_location_does_not_match_interior_gap_tile() {
+        let width = TILE_SIZE * 4;
+        let height = TILE_SIZE * 3;
+        let mut grid = vec![1; width as usize * height as usize];
+
+        for y in 0..height {
+            for x in 0..(TILE_SIZE * 2) {
+                let is_left_arm = x < TILE_SIZE;
+                let is_top_arm = y < TILE_SIZE;
+                let is_bottom_arm = y >= TILE_SIZE * 2;
+                if is_left_arm || is_top_arm || is_bottom_arm {
+                    grid[y as usize * width as usize + x as usize] = 0;
+                }
+            }
+        }
+
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+
+        let interior = Aabb::new(
+            WorldPoint::new(TILE_SIZE + 1, TILE_SIZE + 1),
+            WorldPoint::new(TILE_SIZE + 1, TILE_SIZE + 1),
+        );
+        assert!(!coarse(&index, interior).contains(&R16::new(0)));
+
+        let on_arm = Aabb::new(
+            WorldPoint::new(0, TILE_SIZE + 1),
+            WorldPoint::new(0, TILE_SIZE + 1),
+        );
+        assert!(coarse(&index, on_arm).contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn location_spanning_tile_boundary_matched_from_either_tile() {
+        let width = TILE_SIZE * 2;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+        grid[(TILE_SIZE - 1) as usize] = 0;
+        grid[TILE_SIZE as usize] = 0;
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+
+        let left = Aabb::new(
+            WorldPoint::new(TILE_SIZE - 1, 0),
+            WorldPoint::new(TILE_SIZE - 1, 0),
+        );
+        assert!(coarse(&index, left).contains(&R16::new(0)));
+
+        let right = Aabb::new(WorldPoint::new(TILE_SIZE, 0), WorldPoint::new(TILE_SIZE, 0));
+        assert!(coarse(&index, right).contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn point_query_returns_locations_at_that_pixel() {
+        let width = TILE_SIZE * 2;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+        grid[5] = 0;
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+
+        let point = Aabb::new(WorldPoint::new(5, 0), WorldPoint::new(5, 0));
+        assert!(coarse(&index, point).contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn query_exact_excludes_locations_in_tile_but_outside_rect() {
+        let width = TILE_SIZE * 2;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+
+        for y in 0..32 {
+            for x in 0..32 {
+                grid[y * width as usize + x] = 0;
+            }
+        }
+
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+        let query = Aabb::new(WorldPoint::new(40, 40), WorldPoint::new(60, 60));
+
+        assert!(coarse(&index, query).contains(&R16::new(0)));
+        assert!(!exact(&index, query).contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn query_exact_includes_locations_with_overlapping_pixels() {
+        let width = TILE_SIZE * 2;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+
+        for y in 10..=20 {
+            for x in 10..=20 {
+                grid[y * width as usize + x] = 0;
+            }
+        }
+
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+        let query = Aabb::new(WorldPoint::new(10, 10), WorldPoint::new(20, 20));
+
+        assert!(exact(&index, query).contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn query_exact_handles_concave_locations() {
+        let width = TILE_SIZE * 2;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+
+        for y in 0..48 {
+            for x in 0..48 {
+                let is_left_arm = x < 16;
+                let is_top_arm = y < 16;
+                let is_bottom_arm = y >= 32;
+                if is_left_arm || is_top_arm || is_bottom_arm {
+                    grid[y * width as usize + x] = 0;
+                }
+            }
+        }
+
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+        let interior = Aabb::new(WorldPoint::new(24, 24), WorldPoint::new(28, 28));
+
+        assert!(coarse(&index, interior).contains(&R16::new(0)));
+        assert!(!exact(&index, interior).contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn query_exact_handles_wrapping_location() {
+        let width = TILE_SIZE * 4;
+        let height = TILE_SIZE;
+        let mut grid = vec![1; width as usize * height as usize];
+        grid[0] = 0;
+        grid[width as usize - 1] = 0;
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+
+        let mid = Aabb::new(
+            WorldPoint::new(TILE_SIZE * 2, 0),
+            WorldPoint::new(TILE_SIZE * 2, 0),
+        );
+        assert!(!exact(&index, mid).contains(&R16::new(0)));
+
+        let left = Aabb::new(WorldPoint::new(0, 0), WorldPoint::new(0, 0));
+        assert!(exact(&index, left).contains(&R16::new(0)));
+
+        let right = Aabb::new(WorldPoint::new(width - 1, 0), WorldPoint::new(width - 1, 0));
+        assert!(exact(&index, right).contains(&R16::new(0)));
+    }
+
+    #[test]
+    fn spans_are_sorted_by_y_x_start() {
+        let width = TILE_SIZE * 2;
+        let height = 4;
+        let mut grid = vec![1; width as usize * height as usize];
+        grid[0] = 0;
+        grid[TILE_SIZE as usize] = 0;
+        grid[width as usize] = 0;
+        grid[width as usize + TILE_SIZE as usize] = 0;
+
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+        let lo = index.span_offsets[0] as usize;
+        let hi = index.span_offsets[1] as usize;
+
+        for window in index.spans[lo..hi].windows(2) {
+            assert!((window[0].y, window[0].x_start) < (window[1].y, window[1].x_start));
+        }
+    }
+
+    #[test]
+    fn query_results_are_sorted_and_deduplicated() {
+        let width = TILE_SIZE * 4;
+        let height = TILE_SIZE * 2;
+        let mut grid = vec![3; width as usize * height as usize];
+
+        for y in 0..height {
+            for x in 0..width {
+                let value = if x < TILE_SIZE * 2 { 1 } else { 2 };
+                grid[y as usize * width as usize + x as usize] = value;
+            }
+        }
+
+        for y in 0..height {
+            grid[y as usize * width as usize] = 0;
+        }
+
+        let world = world_from_grid(grid, width);
+        let index = SpatialIndex::from_world(&world);
+
+        let big = Aabb::new(
+            WorldPoint::new(0, 0),
+            WorldPoint::new(width - 1, height - 1),
+        );
+        let results = coarse(&index, big);
+
+        let mut sorted = results.clone();
+        sorted.sort();
+        assert_eq!(results, sorted, "results must be ascending");
+
+        let mut deduped = results.clone();
+        deduped.dedup();
+        assert_eq!(results, deduped, "results must be deduplicated");
+    }
+
+    #[test]
+    fn empty_query_outside_world_returns_nothing() {
+        let world = world_from_halves(vec![0; TILE_SIZE as usize], vec![1; TILE_SIZE as usize], 64);
+        let index = SpatialIndex::from_world(&world);
+
+        let query = Aabb::new(
+            WorldPoint::new(TILE_SIZE * 2, 0),
+            WorldPoint::new(TILE_SIZE * 2, 0),
+        );
+
+        assert_eq!(coarse(&index, query), Vec::<R16>::new());
     }
 }

--- a/src/wasm-eu5-map/src/lib.rs
+++ b/src/wasm-eu5-map/src/lib.rs
@@ -4,10 +4,10 @@ use eu5app::{
 };
 use eu5save::hash::FnvHashSet;
 use pdx_map::{
-    CanvasDimensions, Clock, GpuLocationIdx, GpuSurfaceContext, Hemisphere, HemisphereLength,
-    InteractionController, KeyboardKey, LocationArrays, LocationFlags, LogicalPoint, LogicalSize,
-    MapTexture, MapViewController, MouseButton, PanTarget, PhysicalSize, R16, SpatialIndex,
-    SurfaceMapRenderer, ViewportInsets, World, WorldPoint, default_clock,
+    Aabb, CanvasDimensions, Clock, GpuLocationIdx, GpuSurfaceContext, Hemisphere, HemisphereLength,
+    InteractionController, KeyboardKey, LocationArrays, LocationBitset, LocationFlags,
+    LogicalPoint, LogicalSize, MapTexture, MapViewController, MouseButton, PanTarget, PhysicalSize,
+    R16, SpatialIndex, SurfaceMapRenderer, ViewportInsets, World, WorldPoint, default_clock,
 };
 use std::time::Duration;
 use wasm_bindgen::prelude::*;
@@ -83,6 +83,7 @@ pub struct Eu5WasmMapRenderer {
     input: InteractionController,
     world: World,
     spatial_index: SpatialIndex,
+    spatial_scratch: LocationBitset,
     location_arrays: LocationArrays,
     grouping_table: GroupingTable,
     cached_preview_groups: FnvHashSet<GroupId>,
@@ -132,6 +133,7 @@ impl Eu5WasmMapRenderer {
             input,
             world,
             spatial_index,
+            spatial_scratch: LocationBitset::new(),
             location_arrays: LocationArrays::new(),
             grouping_table: GroupingTable::empty(),
             cached_preview_groups: FnvHashSet::default(),
@@ -492,14 +494,12 @@ impl Eu5WasmMapRenderer {
 
     /// Pan to make the location with `color_id` (R16 texture index) visible,
     /// respecting panel insets. Returns true if a pan was started.
-    /// Uses the spatial index AABB center — fast, no pixel scan.
+    /// Uses a concrete pixel from the spatial index, so wrapping locations pan
+    /// to an actual owned pixel instead of an invalid world-midpoint AABB.
     #[wasm_bindgen]
     pub fn pan_to_color_id(&mut self, color_id: u16, insets: WasmViewportInsets) -> bool {
-        let aabb = self.spatial_index.aabb_of(R16::new(color_id));
-        let center = WorldPoint::new(
-            (aabb.min().x as f32 + aabb.max().x as f32) / 2.0,
-            (aabb.min().y as f32 + aabb.max().y as f32) / 2.0,
-        );
+        let point = self.spatial_index.point_of(R16::new(color_id));
+        let center = WorldPoint::new(point.x as f32, point.y as f32);
         let viewport_insets: ViewportInsets = insets.into();
         self.input
             .pan_to_visible_region(PanTarget::Point(center), viewport_insets)
@@ -523,36 +523,41 @@ impl Eu5WasmMapRenderer {
         renderer.update_locations(&self.location_arrays);
     }
 
-    fn gpu_locations_in_rect(
-        &self,
-        start: LogicalPoint<f32>,
-        end: LogicalPoint<f32>,
-    ) -> impl Iterator<Item = GpuLocationIdx> + '_ {
+    fn fill_locations_in_rect(&mut self, start: LogicalPoint<f32>, end: LogicalPoint<f32>) {
         let (primary, secondary) = self.input.canvas_rect_to_world_aabbs(start, end);
-
-        std::iter::once(primary)
-            .chain(secondary)
-            .flat_map(|aabb| self.spatial_index.query(aabb))
-            .map(|r16| GpuLocationIdx::new(r16.value()))
-            .filter(|gpu| !self.grouping_table.get(*gpu).is_none())
+        let rects: &[Aabb] = match &secondary {
+            Some(s) => &[primary, *s],
+            None => std::slice::from_ref(&primary),
+        };
+        self.spatial_index
+            .query_exact(rects, &mut self.spatial_scratch);
     }
 
     fn resolve_groups_in_rect(
-        &self,
+        &mut self,
         start: LogicalPoint<f32>,
         end: LogicalPoint<f32>,
     ) -> FnvHashSet<GroupId> {
-        self.gpu_locations_in_rect(start, end)
+        self.fill_locations_in_rect(start, end);
+        self.spatial_scratch
+            .drain()
+            .map(|r16| GpuLocationIdx::new(r16.value()))
+            .filter(|gpu| !self.grouping_table.get(*gpu).is_none())
             .map(|gpu| self.grouping_table.get(gpu))
             .collect()
     }
 
     fn resolve_gpu_locations_in_rect(
-        &self,
+        &mut self,
         start: LogicalPoint<f32>,
         end: LogicalPoint<f32>,
     ) -> FnvHashSet<GpuLocationIdx> {
-        self.gpu_locations_in_rect(start, end).collect()
+        self.fill_locations_in_rect(start, end);
+        self.spatial_scratch
+            .drain()
+            .map(|r16| GpuLocationIdx::new(r16.value()))
+            .filter(|gpu| !self.grouping_table.get(*gpu).is_none())
+            .collect()
     }
 }
 


### PR DESCRIPTION
The EU5 spatial index currently stores one AABB per location and tests every location's AABB against the query rect. Two problems:

1. World-wrap bug: locations with pixels near `x=0` and `x=world_width-1` get a merged AABB spanning the whole world, falsely matching nearly every query.
2. Concave-shape false positives: L-shaped AABBs covering large interior regions they don't occupy.

A tile grid fixes both problems. With 16384x8192 world dimensions, ~30k locations, and `R16` IDs already assigned in first-pixel-encountered scan order, the tile entries can be range-encoded for compact storage.

Most importantly we can refine the course hit test with exact locations

Benchmarks in instructions:

- 2x more IR to build the index
- 25x fewer IR small queries
- 6.5x more IR to fulfill large  queries (5632x2048)