### PR TITLE
Add archive dir support for steam asset packing

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -312,14 +312,15 @@ description = "Fetch EU4 or EU5 game files through SteamCMD into assets/steam"
 run = 'cargo run --package pdx-assets -- fetch-game "$@"'
 
 [tasks."assets:steam:bundle"]
-description = "Fetch supported Steam game patches, create raw bundles, and remove installs"
+description = "Fetch supported Steam game patches and create raw bundles"
 usage = '''
 flag "--username <username>" help="Steam username" env="STEAM_USERNAME"
 flag "--game <game>" help="Only process targets for one game" {
   choices "eu4" "eu5"
 }
-flag "--force" help="Recreate bundles that already exist"
-flag "--keep-installs" help="Keep temporary game installs under assets/steam/tmp"
+flag "--version <version>" help="Only process targets matching this version (e.g. 1.2) or 'public' for the current public branch"
+flag "--archive-dir <path>" help="Directory for permanent storage" env="ARCHIVE_DIR"
+flag "--force" help="Re-fetch from Steam even if archive zip already exists"
 flag "--dry-run" help="Print commands without executing them"
 '''
 run = "node ./dev/scripts/fetch-steam-game-bundles.mts"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ assets/game/eu5
 assets/tokens
 assets/vendored/
 .env
+.config/mise.local.toml
 dev/.env.*prod
 dev/.env.*staging
 *.node

--- a/dev/scripts/fetch-steam-game-bundles.mts
+++ b/dev/scripts/fetch-steam-game-bundles.mts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "child_process";
-import { access, mkdir, rm } from "fs/promises";
+import { access, mkdir, rename, rm } from "fs/promises";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -35,16 +35,17 @@ const targets: BundleTarget[] = [
   { game: "eu4", branch: "1.36.2", version: "1.36" },
   { game: "eu4", version: "1.37" },
   { game: "eu5", branch: "1.0.11", version: "1.0" },
-  { game: "eu5", branch: "1.1.0", version: "1.1" },
+  { game: "eu5", branch: "1.1.10", version: "1.1" },
   { game: "eu5", version: "1.2" },
 ];
 
 type Options = {
   game?: Game;
   username: string;
+  archiveDir?: string;
+  version?: string;
   dryRun: boolean;
   force: boolean;
-  keepInstalls: boolean;
 };
 
 const exists = async (path: string) => {
@@ -92,6 +93,11 @@ const readGame = (): Game | undefined => {
   throw new Error(`Invalid usage_game from mise: ${game}`);
 };
 
+const readOptionalString = (name: string) => {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+};
+
 const readOptions = (): Options => {
   const username = process.env.usage_username ?? "";
   if (!username.trim()) {
@@ -101,19 +107,30 @@ const readOptions = (): Options => {
   return {
     username: username.trim(),
     game: readGame(),
+    archiveDir: readOptionalString("usage_archive_dir"),
+    version: readOptionalString("usage_version"),
     dryRun: readBoolean("usage_dry_run"),
     force: readBoolean("usage_force"),
-    keepInstalls: readBoolean("usage_keep_installs"),
   };
 };
 
 const labelFor = (target: BundleTarget) => target.branch ?? "public";
 
+const archiveLabelFor = (target: BundleTarget) => target.branch ?? target.version;
+
 const installDirFor = (target: BundleTarget) =>
   join(projectRoot, "assets", "steam", "tmp", target.game, labelFor(target));
 
-const bundlePathFor = (target: BundleTarget) =>
-  join(projectRoot, "assets", "game-bundles", `${target.game}-${target.version}.zip`);
+const archiveZipPathFor = (target: BundleTarget, archiveDir: string) =>
+  join(archiveDir, target.game, `${archiveLabelFor(target)}.zip`);
+
+const archiveTempZipPathFor = (archiveZipPath: string) => `${archiveZipPath}.tmp`;
+
+const targetMatchesVersion = (target: BundleTarget, version: string | undefined) => {
+  if (version === undefined) return true;
+  if (version === "public") return target.branch === undefined;
+  return target.version === version;
+};
 
 const fetchArgsFor = (target: BundleTarget, installDir: string, username: string) => {
   const args = [
@@ -143,38 +160,95 @@ const main = async () => {
   });
 
   const selectedTargets = targets.filter(
-    (t) => options.game === undefined || t.game === options.game,
+    (t) =>
+      (options.game === undefined || t.game === options.game) &&
+      targetMatchesVersion(t, options.version),
   );
 
   for (const target of selectedTargets) {
-    const bundlePath = bundlePathFor(target);
-    if (!options.force && (await exists(bundlePath))) {
-      console.log(`Skipping ${target.game} ${labelFor(target)}; ${bundlePath} already exists`);
-      continue;
-    }
-
     const installDir = installDirFor(target);
+    const archiveZipPath =
+      options.archiveDir === undefined ? undefined : archiveZipPathFor(target, options.archiveDir);
     console.log(`\n=== ${target.game} ${labelFor(target)} ===`);
 
-    try {
-      await rm(installDir, { force: true, recursive: true });
-      await run(pdxAssetsBinary, fetchArgsFor(target, installDir, options.username), {
-        dryRun: options.dryRun,
-      });
-      await run(
-        pdxAssetsBinary,
-        ["bundle", "--game", target.game, "--version", target.version, installDir, gameBundlesDir],
-        { dryRun: options.dryRun },
-      );
-    } finally {
-      if (!options.keepInstalls) {
+    if (archiveZipPath === undefined) {
+      try {
+        await rm(installDir, { force: true, recursive: true });
+        await run(pdxAssetsBinary, fetchArgsFor(target, installDir, options.username), {
+          dryRun: options.dryRun,
+        });
+        await run(
+          pdxAssetsBinary,
+          [
+            "bundle",
+            "--game",
+            target.game,
+            "--version",
+            target.version,
+            installDir,
+            gameBundlesDir,
+          ],
+          { dryRun: options.dryRun },
+        );
+      } finally {
         if (options.dryRun) {
           console.log(`$ rm -rf ${shellQuote(installDir)}`);
         } else {
           await rm(installDir, { force: true, recursive: true });
         }
       }
+
+      continue;
     }
+
+    const archiveExists = await exists(archiveZipPath);
+    const archiveTempZipPath = archiveTempZipPathFor(archiveZipPath);
+    if (archiveExists && !options.force) {
+      console.log(`Using existing archive ${archiveZipPath}`);
+    } else {
+      try {
+        await rm(installDir, { force: true, recursive: true });
+        await rm(archiveTempZipPath, { force: true });
+        if (options.dryRun) {
+          console.log(`$ mkdir -p ${shellQuote(dirname(archiveZipPath))}`);
+        } else {
+          await mkdir(dirname(archiveZipPath), { recursive: true });
+        }
+        await run(pdxAssetsBinary, fetchArgsFor(target, installDir, options.username), {
+          dryRun: options.dryRun,
+        });
+        await run(pdxAssetsBinary, ["pack", installDir, archiveTempZipPath], {
+          dryRun: options.dryRun,
+        });
+
+        if (options.dryRun) {
+          console.log(`$ mv ${shellQuote(archiveTempZipPath)} ${shellQuote(archiveZipPath)}`);
+        } else {
+          await rename(archiveTempZipPath, archiveZipPath);
+        }
+      } finally {
+        if (options.dryRun) {
+          console.log(`$ rm -rf ${shellQuote(installDir)} ${shellQuote(archiveTempZipPath)}`);
+        } else {
+          await rm(installDir, { force: true, recursive: true });
+          await rm(archiveTempZipPath, { force: true });
+        }
+      }
+    }
+
+    await run(
+      pdxAssetsBinary,
+      [
+        "bundle",
+        "--game",
+        target.game,
+        "--version",
+        target.version,
+        archiveZipPath,
+        gameBundlesDir,
+      ],
+      { dryRun: options.dryRun },
+    );
   }
 };
 

--- a/src/eu5app/src/game_data/game_install/raw.rs
+++ b/src/eu5app/src/game_data/game_install/raw.rs
@@ -308,11 +308,12 @@ where
     }
 
     fn walk_directory(&self, path: &str, ends_with: &[&str]) -> Result<Vec<String>, GameDataError> {
+        let dir_prefix = format!("{}/", path.trim_end_matches('/'));
         let mut files = self
             .entries
             .keys()
             .filter_map(|x| std::str::from_utf8(x).ok())
-            .filter(|file_path| file_path.starts_with(path))
+            .filter(|file_path| file_path.starts_with(&dir_prefix))
             .filter(|file_path| ends_with.iter().any(|suffix| file_path.ends_with(suffix)))
             .map(ToOwned::to_owned)
             .collect::<Vec<_>>();
@@ -528,10 +529,11 @@ mod tests {
             path: &str,
             ends_with: &[&str],
         ) -> Result<Vec<String>, GameDataError> {
+            let dir_prefix = format!("{}/", path.trim_end_matches('/'));
             let mut files = self
                 .files
                 .keys()
-                .filter(|file_path| file_path.starts_with(path))
+                .filter(|file_path| file_path.starts_with(&dir_prefix))
                 .filter(|file_path| ends_with.iter().any(|suffix| file_path.ends_with(suffix)))
                 .cloned()
                 .collect::<Vec<_>>();

--- a/src/pdx-assets/src/bundler.rs
+++ b/src/pdx-assets/src/bundler.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
+use crate::FileProvider;
+
 #[derive(Debug, Clone)]
 pub struct BundleStatistics {
     pub files_added: u32,
@@ -49,7 +51,7 @@ impl AssetBundler {
         Self { manifest, out_file }
     }
 
-    pub fn bundle(&self) -> Result<BundleStatistics> {
+    pub fn bundle<P: FileProvider>(&self, provider: &P) -> Result<BundleStatistics> {
         if let Some(parent) = self.out_file.parent() {
             fs::create_dir_all(parent).with_context(|| {
                 format!("Failed to create output directory {}", parent.display())
@@ -71,10 +73,9 @@ impl AssetBundler {
 
         // Add explicit files
         for file_path in &required_files {
-            let source_path = self.manifest.base_path.join(file_path);
-            if source_path.exists() && source_path.is_file() {
+            if provider.file_exists(file_path) {
                 let (uncompressed, compressed) =
-                    self.add_file_to_zip(&mut zip, &source_path, file_path)?;
+                    self.add_file_to_zip(&mut zip, provider, file_path)?;
                 files_added += 1;
                 total_uncompressed_size += uncompressed;
                 total_compressed_size += compressed;
@@ -99,14 +100,15 @@ impl AssetBundler {
     fn add_file_to_zip<W: Write>(
         &self,
         zip: &mut rawzip::ZipArchiveWriter<W>,
-        source_path: &Path,
+        provider: &impl FileProvider,
         archive_path: &str,
     ) -> Result<(u64, u64)> {
-        let mut file_content = fs::File::open(source_path)
-            .with_context(|| format!("Failed to read file: {}", source_path.display()))?;
+        let mut file_content = provider
+            .open_file(archive_path)
+            .with_context(|| format!("Failed to read file: {}", archive_path))?;
 
         // Determine compression method based on file extension
-        let compression_method = if self.should_compress_file(source_path) {
+        let compression_method = if self.should_compress_file(Path::new(archive_path)) {
             rawzip::CompressionMethod::Zstd
         } else {
             rawzip::CompressionMethod::Store

--- a/src/pdx-assets/src/cli.rs
+++ b/src/pdx-assets/src/cli.rs
@@ -1,7 +1,9 @@
 mod bundle;
 mod compile;
 mod fetch_game;
+mod pack;
 
 pub use bundle::*;
 pub use compile::*;
 pub use fetch_game::*;
+pub use pack::*;

--- a/src/pdx-assets/src/cli/bundle.rs
+++ b/src/pdx-assets/src/cli/bundle.rs
@@ -3,7 +3,7 @@ use crate::asset_compilers::{
 };
 use crate::bundler::{AssetBundler, AssetManifest};
 use crate::images::imagemagick::ImageMagickProcessor;
-use crate::{DirectoryProvider, FileAccessTracker, Game, steam};
+use crate::{FileAccessTracker, FileProvider, Game, create_provider, steam};
 use anyhow::{Context, Result};
 use clap::Args;
 use std::io::stdout;
@@ -42,8 +42,8 @@ impl BundleArgs {
         let games_to_process: Vec<(Game, PathBuf)> = match self.game_directory.as_ref() {
             Some(path) => {
                 // Path provided: detect game from directory
-                let directory_provider = DirectoryProvider::new(path);
-                let tracking_provider = FileAccessTracker::new(directory_provider);
+                let provider = create_provider(path)?;
+                let tracking_provider = FileAccessTracker::new(provider);
                 let game = self.detect_game(&tracking_provider)?;
                 vec![(game, path.clone())]
             }
@@ -65,8 +65,8 @@ impl BundleArgs {
         for (game, game_directory) in games_to_process {
             println!("\n=== Bundling {} ===\n", game);
 
-            let directory_provider = DirectoryProvider::new(&game_directory);
-            let tracking_provider = FileAccessTracker::new(directory_provider);
+            let provider = create_provider(&game_directory)?;
+            let tracking_provider = FileAccessTracker::new(provider);
 
             let options = PackageOptions {
                 game_version: self.version.clone(),
@@ -118,7 +118,7 @@ impl BundleArgs {
                 .unwrap_or_else(|| PathBuf::from(&zip_filename));
 
             let bundler = AssetBundler::new(manifest, out_file);
-            let stats = bundler.bundle()?;
+            let stats = bundler.bundle(&tracking_provider)?;
 
             println!("Files added: {}", stats.files_added);
             println!(
@@ -139,7 +139,7 @@ impl BundleArgs {
         Ok(ExitCode::SUCCESS)
     }
 
-    fn detect_game(&self, provider: &FileAccessTracker<DirectoryProvider>) -> Result<Game> {
+    fn detect_game<P: FileProvider>(&self, provider: &FileAccessTracker<P>) -> Result<Game> {
         // If explicitly specified, use that
         if let Some(game_str) = &self.game {
             game_str.parse()

--- a/src/pdx-assets/src/cli/pack.rs
+++ b/src/pdx-assets/src/cli/pack.rs
@@ -1,0 +1,84 @@
+use anyhow::{Context, Result};
+use clap::Args;
+use std::fs;
+use std::io::BufWriter;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use walkdir::WalkDir;
+
+/// Pack a directory into a STORE zip archive without compression.
+#[derive(Args, Debug)]
+pub struct PackArgs {
+    /// Source directory to pack
+    #[clap(value_parser)]
+    source_dir: PathBuf,
+
+    /// Output zip path
+    #[clap(value_parser)]
+    output_zip: PathBuf,
+}
+
+impl PackArgs {
+    pub fn run(&self) -> Result<ExitCode> {
+        if !self.source_dir.is_dir() {
+            anyhow::bail!(
+                "Source path is not a directory: {}",
+                self.source_dir.display()
+            );
+        }
+
+        if let Some(parent) = self.output_zip.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create output directory {}", parent.display())
+            })?;
+        }
+
+        let output = fs::File::create(&self.output_zip).with_context(|| {
+            format!("Failed to create output zip {}", self.output_zip.display())
+        })?;
+        let writer = BufWriter::new(output);
+        let mut archive = rawzip::ZipArchiveWriter::new(writer);
+
+        let mut files = Vec::new();
+        for entry in WalkDir::new(&self.source_dir) {
+            let entry = entry?;
+            if entry.file_type().is_file() {
+                files.push(entry.into_path());
+            }
+        }
+        files.sort();
+
+        let mut files_added = 0u64;
+        let mut total_bytes = 0u64;
+
+        for file_path in files {
+            let archive_path = relative_zip_path(&self.source_dir, &file_path)?;
+            let mut input = fs::File::open(&file_path)
+                .with_context(|| format!("Failed to open {}", file_path.display()))?;
+
+            let (mut out_file, config) = archive
+                .new_file(&archive_path)
+                .compression_method(rawzip::CompressionMethod::Store)
+                .start()?;
+            let mut zip_writer = config.wrap(&mut out_file);
+            let bytes = std::io::copy(&mut input, &mut zip_writer)?;
+            let (_, output) = zip_writer.finish()?;
+            out_file.finish(output)?;
+
+            files_added += 1;
+            total_bytes += bytes;
+        }
+
+        archive.finish()?;
+
+        println!("Files added: {}", files_added);
+        println!("Bytes written: {}", total_bytes);
+
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
+fn relative_zip_path(source_dir: &Path, file_path: &Path) -> Result<String> {
+    let relative = file_path.strip_prefix(source_dir)?;
+    Ok(relative.to_string_lossy().replace('\\', "/"))
+}

--- a/src/pdx-assets/src/file_provider.rs
+++ b/src/pdx-assets/src/file_provider.rs
@@ -210,10 +210,11 @@ impl FileProvider for ZipProvider {
     }
 
     fn walk_directory(&self, path: &str, ends_with: &[&str]) -> Result<Vec<String>> {
+        let dir_prefix = format!("{}/", path.trim_end_matches('/'));
         let mut results: Vec<String> = self
             .file_index
             .keys()
-            .filter(|file_path| file_path.starts_with(path))
+            .filter(|file_path| file_path.starts_with(&dir_prefix))
             .filter(|file_path| ends_with.iter().any(|suffix| file_path.ends_with(suffix)))
             .cloned()
             .collect();
@@ -314,5 +315,165 @@ where
 
     fn open_file(&self, path: &str) -> Result<Box<dyn Read>> {
         (*self).open_file(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn zip_with_files(
+        files: &[(&str, &[u8], rawzip::CompressionMethod)],
+    ) -> tempfile::NamedTempFile {
+        let mut tmp = tempfile::Builder::new().suffix(".zip").tempfile().unwrap();
+        let mut writer = rawzip::ZipArchiveWriter::new(&mut tmp);
+
+        for (path, contents, compression_method) in files {
+            let (mut entry, config) = writer
+                .new_file(path)
+                .compression_method(*compression_method)
+                .start()
+                .unwrap();
+
+            match compression_method {
+                rawzip::CompressionMethod::Store => {
+                    let mut w = config.wrap(&mut entry);
+                    std::io::copy(&mut Cursor::new(contents), &mut w).unwrap();
+                    let (_, output) = w.finish().unwrap();
+                    entry.finish(output).unwrap();
+                }
+                rawzip::CompressionMethod::Deflate => {
+                    let encoder = flate2::write::DeflateEncoder::new(
+                        &mut entry,
+                        flate2::Compression::default(),
+                    );
+                    let mut w = config.wrap(encoder);
+                    std::io::copy(&mut Cursor::new(contents), &mut w).unwrap();
+                    let (encoder, output) = w.finish().unwrap();
+                    encoder.finish().unwrap();
+                    entry.finish(output).unwrap();
+                }
+                rawzip::CompressionMethod::Zstd => {
+                    let encoder = zstd::stream::Encoder::new(&mut entry, 0).unwrap();
+                    let mut w = config.wrap(encoder);
+                    std::io::copy(&mut Cursor::new(contents), &mut w).unwrap();
+                    let (encoder, output) = w.finish().unwrap();
+                    encoder.finish().unwrap();
+                    entry.finish(output).unwrap();
+                }
+                method => panic!("test helper does not support {method:?}"),
+            }
+        }
+
+        writer.finish().unwrap();
+        tmp
+    }
+
+    #[test]
+    fn walk_directory_does_not_match_sibling_directories_with_shared_prefix() {
+        let tmp = zip_with_files(&[
+            (
+                "game/in_game/common/goods/00_goods.txt",
+                b"x",
+                rawzip::CompressionMethod::Store,
+            ),
+            (
+                "game/in_game/common/goods_demand/army_demands.txt",
+                b"x",
+                rawzip::CompressionMethod::Store,
+            ),
+        ]);
+
+        let provider = ZipProvider::new(tmp.path()).unwrap();
+        let files = provider
+            .walk_directory("game/in_game/common/goods", &[".txt"])
+            .unwrap();
+
+        assert_eq!(files, vec!["game/in_game/common/goods/00_goods.txt"]);
+    }
+
+    #[test]
+    fn read_file_supports_zip_compression_methods_used_by_provider() {
+        let tmp = zip_with_files(&[
+            (
+                "stored.txt",
+                b"stored contents",
+                rawzip::CompressionMethod::Store,
+            ),
+            (
+                "deflated.txt",
+                b"deflated contents",
+                rawzip::CompressionMethod::Deflate,
+            ),
+            (
+                "zstd.txt",
+                b"zstd contents",
+                rawzip::CompressionMethod::Zstd,
+            ),
+        ]);
+
+        let provider = ZipProvider::new(tmp.path()).unwrap();
+
+        assert_eq!(
+            provider.read_file("stored.txt").unwrap(),
+            b"stored contents"
+        );
+        assert_eq!(
+            provider.read_to_string("deflated.txt").unwrap(),
+            "deflated contents"
+        );
+        assert_eq!(provider.read_file("zstd.txt").unwrap(), b"zstd contents");
+    }
+
+    #[test]
+    fn open_file_reads_zip_entry_contents() {
+        let tmp = zip_with_files(&[(
+            "common/countries.txt",
+            b"country = FRA",
+            rawzip::CompressionMethod::Deflate,
+        )]);
+        let provider = ZipProvider::new(tmp.path()).unwrap();
+        let mut reader = provider.open_file("common/countries.txt").unwrap();
+        let mut contents = String::new();
+
+        reader.read_to_string(&mut contents).unwrap();
+
+        assert_eq!(contents, "country = FRA");
+    }
+
+    #[test]
+    fn fs_file_extracts_zip_entry_to_temp_file() {
+        let tmp = zip_with_files(&[(
+            "gfx/interface/icon.dds",
+            b"fake image data",
+            rawzip::CompressionMethod::Store,
+        )]);
+        let provider = ZipProvider::new(tmp.path()).unwrap();
+
+        let fs_file = provider.fs_file("gfx/interface/icon.dds").unwrap();
+
+        assert_eq!(fs_file.path.file_name().unwrap(), "icon.dds");
+        assert_eq!(fs::read(fs_file.path).unwrap(), b"fake image data");
+    }
+
+    #[test]
+    fn missing_zip_entry_returns_not_found_errors() {
+        let tmp = zip_with_files(&[("exists.txt", b"x", rawzip::CompressionMethod::Store)]);
+        let provider = ZipProvider::new(tmp.path()).unwrap();
+
+        assert!(!provider.file_exists("missing.txt"));
+        assert_eq!(
+            provider.read_file("missing.txt").unwrap_err().to_string(),
+            "File not found: missing.txt"
+        );
+        assert_eq!(
+            provider.open_file("missing.txt").err().unwrap().to_string(),
+            "File not found: missing.txt"
+        );
+        assert_eq!(
+            provider.fs_file("missing.txt").unwrap_err().to_string(),
+            "File not found: missing.txt"
+        );
     }
 }

--- a/src/pdx-assets/src/main.rs
+++ b/src/pdx-assets/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use pdx_assets::{BundleArgs, CompileArgs, FetchGameArgs};
+use pdx_assets::{BundleArgs, CompileArgs, FetchGameArgs, PackArgs};
 use std::{io::IsTerminal, process::ExitCode};
 use tracing_subscriber::{EnvFilter, filter::LevelFilter, fmt::format::FmtSpan};
 
@@ -22,6 +22,7 @@ enum Commands {
     Bundle(BundleArgs),
     Compile(CompileArgs),
     FetchGame(FetchGameArgs),
+    Pack(PackArgs),
 }
 
 fn main() -> ExitCode {
@@ -41,6 +42,7 @@ fn main() -> ExitCode {
         Commands::Bundle(args) => args.run(),
         Commands::Compile(args) => args.run(),
         Commands::FetchGame(args) => args.run(),
+        Commands::Pack(args) => args.run(),
     };
 
     match exit_code {


### PR DESCRIPTION
Currently the processing all the EU4 and EU5 patches uses a temporary directory that is wiped after each patch. Thus there is a lot of Steam downloading required. Now with an archive-dir option and a new pack subcommand, we can house the downloads in a zip file for future compilation.