### PR TITLE
Split eu5 game bundle into separate zips

### DIFF
--- a/dev/scripts/setup-assets.mts
+++ b/dev/scripts/setup-assets.mts
@@ -459,8 +459,10 @@ export const dataUrls = (x: any): any => { throw new Error(msg); }
 }
 
 async function setupAssetEu5() {
-  await mkdir(join(projectRoot, "assets", "game", "eu5"), { recursive: true });
-  await touchFile(join(projectRoot, "assets", "game", "eu5", "eu5-1.0.zip"));
+  const versionDir = join(projectRoot, "assets", "game", "eu5", "1.0");
+  await mkdir(versionDir, { recursive: true });
+  await touchFile(join(versionDir, "game.zip"));
+  await touchFile(join(versionDir, "map.zip"));
 }
 
 await setupAssets();

--- a/src/app/app/features/eu5/game-adapter.ts
+++ b/src/app/app/features/eu5/game-adapter.ts
@@ -35,27 +35,68 @@ import type { SharedCanvasInputConfig } from "@/lib/canvas_courier";
 import type { BoxSelectOverlayRect } from "./types/box-select";
 import type { CursorHint } from "./workers/map/map-module";
 
-const bundleUrls = import.meta.glob<true, string, string>(
-  "../../../../../assets/game/eu5/eu5-*.zip",
+const gameZipUrls = import.meta.glob<true, string, string>(
+  "../../../../../assets/game/eu5/*/game.zip",
   { query: "?url", eager: true, import: "default" },
 );
 
-function getBundleUrl(version: string): string {
-  const path = `../../../../../assets/game/eu5/eu5-${version}.zip`;
-  const url = bundleUrls[path];
-  if (url) {
-    return url;
+const mapZipUrls = import.meta.glob<true, string, string>(
+  "../../../../../assets/game/eu5/*/map.zip",
+  { query: "?url", eager: true, import: "default" },
+);
+
+type BundleVersion = { version: string; major: number; minor: number };
+
+function parseBundleVersion(version: string): BundleVersion | null {
+  const match = /^(\d+)\.(\d+)$/.exec(version);
+  if (!match) return null;
+  return { version, major: Number(match[1]), minor: Number(match[2]) };
+}
+
+function extractDirVersion(path: string): string | null {
+  const match = /\/assets\/game\/eu5\/([^/]+)\//.exec(path);
+  return match ? match[1] : null;
+}
+
+function discoverBundles(): Map<string, { game: string; map: string }> {
+  const games = new Map<string, string>();
+  for (const [path, url] of Object.entries(gameZipUrls)) {
+    const version = extractDirVersion(path);
+    if (version !== null) games.set(version, url);
   }
 
-  // Fallback to last bundle in sorted order
-  const bundlePaths = Object.keys(bundleUrls).sort();
-  if (bundlePaths.length === 0) {
-    throw new Error("No game bundles found");
+  const complete = new Map<string, { game: string; map: string }>();
+  for (const [path, mapUrl] of Object.entries(mapZipUrls)) {
+    const version = extractDirVersion(path);
+    if (version === null || parseBundleVersion(version) === null) continue;
+    const gameUrl = games.get(version);
+    if (gameUrl) complete.set(version, { game: gameUrl, map: mapUrl });
   }
 
-  const lastBundle = bundlePaths[bundlePaths.length - 1];
-  console.warn(`Bundle for version ${version} not found, falling back to ${lastBundle}`);
-  return bundleUrls[lastBundle];
+  return complete;
+}
+
+const completeBundles = discoverBundles();
+
+function resolveBundleVersion(requested: string): string {
+  if (completeBundles.has(requested)) return requested;
+
+  const sorted = Array.from(completeBundles.keys())
+    .map((v) => parseBundleVersion(v)!)
+    .sort((a, b) => (b.major === a.major ? b.minor - a.minor : b.major - a.major));
+
+  if (sorted.length === 0) {
+    throw new Error("No complete EU5 optimized bundles found");
+  }
+
+  const latest = sorted[0].version;
+  console.warn(`EU5 bundle for version ${requested} not found, falling back to ${latest}`);
+  return latest;
+}
+
+function getBundleUrls(version: string): { game: string; map: string } {
+  const resolved = resolveBundleVersion(version);
+  return completeBundles.get(resolved)!;
 }
 
 // Worker types
@@ -111,50 +152,59 @@ export class Eu5GameAdapter {
     },
     onProgress?: (increment: number) => void,
   ) {
-    // Fetch the game bundle on the main thread, as our other options are:
-    // - Fetch in the game worker, then transfer to map worker (bad as the
-    //   parsing gamestate blocks the event loop and prevents the message from
-    //   being sent)
-    // - Fetch in both workers (bad: as inter-web worker fetches don't *appear*
-    //   to be consolidated, though under some circumstances they might).
-    // So since we can do the de-duplication ourselves, might as well.
+    // Coordinate part fetching on the main thread. The game worker calls
+    // `gameBundle.selectVersion(version)` after parsing save metadata, which
+    // eagerly kicks off both `game.zip` and `map.zip` fetches against the
+    // resolved bundle family. Each worker awaits only its own part. The
+    // alternative (fetching inside workers) either blocks on gamestate parse
+    // or runs duplicate fetches.
     //
-    // Create bundle coordination: the game worker will call setVersion after
-    // parsing metadata, and both workers will call fetch (which waits for the
-    // version to be set, then fetches the appropriate bundle once).
-    let bundleVersionResolver: ((version: string) => void) | null = null;
-    const bundleVersionPromise = new Promise<string>((resolve) => {
-      bundleVersionResolver = resolve;
+    // Progress: the external UI still shows one combined load. We split the
+    // old "fetch" allocation evenly across game.zip and map.zip.
+    let resolvedVersion: string | null = null;
+    let resolveBundles: (b: { game: Promise<Uint8Array>; map: Promise<Uint8Array> }) => void;
+
+    const bundlesPromise = new Promise<{
+      game: Promise<Uint8Array>;
+      map: Promise<Uint8Array>;
+    }>((resolve) => {
+      resolveBundles = resolve;
     });
 
-    let bundleFetchPromise: Promise<Uint8Array> | null = null;
+    const fetchPart = async (url: string): Promise<Uint8Array> => {
+      const response = await fetchOk(url);
+      const arrayBuffer = await response.arrayBuffer();
+      return new Uint8Array(arrayBuffer);
+    };
 
-    const bundleApi = {
-      setVersion: (version: string) => {
-        if (bundleVersionResolver) {
-          bundleVersionResolver(version);
+    const selectVersion = (version: string) => {
+      if (resolvedVersion !== null) {
+        if (resolvedVersion !== version) {
+          throw new Error(
+            `selectVersion called with ${version} after already resolving ${resolvedVersion}`,
+          );
         }
-      },
-      fetch: async () => {
-        // Only fetch once, even if called by multiple workers
-        if (!bundleFetchPromise) {
-          bundleFetchPromise = (async () => {
-            const version = await bundleVersionPromise;
-            const url = getBundleUrl(version);
-            const response = await fetchOk(url);
-            const arrayBuffer = await response.arrayBuffer();
-            return new Uint8Array(arrayBuffer);
-          })();
-        }
-        return await bundleFetchPromise;
-      },
+        return;
+      }
+      resolvedVersion = version;
+      const urls = getBundleUrls(version);
+      resolveBundles({ game: fetchPart(urls.game), map: fetchPart(urls.map) });
+    };
+
+    const gameBundleApi = {
+      selectVersion,
+      fetch: async () => (await bundlesPromise).game,
+    };
+
+    const mapBundleApi = {
+      fetch: async () => (await bundlesPromise).map,
     };
 
     const [saveEngine, mapEngine] = await Promise.all([
       this.eu5Worker.createGame(
         { save: config.save },
         proxy({
-          bundle: bundleApi,
+          gameBundle: gameBundleApi,
           onProgress: (increment: number) => onProgress?.(increment),
         }),
       ),
@@ -168,7 +218,7 @@ export class Eu5GameAdapter {
           [config.canvas],
         ),
         proxy({
-          bundleFetch: bundleApi.fetch,
+          mapBundle: mapBundleApi,
           onProgress: (increment: number) => onProgress?.(increment),
         }),
       ),

--- a/src/app/app/features/eu5/workers/game/game-module.ts
+++ b/src/app/app/features/eu5/workers/game/game-module.ts
@@ -57,11 +57,11 @@ export const createGame = async (
     save: Eu5SaveInput;
   },
   {
-    bundle,
+    gameBundle,
     onProgress,
   }: {
-    bundle: {
-      setVersion: (version: string) => void;
+    gameBundle: {
+      selectVersion: (version: string) => void;
       fetch: () => Promise<Uint8Array>;
     };
     onProgress?: (increment: number) => void;
@@ -89,19 +89,19 @@ export const createGame = async (
 
   const metadata = saveParser.meta();
   const version = `${metadata.version.major}.${metadata.version.minor}`;
-  bundle.setVersion(version);
-  const gameDataTask = bundle.fetch();
+  gameBundle.selectVersion(version);
+  const gameDataTask = gameBundle.fetch();
 
   const gamestate = timeSync("Parse Gamestate", () => saveParser.parse_gamestate());
   onProgress?.(30); // Parse gamestate
 
   const gameBundleData = await gameDataTask;
-  const gameBundle = timeSync("Create game bundle", () =>
+  const gameBundleWasm = timeSync("Create game bundle", () =>
     wasm_eu5.Eu5WasmGameBundle.open(gameBundleData),
   );
   onProgress?.(5); // Create game bundle
 
-  const app = timeSync("Initialize App", () => wasm_eu5.Eu5App.init(gamestate, gameBundle));
+  const app = timeSync("Initialize App", () => wasm_eu5.Eu5App.init(gamestate, gameBundleWasm));
   onProgress?.(5); // Initialize app
 
   // Build search indexes once after initialization.

--- a/src/app/app/features/eu5/workers/map/map-module.ts
+++ b/src/app/app/features/eu5/workers/map/map-module.ts
@@ -2,7 +2,7 @@ import { timeAsync, timeSync } from "@/lib/timeit";
 import init, {
   Eu5CanvasSurface,
   Eu5WasmMapRenderer,
-  Eu5WasmGameBundle,
+  Eu5WasmMapBundle,
   setup_eu5_map_wasm,
 } from "../../../../wasm/wasm_eu5_map";
 import type { CanvasDisplay, LogLevel } from "../../../../wasm/wasm_eu5_map";
@@ -116,10 +116,10 @@ export const createMapEngine = async (
     inputConfig: SharedCanvasInputConfig;
   },
   {
-    bundleFetch,
+    mapBundle,
     onProgress,
   }: {
-    bundleFetch: () => Promise<Uint8Array>;
+    mapBundle: { fetch: () => Promise<Uint8Array> };
     onProgress?: (increment: number) => void;
   },
 ) => {
@@ -136,10 +136,10 @@ export const createMapEngine = async (
   );
   onProgress?.(5); // Canvas initialization
 
-  const bundle = await bundleFetch();
+  const bundle = await mapBundle.fetch();
 
-  const gameBundle = Eu5WasmGameBundle.open(bundle);
-  const textureData = timeSync("Create Texture Data", () => gameBundle.load_texture_data());
+  const mapBundleWasm = Eu5WasmMapBundle.open(bundle);
+  const textureData = timeSync("Create Texture Data", () => mapBundleWasm.load_texture_data());
 
   const westView = timeSync("Upload Texture Data (West)", () =>
     canvasInit.upload_west_texture(textureData),

--- a/src/eu5app/src/game_data.rs
+++ b/src/eu5app/src/game_data.rs
@@ -5,7 +5,7 @@ pub mod optimized;
 pub mod game_install;
 
 pub use error::GameDataError;
-pub use optimized::OptimizedGameBundle;
+pub use optimized::{OptimizedGameBundle, OptimizedMapBundle};
 
 use eu5save::hash::FxHashMap;
 use pdx_map::R16;

--- a/src/eu5app/src/game_data/game_install.rs
+++ b/src/eu5app/src/game_data/game_install.rs
@@ -8,8 +8,7 @@ pub use raw::{
 };
 
 use crate::game_data::{
-    GameData, GameDataError, OptimizedGameBundle, TextureProvider,
-    optimized::OptimizedTextureBundle,
+    GameData, GameDataError, OptimizedGameBundle, OptimizedMapBundle, TextureProvider,
 };
 
 pub struct Eu5GameInstall {
@@ -18,26 +17,17 @@ pub struct Eu5GameInstall {
 }
 
 impl Eu5GameInstall {
-    /// Open game data from an arbitrary path (auto-detects type)
+    /// Open game data from an arbitrary path.
+    ///
+    /// - File: treated as a raw/source bundle zip.
+    /// - Directory with a `game/` subdirectory: treated as a raw EU5 install
+    ///   or extracted raw source.
+    /// - Other directory: treated as an optimized bundle family directory; must
+    ///   contain `game.zip` and `map.zip` side by side.
     #[tracing::instrument(name = "eu5.game_install.open", skip_all, fields(path = %path.as_ref().display()))]
     pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self, GameDataError> {
         let path = path.as_ref();
         if path.is_file() {
-            let data = std::fs::read(path)
-                .map_err(|e| GameDataError::Io(e, format!("{}", path.display())))?;
-
-            if let Ok(game_data) = OptimizedGameBundle::open(&data) {
-                let game_data = game_data.into_game_data()?;
-                let mut bundle = OptimizedTextureBundle::open(&data)?;
-                let (west_data, east_data) = bundle.load_hemispheres()?;
-                let max_location_index = bundle.load_max_location_index()?;
-                let textures = GameTextures::new(west_data, east_data, max_location_index);
-                return Ok(Self {
-                    textures,
-                    game_data,
-                });
-            }
-
             let file = std::fs::File::open(path)
                 .map_err(|e| GameDataError::Io(e, format!("{}", path.display())))?;
             let mut buffer = vec![0u8; rawzip::RECOMMENDED_BUFFER_SIZE];
@@ -45,7 +35,6 @@ impl Eu5GameInstall {
                 .map_err(GameDataError::ZipAccess)?;
             let zip = ZipArchiveData::open(zip, buffer);
 
-            // Fall back to treating it as a game_install bundle zip
             let (game_data, texture_builder) = RawGameData::from_source(&zip)?;
             let paletted = texture_builder.build()?;
             let game_data = game_data.into_game_data(&paletted);
@@ -56,12 +45,32 @@ impl Eu5GameInstall {
             });
         }
 
-        // Directory - treat as raw game install or extracted bundle
-        let game_installation = GameInstallationDirectory::open(path);
-        let (game_data, texture_builder) = RawGameData::from_source(&game_installation)?;
-        let paletted = texture_builder.build()?;
-        let game_data = game_data.into_game_data(&paletted);
-        let textures = paletted.into_textures();
+        // Raw install / extracted raw source: detect via presence of `game/`.
+        if path.join("game").is_dir() {
+            let game_installation = GameInstallationDirectory::open(path);
+            let (game_data, texture_builder) = RawGameData::from_source(&game_installation)?;
+            let paletted = texture_builder.build()?;
+            let game_data = game_data.into_game_data(&paletted);
+            let textures = paletted.into_textures();
+            return Ok(Self {
+                textures,
+                game_data,
+            });
+        }
+
+        // Optimized bundle family directory: require both parts.
+        let game_zip = path.join("game.zip");
+        let map_zip = path.join("map.zip");
+        let game_bytes = std::fs::read(&game_zip)
+            .map_err(|e| GameDataError::Io(e, format!("{}", game_zip.display())))?;
+        let map_bytes = std::fs::read(&map_zip)
+            .map_err(|e| GameDataError::Io(e, format!("{}", map_zip.display())))?;
+
+        let game_data = OptimizedGameBundle::open(&game_bytes)?.into_game_data()?;
+        let mut map_bundle = OptimizedMapBundle::open(&map_bytes)?;
+        let (west_data, east_data) = map_bundle.load_hemispheres()?;
+        let max_location_index = map_bundle.load_max_location_index()?;
+        let textures = GameTextures::new(west_data, east_data, max_location_index);
         Ok(Self {
             textures,
             game_data,

--- a/src/eu5app/src/game_data/optimized.rs
+++ b/src/eu5app/src/game_data/optimized.rs
@@ -21,7 +21,8 @@ impl WorldMetadata {
     }
 }
 
-/// Optimized game data is the pre-built format for distributing EU5 game data.
+/// Optimized game-domain bundle: language-agnostic gameplay lookup data plus
+/// (transitional) localization. Consumed by the game worker.
 pub struct OptimizedGameBundle<R: AsRef<[u8]>> {
     zip: ZipSliceArchive<R>,
     location_lookup: (u64, rawzip::ZipArchiveEntryWayfinder),
@@ -128,15 +129,17 @@ where
     }
 }
 
+/// Optimized map-domain bundle: hemisphere textures and world metadata.
+/// Consumed by the map worker.
 #[derive(Debug)]
-pub struct OptimizedTextureBundle<R: AsRef<[u8]>> {
+pub struct OptimizedMapBundle<R: AsRef<[u8]>> {
     zip: ZipSliceArchive<R>,
     west_texture: (u64, rawzip::ZipArchiveEntryWayfinder),
     east_texture: (u64, rawzip::ZipArchiveEntryWayfinder),
     world_meta: Option<(u64, rawzip::ZipArchiveEntryWayfinder)>,
 }
 
-impl<R> OptimizedTextureBundle<R>
+impl<R> OptimizedMapBundle<R>
 where
     R: AsRef<[u8]>,
 {
@@ -189,12 +192,7 @@ where
         pdx_zstd::decode_to(entry.data(), dst)?;
         Ok(())
     }
-}
 
-impl<R> OptimizedTextureBundle<R>
-where
-    R: AsRef<[u8]>,
-{
     /// Load the precomputed max location index, when present.
     pub fn load_max_location_index(&self) -> Result<Option<R16>, GameDataError> {
         let Some((meta_bytes, wayfinder)) = self.world_meta else {
@@ -244,7 +242,7 @@ mod tests {
         goods_localization.insert("livestock".to_string(), "Livestock".to_string());
         let mut building_localization = FxHashMap::default();
         building_localization.insert("workshop".to_string(), "Workshop".to_string());
-        let zip = test_bundle(
+        let zip = test_game_zip(
             GoodsData { goods },
             LocalizationsData {
                 countries: FxHashMap::default(),
@@ -278,7 +276,7 @@ mod tests {
                 transport_cost: 1.0,
             },
         );
-        let zip = test_bundle(GoodsData { goods }, LocalizationsData::default());
+        let zip = test_game_zip(GoodsData { goods }, LocalizationsData::default());
 
         let data = OptimizedGameBundle::open(zip)
             .unwrap()
@@ -290,7 +288,7 @@ mod tests {
 
     #[test]
     fn optimized_bundle_falls_back_to_raw_building_key() {
-        let zip = test_bundle(GoodsData::default(), LocalizationsData::default());
+        let zip = test_game_zip(GoodsData::default(), LocalizationsData::default());
 
         let data = OptimizedGameBundle::open(zip)
             .unwrap()
@@ -303,7 +301,37 @@ mod tests {
         );
     }
 
-    fn test_bundle(goods: GoodsData, localizations: LocalizationsData) -> Vec<u8> {
+    #[test]
+    fn game_bundle_rejects_map_zip() {
+        let zip = test_map_zip();
+        let err = OptimizedGameBundle::open(zip).unwrap_err();
+        match err {
+            GameDataError::MissingData(msg) => assert!(msg.contains("location_lookup.bin")),
+            other => panic!("expected MissingData, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_bundle_rejects_game_zip() {
+        let zip = test_game_zip(GoodsData::default(), LocalizationsData::default());
+        let err = OptimizedMapBundle::open(zip).unwrap_err();
+        match err {
+            GameDataError::MissingData(msg) => assert!(msg.contains("locations-0.r16")),
+            other => panic!("expected MissingData, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_bundle_loads_hemispheres_and_metadata() {
+        let zip = test_map_zip();
+        let mut bundle = OptimizedMapBundle::open(zip).unwrap();
+        let (west, east) = bundle.load_hemispheres().unwrap();
+        assert_eq!(west.len(), 4);
+        assert_eq!(east.len(), 4);
+        assert_eq!(bundle.load_max_location_index().unwrap(), Some(R16::new(7)));
+    }
+
+    fn test_game_zip(goods: GoodsData, localizations: LocalizationsData) -> Vec<u8> {
         let output = Cursor::new(Vec::new());
         let mut archive = rawzip::ZipArchiveWriter::new(output);
         write_test_entry(
@@ -313,6 +341,29 @@ mod tests {
         );
         write_test_entry(&mut archive, "localizations.bin", localizations);
         write_test_entry(&mut archive, "game_data.bin", goods);
+        archive.finish().unwrap().into_inner()
+    }
+
+    fn test_map_zip() -> Vec<u8> {
+        let output = Cursor::new(Vec::new());
+        let mut archive = rawzip::ZipArchiveWriter::new(output);
+
+        for filename in ["locations-0.r16", "locations-1.r16"] {
+            let data = vec![R16::new(0); 4];
+            let (mut entry, config) = archive
+                .new_file(filename)
+                .compression_method(CompressionMethod::Zstd)
+                .start()
+                .unwrap();
+            let encoder = pdx_zstd::Encoder::new(&mut entry, 1).unwrap();
+            let mut writer = config.wrap(encoder);
+            writer.write_all(bytemuck::cast_slice(&data)).unwrap();
+            let (encoder, out) = writer.finish().unwrap();
+            encoder.finish().unwrap();
+            entry.finish(out).unwrap();
+        }
+
+        write_test_entry(&mut archive, "world_meta.bin", WorldMetadata::new(7));
         archive.finish().unwrap().into_inner()
     }
 

--- a/src/pdx-assets/src/eu5/compiler.rs
+++ b/src/pdx-assets/src/eu5/compiler.rs
@@ -112,63 +112,75 @@ where
     // Create location data with color awareness
     let locations = textures.location_aware(raw_game_data.locations);
 
-    // Create output directory
-    let eu5_out_dir = out_dir.join("eu5");
-    std::fs::create_dir_all(&eu5_out_dir)?;
+    // Create per-version output directory: assets/game/eu5/{version}/
+    let version_dir = out_dir.join("eu5").join(game_version);
+    std::fs::create_dir_all(&version_dir)?;
 
-    // Create the bundle zip file
-    let bundle_path = eu5_out_dir.join(format!("eu5-{game_version}.zip"));
-    let output = std::fs::File::create(&bundle_path)?;
-    let writer = std::io::BufWriter::new(output);
-    let mut archive = rawzip::ZipArchiveWriter::new(writer);
+    // Game part: language/lookup data consumed by the game worker.
+    let game_path = version_dir.join("game.zip");
+    {
+        let output = std::fs::File::create(&game_path)?;
+        let writer = std::io::BufWriter::new(output);
+        let mut archive = rawzip::ZipArchiveWriter::new(writer);
 
-    write_entry(&mut archive, "location_lookup.bin", &locations)?;
-    write_entry(
-        &mut archive,
-        "localizations.bin",
-        LocalizationsData {
-            countries: raw_game_data.country_localizations,
-            goods: raw_game_data.goods_localizations,
-            buildings: raw_game_data.building_localizations,
-        },
-    )?;
-    write_entry(
-        &mut archive,
-        "game_data.bin",
-        GoodsData {
-            goods: raw_game_data.goods,
-        },
-    )?;
-    let max_location_index = textures.textures().world().max_location_index().value();
-    write_entry(
-        &mut archive,
-        "world_meta.bin",
-        WorldMetadata::new(max_location_index),
-    )?;
+        write_entry(&mut archive, "location_lookup.bin", &locations)?;
+        write_entry(
+            &mut archive,
+            "localizations.bin",
+            LocalizationsData {
+                countries: raw_game_data.country_localizations,
+                goods: raw_game_data.goods_localizations,
+                buildings: raw_game_data.building_localizations,
+            },
+        )?;
+        write_entry(
+            &mut archive,
+            "game_data.bin",
+            GoodsData {
+                goods: raw_game_data.goods,
+            },
+        )?;
+        archive.finish()?
+    };
 
-    // Write R16 texture files
-    for (filename, data) in [
-        ("locations-0.r16", textures.textures().west_data()),
-        ("locations-1.r16", textures.textures().east_data()),
-    ] {
-        let (mut entry, config) = archive
-            .new_file(filename)
-            .compression_method(CompressionMethod::Zstd)
-            .start()?;
-        let encoder = pdx_zstd::Encoder::new(&mut entry, 7)?;
-        let mut writer = config.wrap(encoder);
-        writer.write_all(bytemuck::cast_slice(data))?;
-        let (encoder, out) = writer.finish()?;
-        encoder.finish()?;
-        entry.finish(out)?;
-    }
+    // Map part: hemisphere textures and world metadata consumed by the map worker.
+    let map_path = version_dir.join("map.zip");
+    {
+        let output = std::fs::File::create(&map_path)?;
+        let writer = std::io::BufWriter::new(output);
+        let mut archive = rawzip::ZipArchiveWriter::new(writer);
 
-    archive.finish()?;
+        let max_location_index = textures.textures().world().max_location_index().value();
+        write_entry(
+            &mut archive,
+            "world_meta.bin",
+            WorldMetadata::new(max_location_index),
+        )?;
+
+        for (filename, data) in [
+            ("locations-0.r16", textures.textures().west_data()),
+            ("locations-1.r16", textures.textures().east_data()),
+        ] {
+            let (mut entry, config) = archive
+                .new_file(filename)
+                .compression_method(CompressionMethod::Zstd)
+                .start()?;
+            let encoder = pdx_zstd::Encoder::new(&mut entry, 7)?;
+            let mut writer = config.wrap(encoder);
+            writer.write_all(bytemuck::cast_slice(data))?;
+            let (encoder, out) = writer.finish()?;
+            encoder.finish()?;
+            entry.finish(out)?;
+        }
+
+        archive.finish()?
+    };
 
     tracing::info!(
         name: "eu5.bundle.complete",
-        bundle_path = %bundle_path.display(),
-        "EU5 game bundle created"
+        game_path = %game_path.display(),
+        map_path = %map_path.display(),
+        "EU5 optimized bundle parts created"
     );
 
     if !options.minimal {

--- a/src/wasm-eu5-map/src/lib.rs
+++ b/src/wasm-eu5-map/src/lib.rs
@@ -1,6 +1,5 @@
 use eu5app::{
-    GroupId, GroupingTable, game_data::optimized::OptimizedTextureBundle,
-    should_highlight_individual_locations,
+    GroupId, GroupingTable, game_data::OptimizedMapBundle, should_highlight_individual_locations,
 };
 use eu5save::hash::FnvHashSet;
 use pdx_map::{
@@ -563,17 +562,17 @@ impl Eu5WasmMapRenderer {
 
 #[wasm_bindgen]
 #[derive(Debug)]
-pub struct Eu5WasmGameBundle {
-    textures: OptimizedTextureBundle<Vec<u8>>,
+pub struct Eu5WasmMapBundle {
+    textures: OptimizedMapBundle<Vec<u8>>,
 }
 
 #[wasm_bindgen]
-impl Eu5WasmGameBundle {
+impl Eu5WasmMapBundle {
     #[wasm_bindgen]
     pub fn open(data: Vec<u8>) -> Result<Self, JsError> {
-        OptimizedTextureBundle::open(data)
-            .map(|textures| Eu5WasmGameBundle { textures })
-            .map_err(|e| JsError::new(&format!("Failed to open game bundle: {e}")))
+        OptimizedMapBundle::open(data)
+            .map(|textures| Eu5WasmMapBundle { textures })
+            .map_err(|e| JsError::new(&format!("Failed to open map bundle: {e}")))
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
- Codifies how the game and map bundles are distinctly used. There are no cross-over assets.
- Sets precedent for the future of lazily loading localization too
- Keeps us under the asset size limit (25 MB).