### PR TITLE
Fill uninhabitable with surrounding color

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,6 +2916,8 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "futures-channel",
+ "postcard",
+ "serde",
  "tracing",
  "wasm-bindgen",
  "wgpu",

--- a/src/eu5app/src/game_data.rs
+++ b/src/eu5app/src/game_data.rs
@@ -8,7 +8,7 @@ pub use error::GameDataError;
 pub use optimized::{OptimizedGameBundle, OptimizedLocalizationBundle, OptimizedMapBundle};
 
 use eu5save::hash::FxHashMap;
-use pdx_map::R16;
+use pdx_map::{R16, TopologyIndex};
 use serde::{Deserialize, Serialize};
 
 use crate::GameLocation;
@@ -53,6 +53,7 @@ impl Localization {
 pub struct GameData {
     pub locations: Vec<GameLocation>,
     pub goods: FxHashMap<String, GoodData>,
+    pub topology: TopologyIndex,
 }
 
 impl GameData {
@@ -66,6 +67,7 @@ impl std::fmt::Debug for GameData {
         f.debug_struct("OwnedGameData")
             .field("locations_count", &self.locations.len())
             .field("goods_count", &self.goods.len())
+            .field("topology_len", &self.topology.len())
             .finish()
     }
 }

--- a/src/eu5app/src/game_data/game_install/parsing.rs
+++ b/src/eu5app/src/game_data/game_install/parsing.rs
@@ -10,7 +10,8 @@ use std::sync::LazyLock;
 
 #[derive(Debug)]
 pub struct DefaultMap {
-    pub water_locations: FxHashSet<String>,
+    pub sea_zones: FxHashSet<String>,
+    pub lakes: FxHashSet<String>,
     pub impassable: FxHashSet<String>,
 }
 
@@ -29,13 +30,6 @@ pub fn parse_default_map(reader: impl Read) -> Result<DefaultMap, GameDataError>
         .deserialize()
         .map_err(|e| GameDataError::Jomini(e, "default.map"))?;
 
-    let water_locations = default_map
-        .sea_zones
-        .iter()
-        .chain(default_map.lakes.iter())
-        .cloned()
-        .collect::<FxHashSet<_>>();
-
     let impassable = default_map
         .impassable_mountains
         .iter()
@@ -44,7 +38,8 @@ pub fn parse_default_map(reader: impl Read) -> Result<DefaultMap, GameDataError>
         .collect::<FxHashSet<_>>();
 
     Ok(DefaultMap {
-        water_locations,
+        sea_zones: default_map.sea_zones.into_iter().collect(),
+        lakes: default_map.lakes.into_iter().collect(),
         impassable,
     })
 }
@@ -73,8 +68,10 @@ pub fn parse_locations_data(
     default_map: &DefaultMap,
 ) -> impl Iterator<Item = LocationTerrain> {
     named_locations.into_iter().map(|(name, hex)| {
-        let terrain = if default_map.water_locations.contains(&name) {
-            Terrain::Water
+        let terrain = if default_map.sea_zones.contains(&name) {
+            Terrain::Sea
+        } else if default_map.lakes.contains(&name) {
+            Terrain::Lake
         } else if default_map.impassable.contains(&name) {
             Terrain::Impassable
         } else {

--- a/src/eu5app/src/game_data/game_install/raw.rs
+++ b/src/eu5app/src/game_data/game_install/raw.rs
@@ -589,10 +589,12 @@ impl RawGameData {
     pub fn materialize(self, textures: &PalettedTextures) -> (GameData, Localization) {
         let locations = textures.location_aware(self.locations);
         let localization = Localization::new(self.localizations);
+        let topology = textures.textures().world().build_topology_index();
         (
             GameData {
                 locations,
                 goods: self.goods,
+                topology,
             },
             localization,
         )

--- a/src/eu5app/src/game_data/optimized.rs
+++ b/src/eu5app/src/game_data/optimized.rs
@@ -2,7 +2,7 @@ use crate::{
     GameLocation,
     game_data::{GameData, GameDataError, GoodsData, Localization, LocalizationsData},
 };
-use pdx_map::R16;
+use pdx_map::{R16, TopologyIndex};
 use rawzip::{ZipArchive, ZipSliceArchive};
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +27,7 @@ pub struct OptimizedGameBundle<R: AsRef<[u8]>> {
     zip: ZipSliceArchive<R>,
     location_lookup: (u64, rawzip::ZipArchiveEntryWayfinder),
     game_data: (u64, rawzip::ZipArchiveEntryWayfinder),
+    topology: (u64, rawzip::ZipArchiveEntryWayfinder),
 }
 
 impl<R> OptimizedGameBundle<R>
@@ -37,6 +38,7 @@ where
         let zip = ZipArchive::from_slice(data).map_err(GameDataError::ZipAccess)?;
         let mut location_lookup_entry = None;
         let mut game_data_entry = None;
+        let mut topology_entry = None;
 
         for entry in zip.entries() {
             let entry = entry.map_err(GameDataError::ZipAccess)?;
@@ -48,6 +50,9 @@ where
                 b"game_data.bin" => {
                     game_data_entry = Some((entry.uncompressed_size_hint(), entry.wayfinder()));
                 }
+                b"topology.bin" => {
+                    topology_entry = Some((entry.uncompressed_size_hint(), entry.wayfinder()));
+                }
                 _ => {}
             }
         }
@@ -58,16 +63,24 @@ where
         let game_data = game_data_entry.ok_or_else(|| {
             GameDataError::MissingData("game_data.bin not found in bundle".to_string())
         })?;
+        let topology = topology_entry.ok_or_else(|| {
+            GameDataError::MissingData("topology.bin not found in bundle".to_string())
+        })?;
 
         Ok(Self {
             zip,
             location_lookup,
             game_data,
+            topology,
         })
     }
 
     pub fn into_game_data(self) -> Result<GameData, GameDataError> {
-        let buf_size = self.location_lookup.0.max(self.game_data.0);
+        let buf_size = self
+            .location_lookup
+            .0
+            .max(self.game_data.0)
+            .max(self.topology.0);
         let mut buf = vec![0; buf_size as usize];
 
         let location_entry = self
@@ -86,9 +99,18 @@ where
         pdx_zstd::decode_to(game_data_entry.data(), game_data_buf)?;
         let game_data: GoodsData = postcard::from_bytes(game_data_buf)?;
 
+        let topology_entry = self
+            .zip
+            .get_entry(self.topology.1)
+            .map_err(GameDataError::ZipAccess)?;
+        let topology_buf = &mut buf[..self.topology.0 as usize];
+        pdx_zstd::decode_to(topology_entry.data(), topology_buf)?;
+        let topology: TopologyIndex = postcard::from_bytes(topology_buf)?;
+
         Ok(GameData {
             locations,
             goods: game_data.goods,
+            topology,
         })
     }
 }
@@ -365,7 +387,18 @@ mod tests {
             Vec::<GameLocation>::new(),
         );
         write_test_entry(&mut archive, "game_data.bin", goods);
+        write_test_entry(&mut archive, "topology.bin", empty_topology());
         archive.finish().unwrap().into_inner()
+    }
+
+    fn empty_topology() -> TopologyIndex {
+        use pdx_map::{Hemisphere, HemisphereLength, World};
+        let world = World::builder(
+            Hemisphere::new(vec![R16::new(0)], HemisphereLength::new(1)),
+            Hemisphere::new(vec![R16::new(0)], HemisphereLength::new(1)),
+        )
+        .build();
+        world.build_topology_index()
     }
 
     fn test_loc_zip(localizations: LocalizationsData) -> Vec<u8> {

--- a/src/eu5app/src/models.rs
+++ b/src/eu5app/src/models.rs
@@ -66,7 +66,8 @@ pub enum Terrain {
     #[default]
     Other,
     Impassable,
-    Water,
+    Sea,
+    Lake,
 }
 
 impl Serialize for Terrain {
@@ -77,7 +78,8 @@ impl Serialize for Terrain {
         let s = match self {
             Terrain::Other => 1,
             Terrain::Impassable => 2,
-            Terrain::Water => 3,
+            Terrain::Sea => 3,
+            Terrain::Lake => 4,
         };
         serializer.serialize_u8(s)
     }
@@ -92,7 +94,8 @@ impl<'de> Deserialize<'de> for Terrain {
         match s {
             1 => Ok(Terrain::Other),
             2 => Ok(Terrain::Impassable),
-            3 => Ok(Terrain::Water),
+            3 => Ok(Terrain::Sea),
+            4 => Ok(Terrain::Lake),
             _ => Err(serde::de::Error::custom("invalid terrain value")),
         }
     }
@@ -100,10 +103,18 @@ impl<'de> Deserialize<'de> for Terrain {
 
 impl Terrain {
     pub fn is_water(&self) -> bool {
-        matches!(self, Terrain::Water)
+        matches!(self, Terrain::Sea | Terrain::Lake)
+    }
+
+    pub fn is_sea(&self) -> bool {
+        matches!(self, Terrain::Sea)
     }
 
     pub fn is_passable(&self) -> bool {
         matches!(self, Terrain::Other)
+    }
+
+    pub fn is_surround_fillable(&self) -> bool {
+        matches!(self, Terrain::Lake | Terrain::Impassable)
     }
 }

--- a/src/eu5app/src/session/workspace.rs
+++ b/src/eu5app/src/session/workspace.rs
@@ -65,6 +65,8 @@ pub struct Eu5Workspace<'bump> {
     overlord_of: CountryIndexedVecOwned<Option<CountryIdx>>,
     location_terrain: LocationIndexedVec<Terrain>,
     location_building_levels: OnceLock<LocationIndexedVec<f64>>,
+    color_id_to_location: OnceLock<Vec<Option<LocationIdx>>>,
+    political_surrounded_donors: OnceLock<LocationIndexedVec<Option<LocationIdx>>>,
 
     // Map app state (rendering)
     current_map_mode: MapMode,
@@ -128,6 +130,7 @@ mod insights;
 mod map_render;
 mod overlay;
 mod selection_ops;
+mod terrain_fill;
 
 impl<'bump> Eu5Workspace<'bump> {
     /// Create a new workspace from loaded save data and game data provider
@@ -196,6 +199,8 @@ impl<'bump> Eu5Workspace<'bump> {
             overlord_of,
             location_terrain,
             location_building_levels: OnceLock::new(),
+            color_id_to_location: OnceLock::new(),
+            political_surrounded_donors: OnceLock::new(),
             current_map_mode: MapMode::Political,
             location_arrays,
             gpu_indices,

--- a/src/eu5app/src/session/workspace/entity_profile.rs
+++ b/src/eu5app/src/session/workspace/entity_profile.rs
@@ -978,7 +978,8 @@ impl<'bump> Eu5Workspace<'bump> {
 
         let terrain = match self.location_terrain(idx) {
             Terrain::Other => "Land",
-            Terrain::Water => "Water",
+            Terrain::Sea => "Sea",
+            Terrain::Lake => "Lake",
             Terrain::Impassable => "Impassable",
         }
         .to_string();

--- a/src/eu5app/src/session/workspace/hover.rs
+++ b/src/eu5app/src/session/workspace/hover.rs
@@ -6,6 +6,17 @@ impl<'bump> Eu5Workspace<'bump> {
         let location = self.gamestate().locations.index(location_idx).location();
 
         if location.owner.is_dummy() {
+            // Filled special-terrain locations inherit the source location's
+            // categorical data for hover purposes only; the displayed
+            // `location_id` stays the hovered one.
+            if Self::uses_terrain_fill(mode)
+                && let Some(donor) = self.political_surrounded_donors()[location_idx]
+            {
+                let donor_location = self.gamestate().locations.index(donor).location();
+                return self
+                    .country_hover(location_idx, donor_location, mode)
+                    .unwrap_or(HoverDisplayDataSource::Clear);
+            }
             return HoverDisplayDataSource::Clear;
         }
 

--- a/src/eu5app/src/session/workspace/map_render.rs
+++ b/src/eu5app/src/session/workspace/map_render.rs
@@ -1,5 +1,6 @@
 use crate::gradient::{self, GradientScale};
 
+use super::terrain_fill::compute_surrounded_donors;
 use super::*;
 
 impl<'bump> Eu5Workspace<'bump> {
@@ -93,6 +94,42 @@ impl<'bump> Eu5Workspace<'bump> {
 
     pub fn location_terrain(&self, idx: eu5save::models::LocationIdx) -> Terrain {
         self.location_terrain[idx]
+    }
+
+    /// Reverse map: GPU color-id (R16 value) -> save `LocationIdx`.
+    /// Sized to `max(color_id) + 1`.
+    pub(crate) fn color_id_to_location(&self) -> &[Option<eu5save::models::LocationIdx>] {
+        self.color_id_to_location.get_or_init(|| {
+            let mut max_color_id: u16 = 0;
+            for g in self.gpu_indices.iter().flatten() {
+                max_color_id = max_color_id.max(g.value());
+            }
+            let mut out = vec![None; max_color_id as usize + 1];
+            for (raw_idx, entry) in self.gpu_indices.iter().enumerate() {
+                if let Some(g) = entry {
+                    out[g.value() as usize] =
+                        Some(eu5save::models::LocationIdx::new(raw_idx as u32));
+                }
+            }
+            out
+        })
+    }
+
+    /// Per-location donor override for the political map mode: `Some(donor)`
+    /// when this location's color should be inherited from `donor`.
+    pub(crate) fn political_surrounded_donors(
+        &self,
+    ) -> &LocationIndexedVec<Option<eu5save::models::LocationIdx>> {
+        self.political_surrounded_donors.get_or_init(|| {
+            let reverse = self.color_id_to_location();
+            compute_surrounded_donors(
+                &self.game_data.topology,
+                &self.gpu_indices,
+                &self.location_terrain,
+                reverse,
+                |loc| self.location_political_color(loc),
+            )
+        })
     }
 
     pub fn location_political_color(&self, key: eu5save::models::LocationIdx) -> GpuColor {
@@ -462,6 +499,10 @@ impl<'bump> Eu5Workspace<'bump> {
     }
 
     pub(super) fn build_location_arrays(&mut self) {
+        // Populate donor cache once before the loop so subsequent lookups
+        // are pure indexing.
+        let _ = self.political_surrounded_donors();
+
         for location in self.gamestate.locations.iter() {
             let Some(gpu_index) = self.gpu_indices[location.idx()] else {
                 tracing::debug!(id = ?location.id(), location_idx = ?location.idx(), "Skipping location not in texture");
@@ -469,29 +510,43 @@ impl<'bump> Eu5Workspace<'bump> {
             };
 
             let terrain = self.location_terrain(location.idx());
+            let donor = if terrain.is_water() || !terrain.is_passable() {
+                self.political_surrounded_donors()[location.idx()]
+            } else {
+                None
+            };
+
             let mut gpu_location = self.location_arrays.get_mut(gpu_index);
             gpu_location.set_location_id(pdx_map::LocationId::new(location.idx().value()));
 
             // Water locations get a specific color and no location borders
             if terrain.is_water() {
-                gpu_location.set_primary_color(GpuColor::WATER);
-                gpu_location.set_owner_color(GpuColor::WATER);
-                gpu_location.set_secondary_color(GpuColor::WATER);
+                if donor.is_none() {
+                    gpu_location.set_primary_color(GpuColor::WATER);
+                    gpu_location.set_owner_color(GpuColor::WATER);
+                    gpu_location.set_secondary_color(GpuColor::WATER);
+                    gpu_location
+                        .flags_mut()
+                        .set(LocationFlags::NO_LOCATION_BORDERS);
+                    continue;
+                }
+                // Surrounded water: paint like the donor's land, suppress
+                // location borders so it visually merges with the country.
                 gpu_location
                     .flags_mut()
                     .set(LocationFlags::NO_LOCATION_BORDERS);
-                continue;
             }
 
-            if !terrain.is_passable() {
+            if !terrain.is_passable() && donor.is_none() {
                 gpu_location.set_primary_color(GpuColor::IMPASSABLE);
                 gpu_location.set_owner_color(GpuColor::IMPASSABLE);
                 gpu_location.set_secondary_color(GpuColor::IMPASSABLE);
                 continue;
             }
 
-            let owner_color = self.location_political_color(location.idx());
-            let control_color = self.location_control_color(location.idx());
+            let source = donor.unwrap_or_else(|| location.idx());
+            let owner_color = self.location_political_color(source);
+            let control_color = self.location_control_color(source);
             let mut gpu_location = self.location_arrays.get_mut(gpu_index);
             gpu_location.set_primary_color(owner_color);
             gpu_location.set_secondary_color(control_color);
@@ -530,10 +585,64 @@ impl<'bump> Eu5Workspace<'bump> {
             MapMode::StateEfficacy => self.apply_state_efficacy_colors(),
         };
 
+        if Self::uses_terrain_fill(mode) {
+            self.apply_surrounded_fill_from_current_colors();
+        }
         self.apply_selection_dimming();
         self.apply_focused_flag();
 
         gradient
+    }
+
+    pub(crate) fn uses_terrain_fill(mode: MapMode) -> bool {
+        matches!(mode, MapMode::Political | MapMode::Religion)
+    }
+
+    fn apply_surrounded_fill_from_current_colors(&mut self) {
+        // Donor color is read live from the GPU buffers via each location's
+        // gpu index. Donors are always non-fillable boundary land, which this
+        // pass never mutates, so reading them live matches a pre-pass snapshot
+        // without the per-rebuild allocation.
+        let donors = compute_surrounded_donors(
+            &self.game_data.topology,
+            &self.gpu_indices,
+            &self.location_terrain,
+            self.color_id_to_location(),
+            |loc| {
+                self.gpu_indices[loc]
+                    .map(|g| self.location_arrays.buffers().primary_colors()[g.value() as usize])
+                    .unwrap_or(GpuColor::DEBUG)
+            },
+        );
+
+        for idx in 0..self.gamestate.locations.len() {
+            let location_idx = eu5save::models::LocationIdx::new(idx as u32);
+            let terrain = self.location_terrain(location_idx);
+            if !terrain.is_surround_fillable() {
+                continue;
+            }
+            let Some(donor) = donors[location_idx] else {
+                continue;
+            };
+            let (Some(gpu_index), Some(donor_gpu)) =
+                (self.gpu_indices[location_idx], self.gpu_indices[donor])
+            else {
+                continue;
+            };
+
+            let buffers = self.location_arrays.buffers();
+            let primary = buffers.primary_colors()[donor_gpu.value() as usize];
+            let secondary = buffers.secondary_colors()[donor_gpu.value() as usize];
+
+            let mut gpu_location = self.location_arrays.get_mut(gpu_index);
+            gpu_location.set_primary_color(primary);
+            gpu_location.set_secondary_color(secondary);
+            if terrain.is_water() {
+                gpu_location
+                    .flags_mut()
+                    .set(LocationFlags::NO_LOCATION_BORDERS);
+            }
+        }
     }
 
     fn apply_selection_dimming(&mut self) {
@@ -542,12 +651,20 @@ impl<'bump> Eu5Workspace<'bump> {
         }
 
         const DIM: f32 = 0.3;
+        // Snapshot donor lookups up front so we don't hold an immutable borrow
+        // across `location_arrays.get_mut` below.
+        let donors: Vec<Option<eu5save::models::LocationIdx>> =
+            self.political_surrounded_donors().iter().copied().collect();
         for location in self.gamestate.locations.iter() {
             let terrain = self.location_terrain(location.idx());
-            if matches!(terrain, Terrain::Impassable) {
+            if self.selection_state.contains(location.idx()) {
                 continue;
             }
-            if self.selection_state.contains(location.idx()) {
+            // Surrounded special-terrain inherits selection state from its
+            // donor so it stays in sync with the rest of the country.
+            if let Some(donor) = donors[location.idx().value() as usize]
+                && self.selection_state.contains(donor)
+            {
                 continue;
             }
             let Some(gpu_idx) = self.gpu_indices[location.idx()] else {
@@ -555,8 +672,12 @@ impl<'bump> Eu5Workspace<'bump> {
             };
             let mut s = self.location_arrays.get_mut(gpu_idx);
 
-            // Only dim water that has been painted by the map mode (ie: market mode).
+            // Only dim special terrain that has been painted by the active map
+            // mode (i.e., either surrounded by a donor or market-coloured).
             if terrain.is_water() && s.primary_color() == GpuColor::WATER {
+                continue;
+            }
+            if !terrain.is_passable() && s.primary_color() == GpuColor::IMPASSABLE {
                 continue;
             }
             s.set_primary_color(s.primary_color().dim(DIM));
@@ -580,6 +701,9 @@ impl<'bump> Eu5Workspace<'bump> {
     }
 
     fn apply_political_colors(&mut self) -> gradient::MapLegend {
+        // Surrounded special-terrain is painted by the shared
+        // `apply_surrounded_fill_from_current_colors` post-pass (run from
+        // `set_map_mode`), so this loop only needs each location's own color.
         for idx in 0..self.gamestate.locations.len() {
             let location_idx = eu5save::models::LocationIdx::new(idx as u32);
             let Some(gpu_index) = self.gpu_indices[location_idx] else {

--- a/src/eu5app/src/session/workspace/selection_ops.rs
+++ b/src/eu5app/src/session/workspace/selection_ops.rs
@@ -518,8 +518,32 @@ impl<'bump> Eu5Workspace<'bump> {
     pub fn can_highlight_location(&self, location_idx: eu5save::models::LocationIdx) -> bool {
         let terrain = self.location_terrain(location_idx);
 
-        // Can highlight if terrain is not water and not impassable
-        !terrain.is_water() && terrain.is_passable()
+        if !terrain.is_water() && terrain.is_passable() {
+            return true;
+        }
+
+        // Surrounded special-terrain participates in highlights as if it were
+        // part of the donor's country.
+        self.political_surrounded_donors()[location_idx].is_some()
+    }
+
+    /// Resolve the "effective" owner for highlight/hover purposes: a location's
+    /// real owner, or — for surrounded special-terrain — the donor's owner.
+    fn resolved_political_owner(
+        &self,
+        location_idx: eu5save::models::LocationIdx,
+    ) -> Option<eu5save::models::RealCountryId> {
+        let location = self.gamestate.locations.index(location_idx).location();
+        if let Some(real) = location.owner.real_id() {
+            return Some(real);
+        }
+        let donor = self.political_surrounded_donors()[location_idx]?;
+        self.gamestate
+            .locations
+            .index(donor)
+            .location()
+            .owner
+            .real_id()
     }
 
     pub fn clear_highlights(&mut self) {
@@ -549,8 +573,7 @@ impl<'bump> Eu5Workspace<'bump> {
 
         for entry in self.gamestate.locations.iter() {
             let idx = entry.idx();
-            if entry.location().owner.real_id() != Some(owner) || !self.can_highlight_location(idx)
-            {
+            if self.resolved_political_owner(idx) != Some(owner) {
                 continue;
             }
 
@@ -598,13 +621,37 @@ impl<'bump> Eu5Workspace<'bump> {
         }
 
         if let Some(anchor) = self.derived_entity_anchor
-            && self.same_entity(location_idx, anchor, scope_mode)
+            && self.same_entity_for_hover(location_idx, anchor, scope_mode)
         {
             self.highlight_location(location_idx);
             return;
         }
 
         self.highlight_entity(location_idx);
+    }
+
+    fn same_entity_for_hover(
+        &self,
+        a: eu5save::models::LocationIdx,
+        b: eu5save::models::LocationIdx,
+        mode: MapMode,
+    ) -> bool {
+        if self.same_entity(a, b, mode) {
+            return true;
+        }
+        // Filled special-terrain has no real owner of its own; treat it as
+        // part of the source country only in modes where terrain fill is
+        // actually rendered.
+        if !Self::uses_terrain_fill(mode) {
+            return false;
+        }
+        match (
+            self.resolved_political_owner(a),
+            self.resolved_political_owner(b),
+        ) {
+            (Some(o1), Some(o2)) => o1 == o2,
+            _ => false,
+        }
     }
 
     fn highlight_locations_by_index(&mut self, idxs: &eu5save::models::LocationIndexedVec<bool>) {
@@ -632,13 +679,12 @@ impl<'bump> Eu5Workspace<'bump> {
 
             self.highlight_locations_by_index(&idxs);
         } else {
-            let owner = location.owner.real_id();
+            let owner = self.resolved_political_owner(location_idx);
             let mut idxs = self.gamestate.locations.create_index(false);
 
             if let Some(owner) = owner {
                 for entry in self.gamestate.locations.iter() {
-                    idxs[entry.idx()] =
-                        entry.location().owner.real_id().is_some_and(|x| x == owner);
+                    idxs[entry.idx()] = self.resolved_political_owner(entry.idx()) == Some(owner);
                 }
             }
 

--- a/src/eu5app/src/session/workspace/terrain_fill.rs
+++ b/src/eu5app/src/session/workspace/terrain_fill.rs
@@ -1,0 +1,274 @@
+use crate::models::Terrain;
+use eu5save::models::{LocationIdx, LocationIndexedVec};
+use pdx_map::{GpuColor, GpuLocationIdx, TopologyIndex};
+use std::collections::VecDeque;
+
+/// Compute per-location donor overrides for connected components of fillable
+/// terrain (lakes + impassable) that are surrounded by a single uniform color
+/// from `color_fn`. Sea locations are neither filled nor counted as boundary
+/// donor colors.
+///
+/// Returns a per-location vec: `Some(donor)` for members of a surrounded
+/// component (donor is a representative boundary `LocationIdx` whose color
+/// should be adopted), `None` otherwise.
+pub(crate) fn compute_surrounded_donors(
+    topology: &TopologyIndex,
+    gpu_indices: &LocationIndexedVec<Option<GpuLocationIdx>>,
+    location_terrain: &LocationIndexedVec<Terrain>,
+    color_id_to_location: &[Option<LocationIdx>],
+    color_fn: impl Fn(LocationIdx) -> GpuColor,
+) -> LocationIndexedVec<Option<LocationIdx>> {
+    // Invariant: gpu_indices / location_terrain are sized to location_count,
+    // which is `gamestate.locations.len()`.
+    let mut donors = gpu_indices.map(|_| None);
+    let mut visited = gpu_indices.map(|_| false);
+
+    // Reused across components to avoid per-component allocations. `queue` always
+    // drains to empty via `pop_front`; `members` is cleared explicitly because a
+    // conflicted component skips the `drain(..)` below.
+    let mut members: Vec<LocationIdx> = Vec::new();
+    let mut queue: VecDeque<LocationIdx> = VecDeque::new();
+
+    for (raw_idx, _start) in gpu_indices.iter().enumerate() {
+        let start = LocationIdx::new(raw_idx as u32);
+
+        if visited[start] || !location_terrain[start].is_surround_fillable() {
+            continue;
+        }
+
+        members.clear();
+        // `uniform_color` and `chosen_donor` are set together: the donor is the
+        // first boundary location whose color defines the component's color.
+        let mut uniform_color: Option<GpuColor> = None;
+        let mut chosen_donor: Option<LocationIdx> = None;
+        let mut conflict = false;
+
+        visited[start] = true;
+        queue.push_back(start);
+
+        while let Some(loc) = queue.pop_front() {
+            members.push(loc);
+
+            let Some(gpu_idx) = gpu_indices[loc] else {
+                continue;
+            };
+
+            for nb in topology.neighbors_of_index(gpu_idx.value()) {
+                let color_id = nb.value() as usize;
+                let Some(nb_loc) = color_id_to_location.get(color_id).and_then(|opt| *opt) else {
+                    // R16 with no corresponding LocationIdx — treat as an
+                    // ambiguous boundary; do not paint.
+                    conflict = true;
+                    continue;
+                };
+
+                let nb_terrain = location_terrain[nb_loc];
+                if nb_terrain.is_surround_fillable() {
+                    // Always keep expanding the flood fill, even after a
+                    // conflict, so every connected member is marked visited and
+                    // never restarted as its own component below.
+                    if !visited[nb_loc] {
+                        visited[nb_loc] = true;
+                        queue.push_back(nb_loc);
+                    }
+                } else if nb_terrain.is_sea() || conflict {
+                    // Sea contributes no color; once conflicted, the boundary
+                    // color no longer matters, so skip the `color_fn` work.
+                    continue;
+                } else {
+                    let c = color_fn(nb_loc);
+                    // Ambiguous boundary colors do not contribute to uniformity.
+                    if c == GpuColor::WATER || c == GpuColor::IMPASSABLE || c == GpuColor::UNOWNED {
+                        continue;
+                    }
+                    match uniform_color {
+                        None => {
+                            uniform_color = Some(c);
+                            chosen_donor = Some(nb_loc);
+                        }
+                        Some(prev) if prev == c => {}
+                        _ => conflict = true,
+                    }
+                }
+            }
+        }
+
+        let Some(donor) = chosen_donor.filter(|_| !conflict) else {
+            continue;
+        };
+
+        for m in members.drain(..) {
+            donors[m] = Some(donor);
+        }
+    }
+
+    donors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pdx_map::{Hemisphere, HemisphereLength, R16, World};
+
+    fn world_from_grid(grid: &[u16], world_width: u32, height: u32) -> World {
+        let hemisphere_width = world_width / 2;
+        let mut west = Vec::new();
+        let mut east = Vec::new();
+        for y in 0..height {
+            for x in 0..hemisphere_width {
+                west.push(R16::new(grid[(y * world_width + x) as usize]));
+            }
+            for x in hemisphere_width..world_width {
+                east.push(R16::new(grid[(y * world_width + x) as usize]));
+            }
+        }
+        World::builder(
+            Hemisphere::new(west, HemisphereLength::new(hemisphere_width)),
+            Hemisphere::new(east, HemisphereLength::new(hemisphere_width)),
+        )
+        .build()
+    }
+
+    // Helper to build the inputs the algorithm needs:
+    //   - `terrains[i]` is the terrain for LocationIdx(i)
+    //   - `colors[i]`   is the GpuColor for non-special LocationIdx(i)
+    // The R16 color-id is taken to equal i for simplicity.
+    fn build(
+        terrains: &[Terrain],
+        colors: &[GpuColor],
+        grid: &[u16],
+        width: u32,
+        height: u32,
+    ) -> LocationIndexedVec<Option<LocationIdx>> {
+        let world = world_from_grid(grid, width, height);
+        let topology = world.build_topology_index();
+        let n = terrains.len();
+
+        let gpu_indices = LocationIndexedVec::from_vec(
+            (0..n)
+                .map(|i| Some(GpuLocationIdx::new(i as u16)))
+                .collect(),
+        );
+        let location_terrain = LocationIndexedVec::from_vec(terrains.to_vec());
+        let color_map: Vec<Option<LocationIdx>> =
+            (0..n).map(|i| Some(LocationIdx::new(i as u32))).collect();
+
+        compute_surrounded_donors(
+            &topology,
+            &gpu_indices,
+            &location_terrain,
+            &color_map,
+            |loc| colors[loc.value() as usize],
+        )
+    }
+
+    const A: GpuColor = GpuColor::from_rgb(10, 0, 0);
+    const B: GpuColor = GpuColor::from_rgb(0, 10, 0);
+
+    #[test]
+    fn lake_enclosed_by_one_country() {
+        // 3x3 grid, center is water (idx 4), all others are A
+        let grid = [
+            0, 1, 2, 0, 1, 2, //
+            3, 4, 5, 3, 4, 5, //
+            6, 7, 8, 6, 7, 8,
+        ];
+        let mut terrains = [Terrain::Other; 9];
+        terrains[4] = Terrain::Lake;
+        let colors = [A; 9];
+
+        let donors = build(&terrains, &colors, &grid, 6, 3);
+        let donor = donors[LocationIdx::new(4)].expect("lake should have donor");
+        assert_eq!(colors[donor.value() as usize], A);
+    }
+
+    #[test]
+    fn multi_cell_component_enclosed_by_one_country() {
+        // idx 4 and idx 5 are adjacent lakes forming a single connected
+        // component; every surrounding location belongs to country A. The BFS
+        // must merge them and assign both the same donor.
+        let grid = [
+            0, 1, 2, 0, 1, 2, //
+            3, 4, 5, 3, 4, 5, //
+            6, 7, 8, 6, 7, 8,
+        ];
+        let mut terrains = [Terrain::Other; 9];
+        terrains[4] = Terrain::Lake;
+        terrains[5] = Terrain::Lake;
+        let colors = [A; 9];
+
+        let donors = build(&terrains, &colors, &grid, 6, 3);
+        let d4 = donors[LocationIdx::new(4)].expect("cell 4 should have donor");
+        let d5 = donors[LocationIdx::new(5)].expect("cell 5 should have donor");
+        assert_eq!(d4, d5, "merged component shares one donor");
+        assert_eq!(colors[d4.value() as usize], A);
+    }
+
+    #[test]
+    fn lake_bordered_by_two_countries_no_override() {
+        let grid = [
+            0, 1, 2, 0, 1, 2, //
+            3, 4, 5, 3, 4, 5, //
+            6, 7, 8, 6, 7, 8,
+        ];
+        let mut terrains = [Terrain::Other; 9];
+        terrains[4] = Terrain::Lake;
+        let mut colors = [A; 9];
+        colors[1] = B;
+
+        let donors = build(&terrains, &colors, &grid, 6, 3);
+        assert!(donors[LocationIdx::new(4)].is_none());
+    }
+
+    #[test]
+    fn lake_adjacent_to_unowned_no_override() {
+        let grid = [
+            0, 1, 2, 0, 1, 2, //
+            3, 4, 5, 3, 4, 5, //
+            6, 7, 8, 6, 7, 8,
+        ];
+        let mut terrains = [Terrain::Other; 9];
+        terrains[4] = Terrain::Lake;
+        let mut colors = [A; 9];
+        colors[1] = GpuColor::UNOWNED;
+
+        let donors = build(&terrains, &colors, &grid, 6, 3);
+        // Boundary with UNOWNED is ignored. Remaining boundaries are all A,
+        // so the lake should still be surrounded.
+        let donor = donors[LocationIdx::new(4)].expect("lake should have donor");
+        assert_eq!(colors[donor.value() as usize], A);
+    }
+
+    #[test]
+    fn impassable_touching_sea_and_one_country_fills() {
+        let grid = [
+            0, 1, 2, 0, 1, 2, //
+            3, 4, 5, 3, 4, 5, //
+            6, 7, 8, 6, 7, 8,
+        ];
+        let mut terrains = [Terrain::Other; 9];
+        terrains[4] = Terrain::Impassable;
+        terrains[5] = Terrain::Sea;
+        let colors = [A; 9];
+
+        let donors = build(&terrains, &colors, &grid, 6, 3);
+        let donor = donors[LocationIdx::new(4)].expect("impassable should have donor");
+        assert_eq!(colors[donor.value() as usize], A);
+        assert!(donors[LocationIdx::new(5)].is_none());
+    }
+
+    #[test]
+    fn component_with_only_sea_boundary_no_override() {
+        let grid = [
+            1, 1, 1, 1, //
+            1, 0, 1, 0, //
+            1, 1, 1, 1,
+        ];
+        let terrains = [Terrain::Lake, Terrain::Sea];
+        let colors = [A, A];
+
+        let donors = build(&terrains, &colors, &grid, 4, 3);
+        assert!(donors[LocationIdx::new(0)].is_none());
+        assert!(donors[LocationIdx::new(1)].is_none());
+    }
+}

--- a/src/eu5app/tests/it/snapshots/it__workspace_scenarios@Clandeboye.eu5.save.snap
+++ b/src/eu5app/tests/it/snapshots/it__workspace_scenarios@Clandeboye.eu5.save.snap
@@ -16,17 +16,17 @@ input_file: src/eu5app/tests/it/saves.d/Clandeboye.eu5.save
     }
   ],
   "map_mode_colors": {
-    "building_levels": "0xf3c03224d8dc0794b478bfcbd6e5720df7d62229d8d602c2b81fd4c29c3a9bb6",
-    "control": "0xfe012cddbf3709f6bdc62afcf3406de09dadfaedad4db8c035b50ad726811181",
-    "development": "0xdd95ba93a37136d7dde68d7e1cafe24a7a8fefd5eb898e2e93749b3f9e401d29",
-    "markets": "0x7eef6b272c18867c72b7880422d2bfef8ac23380b653d387f0762bb2a6957955",
-    "political": "0x3c5e79d1450bbb157fa83171d2c1ad0f23f6794f9097cde8c0dfbc3cd2c73e1d",
-    "population": "0x799e75484664a7f27fc01c4a9f419cb966d61c8dbcdce5e1759fc24b6c8af73c",
-    "religion": "0xe424c860024bd7e944ef54962a0337845a7ee7962f35552a7603e8385117177a",
-    "rgo_level": "0xecef7be6af747cb86a9b0e434da3435323c170e42a827881b791241a64e68551",
-    "state_efficacy": "0xc4f549fd28ac2645823e85681716cbcab97e0814f05d4934d7e770859f73dfd3",
-    "unrealized_tax_base": "0xdf3e5255e2c0a6fb69accc5dba9e44a6ad4016a34e3032468f23204d0e7fd2e0",
-    "wealth": "0x6900729141c0595d2f5bff1dfe665bdad4c7d53adc8e3248f77741f16f07ba58"
+    "building_levels": "0x8d1e82d0c5c5c9858cb40c332f92807b94eb4094498aa4ca4a8704337ba1d09a",
+    "control": "0xa2b6ca8f083af04490a181ae52726d4a1ad3cb8d430b64ab6ca432ad22d5cfbe",
+    "development": "0x402baf97468b747cda23367d86ff4eed6de64fd333f5df4727fd35f981d8403b",
+    "markets": "0xf78269c0cee1a142dd102aecdc3a020e9cdefd97f4c4cb2792739acfa79b7161",
+    "political": "0xb22a8e8f923086c3f5db27ee5690add3317f189b8a01fcac42cc695ba2e6ee47",
+    "population": "0xe03a436e1967d77b4f91086c53eb034c62bdf4957f31a111b656c2205fd4bf85",
+    "religion": "0x9936969cfc7047864dbee0054be90abfd632ce4459215ed51d17b2e74de96e16",
+    "rgo_level": "0x812bd2131c459d7e0e1e65a1452d638fbaa644d27cce8bf5da29d01fd4e45664",
+    "state_efficacy": "0x1de0cf542b2d20de6e5c27d78d31ff15e4233afb57dc3c6e5469f1d906e74b20",
+    "unrealized_tax_base": "0x06a78fc9032ee2221bb137c11a81226cab1dcf3a33039a587e160c6f69a31d71",
+    "wealth": "0xbc76c41458128e099686f31c3772622f327b8aa782127de6ce1bbb6c82d4ad1f"
   },
   "save_version": "1.0.4",
   "selection_counts": {

--- a/src/eu5app/tests/it/snapshots/it__workspace_scenarios@debug-1.0.eu5.save.snap
+++ b/src/eu5app/tests/it/snapshots/it__workspace_scenarios@debug-1.0.eu5.save.snap
@@ -16,17 +16,17 @@ input_file: src/eu5app/tests/it/saves.d/debug-1.0.eu5.save
     }
   ],
   "map_mode_colors": {
-    "building_levels": "0x4c85a6fc211e826dc99dcde117dae98a30afa8077f105a06b2144daff953ffab",
-    "control": "0x30c0fe477b303a9f5be4c14317d9bd4b97375fc4214144eb755da82a30ad4c4d",
-    "development": "0xe607c912a03177e4448d95ea553e51cb4c1c566fcee400f0655f4c3d2d00418f",
-    "markets": "0x250d38d1849dceef72516ba840f26487c09f5cbe8e8c357cf6e9abf2972da5ef",
-    "political": "0x581133f6e235f7f728f0cf3eab84db641a410726acd71a3d35f5a2fba5185c8a",
-    "population": "0x0f1d06df69f6379c616dc273a78e42cffb86ff962f34c1dee8d0363d7302bb4a",
-    "religion": "0xcdd369549b541164e4df30eec2f86bd52e51e6e4a8f8d70e02ad1de525ff9769",
-    "rgo_level": "0xe6ad949687bed97bdf923df24c6eb6104f1abc4a3337dd41220c97b367166f80",
-    "state_efficacy": "0x3cb5ab4cb962b133063acd9adfdd5515f6009af4412e19699a921168bca85f7a",
-    "unrealized_tax_base": "0x2ce7b415d88356e3b6116654a153e1f1a1d6938ce90e7a7ee5a305c39a0bdf7d",
-    "wealth": "0xd442603f9b52f9ee32a5c3310a365289ebe36039fe7cde6e2185503bb0615f89"
+    "building_levels": "0x94da3b4cf114afef7c7684f216b7c7c1bdf85c9cc9fda23ecb72d673d0f958d1",
+    "control": "0x25c37576a1e69d59a2ee08600a06f641a2121626e9c1f405e881da32e3d0202b",
+    "development": "0xd63de34428f7a7c457561da7b532b0d6d17013b55956ac1db3a1d1bf4ef18978",
+    "markets": "0x5663082779318f428c5587748fafb98b9648bc0c1597df7723c03b8c5b75e5ec",
+    "political": "0xa28846f8d1e89dbceb2c1971201a199770df052d8f209ab783250b33689f2bfd",
+    "population": "0x5a60c582e246aa3affd250b95bfb162f4f060316e83aae2164ed8133287c21f8",
+    "religion": "0x2501570fda6aaf52e9ff64858f0b690c7151eee463e9f2501692ec3465030723",
+    "rgo_level": "0x4e0c94c1c0729ee4263de2e7d1645db9776d447423683a563e58996a6d165fd0",
+    "state_efficacy": "0xb0abd0b551b041f2332fccee13cccdadbcf2d1f6559dd2b86566e353c133d65c",
+    "unrealized_tax_base": "0x2737b7f47f256d8be439db4efa221399cf092f93c69b661aa3ea784ded570a53",
+    "wealth": "0xc7e847c748424ef492b74074b78f302d359daed3e2e1e0c4377be7669e6d55b3"
   },
   "save_version": "1.0.0",
   "selection_counts": {

--- a/src/eu5save/src/models/locations.rs
+++ b/src/eu5save/src/models/locations.rs
@@ -263,6 +263,16 @@ pub struct LocationIndexedVec<T> {
 }
 
 impl<T> LocationIndexedVec<T> {
+    pub fn from_vec(data: Vec<T>) -> Self {
+        Self { data }
+    }
+
+    pub fn map<U, F: FnMut(&T) -> U>(&self, mut f: F) -> LocationIndexedVec<U> {
+        LocationIndexedVec {
+            data: self.data.iter().map(&mut f).collect(),
+        }
+    }
+
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.data.iter()
     }

--- a/src/pdx-assets/src/eu5/compiler.rs
+++ b/src/pdx-assets/src/eu5/compiler.rs
@@ -124,6 +124,8 @@ where
 
     let textures = texture_builder.build()?;
 
+    let topology = textures.textures().world().build_topology_index();
+
     // Create location data with color awareness
     let locations = textures.location_aware(raw_game_data.locations);
 
@@ -146,6 +148,7 @@ where
                 goods: raw_game_data.goods,
             },
         )?;
+        write_entry(&mut archive, "topology.bin", &topology)?;
         archive.finish()?
     };
 

--- a/src/pdx-map/Cargo.toml
+++ b/src/pdx-map/Cargo.toml
@@ -13,8 +13,12 @@ date-layer = ["render"]
 [dependencies]
 bytemuck = { workspace = true, features = ["derive"] }
 futures-channel = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true, optional = true }
 wgpu = { workspace = true, optional = true }
+
+[dev-dependencies]
+postcard = { workspace = true, features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { workspace = true, default-features = false }

--- a/src/pdx-map/src/pixel.rs
+++ b/src/pdx-map/src/pixel.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use bytemuck::{Pod, Zeroable};
+use serde::{Deserialize, Serialize};
 
 /// 24-bit RGB color
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
@@ -34,7 +35,9 @@ impl From<[u8; 3]> for Rgb {
 }
 
 /// 16-bit red channel used as location index in Paradox map textures
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable, Serialize, Deserialize,
+)]
 #[repr(transparent)]
 pub struct R16(u16);
 

--- a/src/pdx-map/src/world/topology.rs
+++ b/src/pdx-map/src/world/topology.rs
@@ -1,7 +1,8 @@
 use super::World;
 use crate::R16;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TopologyIndex {
     neighbors: Vec<R16>,
     meta: Vec<NodeEntry>,
@@ -99,7 +100,7 @@ impl TopologyIndex {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct NodeEntry {
     offset: u32,
     len: u16,
@@ -195,6 +196,16 @@ mod tests {
         assert_eq!(to_values(topology.neighbors_of_index(0)), vec![1, 2]);
         assert_eq!(to_values(topology.neighbors_of_index(1)), vec![0, 2]);
         assert_eq!(to_values(topology.neighbors_of_index(2)), vec![0, 1]);
+    }
+
+    #[test]
+    fn topology_index_round_trips_through_postcard() {
+        let grid = vec![2u16, 0u16, 0u16, 1u16];
+        let world = world_from_grid(&grid, 4, 1);
+        let topology = TopologyIndex::from_world(&world);
+        let bytes = postcard::to_allocvec(&topology).unwrap();
+        let decoded: TopologyIndex = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(topology, decoded);
     }
 
     #[test]


### PR DESCRIPTION
The topology index ships as precomputed data in the game bundle. It increases the bundle size by about 400KB, but this saves about 400ms of loading. Since the bundle can be cached, this seems like the right call to make. 

<img width="2158" height="1079" alt="image" src="https://github.com/user-attachments/assets/f7b11d96-098c-43b7-b76c-6b691a97d6e1" />
