### PR TITLE
Fix Knights of the Caribbean achievement

### DIFF
--- a/src/eu4game/src/achievements.rs
+++ b/src/eu4game/src/achievements.rs
@@ -2198,7 +2198,7 @@ impl<'a> AchievementHunter<'a> {
             .iter()
             .all(|id| self.owns_core_province_id(ProvinceId::from(*id)))
                 && self.all_provs_in_region("carribeans_region", |prov, _| {
-                    prov.owner == Some(self.starting_country)
+                    prov.owner == Some(self.tag)
                 })
         } else {
             false


### PR DESCRIPTION
The achievement only requires starting as the knights. One can form Jerusalem and still get the achievement.