### PR TITLE
Handle version skew by prompting reload

### DIFF
--- a/src/app/app/entry.client.tsx
+++ b/src/app/app/entry.client.tsx
@@ -2,8 +2,10 @@ import { HydratedRouter } from "react-router/dom";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { sentryInit } from "./lib/sentry";
+import { registerPreloadErrorHandler } from "./lib/preloadError";
 
 sentryInit();
+registerPreloadErrorHandler();
 
 startTransition(() => {
   hydrateRoot(

--- a/src/app/app/features/engine/engineStore.ts
+++ b/src/app/app/features/engine/engineStore.ts
@@ -62,3 +62,4 @@ const useEngineStore = create<EngineState>()((set, get) => ({
 export const useSaveFileInput = () => useEngineStore((x) => x.input);
 export const useSaveInputId = () => useEngineStore((x) => x.inputId);
 export const useEngineActions = () => useEngineStore((x) => x.actions);
+export const isSaveLoaded = () => useEngineStore.getState().input !== null;

--- a/src/app/app/lib/captureException.ts
+++ b/src/app/app/lib/captureException.ts
@@ -1,4 +1,5 @@
 import type { captureException as SentryCaptureException } from "@sentry/react-router";
+import { isStaleVersion } from "@/lib/staleVersion";
 
 type CaptureException = typeof SentryCaptureException;
 type CaptureExceptionImpl = (
@@ -16,6 +17,10 @@ export const captureException = (
     console.error(exception, exception.stack);
   } else {
     console.error(exception);
+  }
+
+  if (isStaleVersion()) {
+    return undefined;
   }
 
   return captureImplementation?.(exception, captureContext);

--- a/src/app/app/lib/events.ts
+++ b/src/app/app/lib/events.ts
@@ -46,6 +46,10 @@ export type Event =
       kind: "Whats new clicked";
       source: "button" | "banner";
       latestRelease?: string;
+    }
+  | {
+      kind: "Preload error";
+      saveLoaded: boolean;
     };
 
 let isRecording = false;

--- a/src/app/app/lib/preloadError.ts
+++ b/src/app/app/lib/preloadError.ts
@@ -1,0 +1,44 @@
+import { isSaveLoaded } from "@/features/engine/engineStore";
+import { emitEvent } from "@/lib/events";
+import { markStaleVersion } from "@/lib/staleVersion";
+import { toast } from "@/lib/toast";
+
+const TOAST_ID = "preload-error-new-version";
+
+// See vite load error handling: https://vite.dev/guide/build#load-error-handling
+export function registerPreloadErrorHandler() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  let prompted = false;
+
+  window.addEventListener("vite:preloadError", (event) => {
+    event.preventDefault();
+    markStaleVersion();
+
+    const saveLoaded = isSaveLoaded();
+    emitEvent({ kind: "Preload error", saveLoaded });
+
+    if (!saveLoaded) {
+      // Nothing in memory to lose; reload to pick up the new asset manifest.
+      window.location.reload();
+      return;
+    }
+
+    // A save is being analyzed. Reloading would discard that work, so prompt
+    // instead of forcing it. Deduped so repeated chunk failures don't stack.
+    if (prompted) {
+      return;
+    }
+    prompted = true;
+
+    toast.info("A new version of PDX Tools is available", {
+      description: "Reload to load the latest. Your current analysis will be lost.",
+      duration: Infinity,
+      closeButton: true,
+      id: TOAST_ID,
+      action: { label: "Reload", onClick: () => window.location.reload() },
+    });
+  });
+}

--- a/src/app/app/lib/staleVersion.ts
+++ b/src/app/app/lib/staleVersion.ts
@@ -1,0 +1,14 @@
+// Set once a `vite:preloadError` is seen: a deploy has replaced the asset
+// manifest, so chunks referenced by the currently-loaded page may 404. Read by
+// `captureException` to suppress the resulting (secondary) errors that every
+// React error boundary would otherwise report to Sentry once the app is known
+// to be running against a stale deploy. See `lib/preloadError.ts`.
+let stale = false;
+
+export function markStaleVersion() {
+  stale = true;
+}
+
+export function isStaleVersion() {
+  return stale;
+}

--- a/src/app/app/lib/toast.tsx
+++ b/src/app/app/lib/toast.tsx
@@ -1,27 +1,40 @@
 import { toast as sonnerToast } from "sonner";
 import { cx } from "class-variance-authority";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import { Button } from "@/components/Button";
+
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
 
 interface ToastProps {
   id: string | number;
-  type: "success" | "error";
+  type: "success" | "error" | "info";
   title: string;
   description?: string;
   closeButton?: boolean;
+  action?: ToastAction;
 }
 
-function Toast({ id, type, title, description, closeButton }: ToastProps) {
+function Toast({ id, type, title, description, closeButton, action }: ToastProps) {
   return (
     <div
       className={cx(
         "flex w-full items-start gap-3 rounded-lg border-2 border-solid p-4 shadow-lg",
         type === "success" && "border-green-200 bg-green-100",
         type === "error" && "border-rose-200 bg-rose-100",
+        type === "info" && "border-sky-200 bg-sky-100",
       )}
     >
       <div className="flex-1">
         <p className="text-sm font-medium text-gray-900">{title}</p>
         {description && <p className="mt-1 text-sm text-gray-700">{description}</p>}
+        {action && (
+          <Button variant="primary" className="mt-3 text-sm" onClick={() => action.onClick()}>
+            {action.label}
+          </Button>
+        )}
       </div>
       {closeButton && (
         <button
@@ -55,6 +68,30 @@ export const toast = {
         />
       ),
       { duration: opts?.duration ?? 4000 },
+    );
+  },
+  info(
+    title: string,
+    opts?: {
+      description?: string;
+      duration?: number;
+      closeButton?: boolean;
+      action?: ToastAction;
+      id?: string | number;
+    },
+  ) {
+    return sonnerToast.custom(
+      (id) => (
+        <Toast
+          id={id}
+          type="info"
+          title={title}
+          description={opts?.description}
+          closeButton={opts?.closeButton}
+          action={opts?.action}
+        />
+      ),
+      { duration: opts?.duration ?? 4000, id: opts?.id },
     );
   },
 };


### PR DESCRIPTION
Each deploy publishes new hashed asset filenames and swaps the Cloudflare Workers Assets manifest, so chunks referenced by an already-open page start returning 404. Users then hit "Failed to fetch dynamically imported module" when a lazy import (game UIs, viz charts) loads.