### PR TITLE
Add preconnect to media domain

### DIFF
--- a/src/app/app/lib/media.ts
+++ b/src/app/app/lib/media.ts
@@ -1,6 +1,13 @@
+import type { LinksFunction } from "react-router";
+
 export const mediaOrigin = import.meta.env.VITE_MEDIA_ORIGIN;
 
 // Production reads bypass the Worker through the R2 custom domain. Dev and test
 // builds omit VITE_MEDIA_ORIGIN and use the local MEDIA_BUCKET Worker route.
 export const ogImageUrl = (saveId: string, game = "eu4") =>
   mediaOrigin ? `${mediaOrigin}/${game}/og/${saveId}.webp` : `/${game}/saves/${saveId}/og`;
+
+// Warm the connection to the media origin for routes that render OG images.
+export const mediaPreconnectLinks: ReturnType<LinksFunction> = mediaOrigin
+  ? [{ rel: "preconnect", href: mediaOrigin }]
+  : [];

--- a/src/app/app/routes/eu4._index.tsx
+++ b/src/app/app/routes/eu4._index.tsx
@@ -2,6 +2,7 @@ import { WebPage } from "@/components/layout/WebPage";
 import { LoadingState } from "@/components/LoadingState";
 import { Eu4GamePage } from "@/features/eu4/Eu4GamePage";
 import { seo } from "@/lib/seo";
+import { mediaPreconnectLinks } from "@/lib/media";
 import { usingDb } from "@/server-lib/db/connection";
 import { getSaves } from "@/server-lib/fn/new";
 import { withCore } from "@/server-lib/middleware";
@@ -16,6 +17,8 @@ export const meta = () =>
     title: "EU4 - PDX Tools",
     description: "Latest uploaded EU4 saves",
   });
+
+export const links = () => mediaPreconnectLinks;
 
 export const loader = withCore(async ({ context }: Route.LoaderArgs) => {
   const { db, close } = usingDb(context);

--- a/src/app/app/routes/eu4.saves.$saveId.tsx
+++ b/src/app/app/routes/eu4.saves.$saveId.tsx
@@ -1,6 +1,6 @@
 import Eu4Ui from "@/features/eu4/Eu4Ui";
 import { seo } from "@/lib/seo";
-import { ogImageUrl } from "@/lib/media";
+import { ogImageUrl, mediaPreconnectLinks } from "@/lib/media";
 import { useParams } from "react-router";
 import { useMemo } from "react";
 import type { Route } from "./+types/eu4.saves.$saveId";
@@ -11,6 +11,8 @@ export const meta = ({ params: { saveId } }: Route.MetaArgs) =>
     description: `View EU4 maps, charts, timelapses, and data`,
     image: ogImageUrl(saveId),
   });
+
+export const links = () => mediaPreconnectLinks;
 
 export default function SaveRoute() {
   const { saveId } = useParams();

--- a/src/app/app/routes/users.$userId.tsx
+++ b/src/app/app/routes/users.$userId.tsx
@@ -6,6 +6,7 @@ import { UserSaveTable } from "@/features/account/UserSaveTable";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { hasPermission, userId } from "@/lib/auth";
 import { seo } from "@/lib/seo";
+import { mediaPreconnectLinks } from "@/lib/media";
 import { getUser } from "@/server-lib/db";
 import { usingDb } from "@/server-lib/db/connection";
 import { withCore } from "@/server-lib/middleware";
@@ -20,6 +21,8 @@ export const meta = ({ params: { userId } }: Route.MetaArgs) =>
     title: "User saves - PDX Tools",
     description: `EU4 Saves uploaded by user ${userId}`,
   });
+
+export const links = () => mediaPreconnectLinks;
 
 export const loader = withCore(async ({ params, context }: Route.LoaderArgs) => {
   const { userId: uid } = params;


### PR DESCRIPTION
Saw that some initial images were delayed by a 250ms connection, so the hope is that we can preconnect while streaming in the data.