### PR TITLE
Reference Cloudflare default cache directly

### DIFF
--- a/src/app/app/routes/api.saves.$saveId.file.ts
+++ b/src/app/app/routes/api.saves.$saveId.file.ts
@@ -27,12 +27,7 @@ export async function loader({ request, params, context }: Route.LoaderArgs) {
     const url = new URL(request.url);
     const cacheKey = new Request(url.toString(), request);
 
-    let cache: Cache;
-    if ("default" in context.cloudflare.caches) {
-      cache = context.cloudflare.caches.default as Cache;
-    } else {
-      cache = await context.cloudflare.caches.open("pdx-cache");
-    }
+    const cache = context.cloudflare.caches.default;
 
     let response = await cache.match(cacheKey);
     if (response) {

--- a/src/app/env.d.ts
+++ b/src/app/env.d.ts
@@ -3,4 +3,10 @@ import type * as CloudflareWorkersModule from "cloudflare:workers";
 declare global {
   type CloudflareWorkerEnv = CloudflareWorkersModule["env"];
   interface Env extends CloudflareWorkerEnv {}
+
+  // The DOM lib's `CacheStorage` omits Cloudflare's per-zone `default` cache,
+  // which the Workers runtime always exposes. Augment it back in.
+  interface CacheStorage {
+    readonly default: Cache;
+  }
 }


### PR DESCRIPTION
The branch only existed to work around the DOM lib's `CacheStorage` type omitting `default`.