### PR TITLE
Gate authenticated pages behind login screen instead of error

### DIFF
--- a/src/app/app/components/layout/auth/SteamButton.tsx
+++ b/src/app/app/components/layout/auth/SteamButton.tsx
@@ -2,8 +2,17 @@ import { Link } from "@/components/Link";
 import steam_login_image from "./sign-in-through-steam.png";
 
 const externalAddress = import.meta.env.VITE_EXTERNAL_ADDRESS;
-let steamUrl: URL | undefined;
-if (externalAddress) {
+
+function callbackUrl(returnTo?: string) {
+  const base = `${externalAddress}/api/login/steam-callback`;
+  return returnTo ? `${base}?returnTo=${encodeURIComponent(returnTo)}` : base;
+}
+
+function steamLoginUrl(returnTo?: string) {
+  if (!externalAddress) {
+    return undefined;
+  }
+
   const params = {
     "openid.ns": "http://specs.openid.net/auth/2.0",
     "openid.sreg": "http://openid.net/extensions/sreg/1.1",
@@ -11,11 +20,12 @@ if (externalAddress) {
     "openid.claimed_id": "http://specs.openid.net/auth/2.0/identifier_select",
     "openid.mode": "checkid_setup",
     "openid.realm": externalAddress,
-    "openid.return_to": `${externalAddress}/api/login/steam-callback`,
+    "openid.return_to": callbackUrl(returnTo),
   };
 
-  steamUrl = new URL("https://steamcommunity.com/openid/login");
+  const steamUrl = new URL("https://steamcommunity.com/openid/login");
   steamUrl.search = new URLSearchParams(params).toString();
+  return steamUrl;
 }
 
 function SteamImage() {
@@ -30,9 +40,10 @@ function SteamImage() {
   );
 }
 
-function SteamForm() {
+function SteamForm({ returnTo }: { returnTo?: string }) {
   return (
     <form method="GET" action="/api/login/steam-callback">
+      {returnTo ? <input type="hidden" name="returnTo" value={returnTo} /> : null}
       <button type="submit">
         <SteamImage />
       </button>
@@ -40,7 +51,8 @@ function SteamForm() {
   );
 }
 
-export const SteamButton = () => {
+export const SteamButton = ({ returnTo }: { returnTo?: string }) => {
+  const steamUrl = steamLoginUrl(returnTo);
   if (steamUrl) {
     return (
       <Link
@@ -52,6 +64,6 @@ export const SteamButton = () => {
       </Link>
     );
   } else {
-    return <SteamForm />;
+    return <SteamForm returnTo={returnTo} />;
   }
 };

--- a/src/app/app/features/account/LoginRequired.tsx
+++ b/src/app/app/features/account/LoginRequired.tsx
@@ -1,0 +1,27 @@
+import { useLocation } from "react-router";
+import { SteamButton } from "@/components/layout/auth/SteamButton";
+
+type LoginRequiredProps = {
+  title?: string;
+  message?: string;
+};
+
+export function LoginRequired({
+  title = "Sign in required",
+  message = "Sign in through Steam to view and manage your account.",
+}: LoginRequiredProps) {
+  const location = useLocation();
+  const returnTo = `${location.pathname}${location.search}`;
+  return (
+    <div className="mx-auto max-w-5xl space-y-5 p-5">
+      <h1 className="text-4xl">{title}</h1>
+      <p>{message}</p>
+      <p className="text-gray-600 dark:text-gray-400">
+        New to PDX Tools? Signing in with Steam creates your account automatically.
+      </p>
+      <div className="flex">
+        <SteamButton returnTo={returnTo} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/features/account/index.tsx
+++ b/src/app/app/features/account/index.tsx
@@ -1,2 +1,3 @@
 export * from "./Account";
+export * from "./LoginRequired";
 export * from "./SessionProvider";

--- a/src/app/app/routes/account.tsx
+++ b/src/app/app/routes/account.tsx
@@ -1,6 +1,6 @@
 import { WebPage } from "@/components/layout/WebPage";
 import { LoggedIn } from "@/components/LoggedIn";
-import { Account } from "@/features/account";
+import { Account, LoginRequired } from "@/features/account";
 import { useLoaderData } from "react-router";
 import { pdxSession } from "@/server-lib/auth/session";
 import { seo } from "@/lib/seo";
@@ -14,9 +14,6 @@ export const meta = () =>
 
 export const loader = async ({ request, context }: Route.LoaderArgs) => {
   const session = await pdxSession({ request, context }).get();
-  if (session.kind !== "user") {
-    throw new Error("Not logged in");
-  }
   return { session };
 };
 
@@ -24,9 +21,13 @@ export default function AccountRoute() {
   const { session } = useLoaderData<typeof loader>();
   return (
     <WebPage>
-      <LoggedIn session={session}>
-        <Account />
-      </LoggedIn>
+      {session.kind === "user" ? (
+        <LoggedIn session={session}>
+          <Account />
+        </LoggedIn>
+      ) : (
+        <LoginRequired title="Manage Your Account" />
+      )}
     </WebPage>
   );
 }

--- a/src/app/app/routes/api.login.steam-callback.ts
+++ b/src/app/app/routes/api.login.steam-callback.ts
@@ -7,6 +7,7 @@ import { withCore } from "@/server-lib/middleware";
 import type { AppLoadContext } from "react-router";
 import { withDb } from "@/server-lib/db/middleware";
 import { pdxSession } from "@/server-lib/auth/session";
+import { safeRedirect } from "@/server-lib/auth/redirect";
 import { pdxSteam } from "@/server-lib/steam.server";
 import { userId } from "@/lib/auth";
 import type { Route } from "./+types/api.login.steam-callback";
@@ -43,7 +44,7 @@ export const loader = withCore(
       event: user.inserted ? "User created" : "User updated",
     });
 
-    const dest = new URL("/", request.url);
+    const dest = new URL(safeRedirect(searchParams.get("returnTo")), request.url);
 
     const sessionStorage = pdxSession({ context, request });
     const session = await sessionStorage.new();

--- a/src/app/app/server-lib/auth/redirect.ts
+++ b/src/app/app/server-lib/auth/redirect.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns `to` only when it is a safe, same-origin relative path; otherwise the
+ * `fallback`. Guards against open redirects by rejecting absolute URLs and
+ * protocol-relative (`//host`) or backslash (`/\host`) tricks.
+ */
+export function safeRedirect(to: string | null | undefined, fallback = "/"): string {
+  if (!to || !to.startsWith("/") || to.startsWith("//") || to.startsWith("/\\")) {
+    return fallback;
+  }
+  return to;
+}

--- a/src/app/tests/redirect.test.ts
+++ b/src/app/tests/redirect.test.ts
@@ -1,0 +1,28 @@
+import { safeRedirect } from "@/server-lib/auth/redirect";
+import { describe, expect, it } from "vitest";
+
+describe("safeRedirect", () => {
+  it("keeps same-origin relative paths", () => {
+    expect(safeRedirect("/account")).toBe("/account");
+    expect(safeRedirect("/users/123?tab=saves")).toBe("/users/123?tab=saves");
+  });
+
+  it("falls back when missing", () => {
+    expect(safeRedirect(null)).toBe("/");
+    expect(safeRedirect(undefined)).toBe("/");
+    expect(safeRedirect("")).toBe("/");
+  });
+
+  it("rejects open redirects", () => {
+    expect(safeRedirect("//evil.com")).toBe("/");
+    expect(safeRedirect("/\\evil.com")).toBe("/");
+    expect(safeRedirect("https://evil.com")).toBe("/");
+    expect(safeRedirect("mailto:foo@bar.com")).toBe("/");
+    expect(safeRedirect("account")).toBe("/");
+  });
+
+  it("honors a custom fallback", () => {
+    expect(safeRedirect(null, "/home")).toBe("/home");
+    expect(safeRedirect("//evil.com", "/home")).toBe("/home");
+  });
+});


### PR DESCRIPTION
Currently there is a nasty UI where the user just sees "server error" instead of being able to log in.

This is when they land on /account from the API pages.