### PR TITLE
Revert json logs to plaintext for services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,16 +3870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3889,15 +3879,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "signal", "sync"] }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(target_env = "musl")'.dependencies]
 mimalloc = { workspace = true }

--- a/src/api/src/main.rs
+++ b/src/api/src/main.rs
@@ -43,18 +43,14 @@ async fn health() -> StatusCode {
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let builder = tracing_subscriber::fmt()
+
+    tracing_subscriber::fmt()
         .with_target(false)
         .with_span_events(FmtSpan::CLOSE)
-        .with_env_filter(filter);
-
-    // Pretty, colored output in an interactive terminal; structured JSON
-    // otherwise.
-    if std::io::stdout().is_terminal() {
-        builder.compact().init();
-    } else {
-        builder.json().init();
-    }
+        .with_env_filter(filter)
+        .with_ansi(std::io::stdout().is_terminal())
+        .compact()
+        .init();
 
     let port = match std::env::var("PORT") {
         Ok(x) => x.parse::<u16>().unwrap(),


### PR DESCRIPTION
Nothing beats plaintext for logs. The JSON logs were collapsed and difficult to read in the log viewer.