### PR TITLE
Avoid infra environment variables impacting releases

### DIFF
--- a/.config/mise.infra.toml
+++ b/.config/mise.infra.toml
@@ -3,15 +3,13 @@
 [tools]
 "github:opentofu/opentofu" = "1.12.1"
 
-[env]
-_.file = [
-    { path = "dev/infra/state.local.env", redact = true },
-    { path = "dev/infra/cloudflare/cf.local.env", redact = true },
-]
-
 [tasks."infra:cf:init"]
 description = "Initialize the Cloudflare OpenTofu backend and provider"
 dir = "dev/infra/cloudflare"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+    { path = "dev/infra/cloudflare/cf.local.env", redact = true },
+]
 env.CLOUDFLARE_API_TOKEN = { required = "Set CLOUDFLARE_API_TOKEN in dev/infra/cloudflare/cf.local.env" }
 env.AWS_ACCESS_KEY_ID = { required = "Set AWS_ACCESS_KEY_ID in dev/infra/state.local.env" }
 env.AWS_SECRET_ACCESS_KEY = { required = "Set AWS_SECRET_ACCESS_KEY in dev/infra/state.local.env" }
@@ -30,6 +28,10 @@ run = "tofu fmt -check -diff"
 [tasks."infra:cf:validate"]
 description = "Validate Cloudflare OpenTofu configuration"
 dir = "dev/infra/cloudflare"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+    { path = "dev/infra/cloudflare/cf.local.env", redact = true },
+]
 env.CLOUDFLARE_API_TOKEN = { required = "Set CLOUDFLARE_API_TOKEN in dev/infra/cloudflare/cf.local.env" }
 env.AWS_ACCESS_KEY_ID = { required = "Set AWS_ACCESS_KEY_ID in dev/infra/state.local.env" }
 env.AWS_SECRET_ACCESS_KEY = { required = "Set AWS_SECRET_ACCESS_KEY in dev/infra/state.local.env" }
@@ -39,11 +41,19 @@ run = "tofu validate"
 description = "Plan Cloudflare OpenTofu changes"
 depends = ["infra:cf:validate"]
 dir = "dev/infra/cloudflare"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+    { path = "dev/infra/cloudflare/cf.local.env", redact = true },
+]
 run = "tofu plan -input=false"
 
 [tasks."infra:cf:backup"]
 description = "Snapshot Cloudflare OpenTofu state to dev/infra/backups"
 dir = "dev/infra/cloudflare"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+    { path = "dev/infra/cloudflare/cf.local.env", redact = true },
+]
 env.CLOUDFLARE_API_TOKEN = { required = "Set CLOUDFLARE_API_TOKEN in dev/infra/cloudflare/cf.local.env" }
 env.AWS_ACCESS_KEY_ID = { required = "Set AWS_ACCESS_KEY_ID in dev/infra/state.local.env" }
 env.AWS_SECRET_ACCESS_KEY = { required = "Set AWS_SECRET_ACCESS_KEY in dev/infra/state.local.env" }
@@ -57,6 +67,10 @@ tofu state pull > "../backups/$(date -u +%Y%m%dT%H%M%SZ).tfstate"
 description = "Apply Cloudflare OpenTofu changes after taking a state backup"
 depends = ["infra:cf:backup"]
 dir = "dev/infra/cloudflare"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+    { path = "dev/infra/cloudflare/cf.local.env", redact = true },
+]
 run = "tofu apply -auto-approve"
 
 [tasks."infra:cf:change"]
@@ -67,6 +81,9 @@ depends = ["infra:cf:fmt:check", "infra:cf:plan"]
 description = "Show the media.pdx.tools R2 custom domain"
 depends = ["pnpm-install"]
 dir = "dev/infra/cloudflare"
+env._.file = [
+    { path = "dev/infra/cloudflare/cf.local.env", redact = true },
+]
 env.CLOUDFLARE_API_TOKEN = { required = "Set CLOUDFLARE_API_TOKEN in dev/infra/cloudflare/cf.local.env" }
 run = "wrangler r2 bucket domain get pdx-media --domain media.pdx.tools"
 
@@ -74,6 +91,9 @@ run = "wrangler r2 bucket domain get pdx-media --domain media.pdx.tools"
 description = "Attach media.pdx.tools to the pdx-media R2 bucket"
 depends = ["pnpm-install"]
 dir = "dev/infra/cloudflare"
+env._.file = [
+    { path = "dev/infra/cloudflare/cf.local.env", redact = true },
+]
 env.CLOUDFLARE_API_TOKEN = { required = "Set CLOUDFLARE_API_TOKEN in dev/infra/cloudflare/cf.local.env" }
 env.ZONE_ID = { required = "Set ZONE_ID in dev/infra/cloudflare/cf.local.env" }
 run = 'wrangler r2 bucket domain add pdx-media --domain media.pdx.tools --zone-id "$ZONE_ID" --min-tls 1.2'
@@ -81,6 +101,9 @@ run = 'wrangler r2 bucket domain add pdx-media --domain media.pdx.tools --zone-i
 [tasks."infra:gcp:init"]
 description = "Initialize the GCP OpenTofu backend and provider"
 dir = "dev/infra/gcp"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+]
 env.AWS_ACCESS_KEY_ID = { required = "Set AWS_ACCESS_KEY_ID in dev/infra/state.local.env" }
 env.AWS_SECRET_ACCESS_KEY = { required = "Set AWS_SECRET_ACCESS_KEY in dev/infra/state.local.env" }
 run = "tofu init"
@@ -98,6 +121,9 @@ run = "tofu fmt -check -diff"
 [tasks."infra:gcp:validate"]
 description = "Validate GCP OpenTofu configuration"
 dir = "dev/infra/gcp"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+]
 env.AWS_ACCESS_KEY_ID = { required = "Set AWS_ACCESS_KEY_ID in dev/infra/state.local.env" }
 env.AWS_SECRET_ACCESS_KEY = { required = "Set AWS_SECRET_ACCESS_KEY in dev/infra/state.local.env" }
 run = "tofu validate"
@@ -106,11 +132,17 @@ run = "tofu validate"
 description = "Plan GCP OpenTofu changes"
 depends = ["infra:gcp:validate"]
 dir = "dev/infra/gcp"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+]
 run = "tofu plan -input=false"
 
 [tasks."infra:gcp:backup"]
 description = "Snapshot GCP OpenTofu state to dev/infra/backups"
 dir = "dev/infra/gcp"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+]
 env.AWS_ACCESS_KEY_ID = { required = "Set AWS_ACCESS_KEY_ID in dev/infra/state.local.env" }
 env.AWS_SECRET_ACCESS_KEY = { required = "Set AWS_SECRET_ACCESS_KEY in dev/infra/state.local.env" }
 run = '''
@@ -123,6 +155,9 @@ tofu state pull > "../backups/gcp-$(date -u +%Y%m%dT%H%M%SZ).tfstate"
 description = "Apply GCP OpenTofu changes after taking a state backup"
 depends = ["infra:gcp:backup"]
 dir = "dev/infra/gcp"
+env._.file = [
+    { path = "dev/infra/state.local.env", redact = true },
+]
 run = "tofu apply -auto-approve"
 
 [tasks."infra:gcp:change"]


### PR DESCRIPTION
CLOUDFLARE_API_TOKEN was getting in the way, so we lazily source the infra environment for specific tasks