### PR TITLE
Add EU5 coat of arms flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bcdec_rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09c37bc0e9f0924b7dae9988265ef3c76c88538f41a3b06caf4bed07cee5226"
+
+[[package]]
 name = "bench"
 version = "0.1.0"
 dependencies = [
@@ -447,6 +453,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -830,6 +842,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "ddsfile"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479dfe1e6737aa9e96c6ac7b69689dc4c32da8383f2c12744739d76afa8b66c4"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "enum-primitive-derive",
+ "num-traits",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +960,17 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c375b9c5eadb68d0a6efee2999fef292f45854c3444c86f09d8ab086ba942b0e"
+dependencies = [
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "equivalent"
@@ -1425,6 +1460,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -1713,6 +1749,20 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png",
+]
+
+[[package]]
+name = "image_dds"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3388630ed66c07107145ac5b13c804261f18d5daf0dd2699481888aba16cd38"
+dependencies = [
+ "bcdec_rs",
+ "bytemuck",
+ "ddsfile",
+ "half",
+ "image",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2820,6 +2870,7 @@ dependencies = [
  "eu5save",
  "flate2",
  "image",
+ "image_dds",
  "jomini",
  "mimalloc",
  "pdx-map",
@@ -2827,6 +2878,7 @@ dependencies = [
  "postcard",
  "rawbmp",
  "rawzip",
+ "rayon",
  "regex",
  "schemas",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ gungraun = "0.17.2"
 highway = "1.3"
 hoi4save = { git = "https://github.com/rakaly/hoi4save.git" }
 image = { version = "0.25.10", default-features = false }
+image_dds = { version = "0.7", default-features = false, features = ["ddsfile", "image"] }
 imperator-save = { git = "https://github.com/rakaly/imperator-save.git" }
 insta = { version = "1.47", features = ["json"] }
 jomini = { version = "0.35", features = ["envelope"] }

--- a/dev/scripts/fetch-steam-game-bundles.mts
+++ b/dev/scripts/fetch-steam-game-bundles.mts
@@ -37,7 +37,7 @@ const targets: BundleTarget[] = [
   { game: "eu5", branch: "1.0.11", version: "1.0" },
   { game: "eu5", branch: "1.1.10", version: "1.1" },
   { game: "eu5", branch: "1.2.5", version: "1.2" },
-  { game: "eu5", version: "1.3.11" },
+  { game: "eu5", branch: "1.3.11", version: "1.3" },
 ];
 
 type Options = {

--- a/dev/scripts/setup-assets.mts
+++ b/dev/scripts/setup-assets.mts
@@ -2,7 +2,7 @@
 
 import { exec } from "child_process";
 import { promisify } from "util";
-import { readdir, access, mkdir, writeFile, copyFile, readFile, stat } from "fs/promises";
+import { readdir, access, mkdir, writeFile, copyFile, readFile, rm, stat } from "fs/promises";
 import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -100,14 +100,14 @@ const getMontageFontArg = () => {
   return font ? ` -font ${shellQuote(font)}` : "";
 };
 
-const findLatestBundle = async () => {
-  const eu4AssetsDir = join(projectRoot, "assets/game/eu4");
+const findLatestBundle = async (game: string) => {
+  const gameAssetsDir = join(projectRoot, "assets/game", game);
 
-  if (!(await exists(eu4AssetsDir))) {
+  if (!(await exists(gameAssetsDir))) {
     return null;
   }
 
-  const contents = await readdir(eu4AssetsDir);
+  const contents = await readdir(gameAssetsDir);
   const versions = contents
     .filter((item) => item !== "common" && /^\d+\.\d+$/.test(item))
     .sort((a, b) => {
@@ -118,7 +118,7 @@ const findLatestBundle = async () => {
 
   // Find the latest version that has common/images directory
   for (const version of versions) {
-    const commonImagesDir = join(eu4AssetsDir, version, "common", "images");
+    const commonImagesDir = join(gameAssetsDir, version, "common", "images");
     if (await exists(commonImagesDir)) {
       return { version, path: commonImagesDir };
     }
@@ -128,37 +128,33 @@ const findLatestBundle = async () => {
 };
 
 const copyDirectoryRecursive = async (src: string, dest: string) => {
-  try {
-    await mkdir(dest, { recursive: true });
-    const entries = await readdir(src, { withFileTypes: true });
+  await mkdir(dest, { recursive: true });
+  const entries = await readdir(src, { withFileTypes: true });
 
-    for (const entry of entries) {
-      const srcPath = join(src, entry.name);
-      const destPath = join(dest, entry.name);
+  for (const entry of entries) {
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
 
-      if (entry.isDirectory()) {
-        await copyDirectoryRecursive(srcPath, destPath);
-      } else {
-        await copyFile(srcPath, destPath);
-      }
+    if (entry.isDirectory()) {
+      await copyDirectoryRecursive(srcPath, destPath);
+    } else {
+      await copyFile(srcPath, destPath);
     }
-  } catch (error) {
-    console.warn(`Failed to copy directory ${src} to ${dest}: ${(error as Error).message}`);
   }
 };
 
-const updateCommonImages = async () => {
-  console.log("🖼️  Updating common images from latest bundle...");
+const updateCommonImages = async (game: string) => {
+  console.log(`🖼️  Updating ${game} common images from latest bundle...`);
 
-  const latestBundle = await findLatestBundle();
+  const latestBundle = await findLatestBundle(game);
   if (!latestBundle) {
-    console.log("  ⚠️  No compiled game bundle with images found, skipping image update");
+    console.log(`  ⚠️  No compiled ${game} bundle with images found, skipping image update`);
     return;
   }
 
   console.log(`  📦 Found latest bundle: ${latestBundle.version}`);
 
-  const commonImagesDir = join(projectRoot, "assets/game/eu4/common/images");
+  const commonImagesDir = join(projectRoot, "assets/game", game, "common/images");
 
   // Copy subdirectories from latest bundle
   const bundleImagesDir = latestBundle.path;
@@ -168,6 +164,13 @@ const updateCommonImages = async () => {
     if (entry.isDirectory()) {
       const srcPath = join(bundleImagesDir, entry.name);
       const destPath = join(commonImagesDir, entry.name);
+      // EU5 flag shards are authoritative. Replace that directory so a newer
+      // bundle with fewer shards cannot leave stale indexes behind. Other
+      // common image directories contain checked-in fallbacks that an asset
+      // bundle may not include, so they must remain additive.
+      if (game === "eu5" && entry.name === "flags") {
+        await rm(destPath, { recursive: true, force: true });
+      }
       await copyDirectoryRecursive(srcPath, destPath);
       console.log(`  📁 Copied directory: ${entry.name}`);
     }
@@ -179,7 +182,7 @@ const updateCommonImages = async () => {
 // Main script
 async function setupAssets() {
   // Update common images from latest bundle first
-  await updateCommonImages();
+  await updateCommonImages("eu4");
 
   const gitignoreContent = await readFile(join(projectRoot, ".gitignore"), "utf-8");
   const eu4ImagePaths = gitignoreContent
@@ -461,6 +464,20 @@ async function setupAssetEu5() {
   await touchFile(join(versionDir, "game.zip"));
   await touchFile(join(versionDir, "map.zip"));
   await touchFile(join(versionDir, "loc-en.zip"));
+
+  // Sync compiled images (e.g. the flag atlas) from the latest versioned bundle
+  // into the unversioned `common/images` dir the frontend imports from.
+  await updateCommonImages("eu5");
+
+  // The EU5 flags component discovers the alphabetically sharded atlases in
+  // this directory. Lay down one empty shard so asset-free development builds
+  // exercise the same import path as compiled assets.
+  const flagsDir = join(projectRoot, "assets", "game", "eu5", "common", "images", "flags");
+  await mkdir(flagsDir, { recursive: true });
+  for (const webp of ["flags-00_x72.webp", "flags-00_x144.webp"]) {
+    await touchFile(join(flagsDir, webp));
+  }
+  await createFileIfEmpty(join(flagsDir, "flags-00.json"), "{}");
 }
 
 await setupAssets();

--- a/src/app/app/features/eu5/Eu5InsightPanel.tsx
+++ b/src/app/app/features/eu5/Eu5InsightPanel.tsx
@@ -2,6 +2,8 @@ import type React from "react";
 import { useCallback } from "react";
 import { ResizablePanel } from "./components/ResizablePanel";
 import type { ActiveProfileIdentity, EntityHeader } from "@/wasm/wasm_eu5";
+import { formatCompact, formatInt } from "@/lib/format";
+import { Eu5Flag } from "./components/flags/Eu5Flag";
 import { useEu5MapMode, useEu5SelectionState, useSetEu5InsightPanelWidth } from "./store";
 import { StateEfficacyInsight } from "./features/insights/StateEfficacy";
 import { ControlInsight } from "./features/insights/Control";
@@ -206,20 +208,61 @@ function EntityPanelTitle({
 }
 
 function EntityTitleContent({ header }: { header: EntityHeader }) {
-  return (
-    <span className="inline-flex max-w-full min-w-0 items-center gap-2">
-      <span
-        className="h-3.5 w-3.5 shrink-0 rounded-[1px] border border-black/25"
-        style={{ backgroundColor: header.colorHex }}
-      />
-      {header.tag && (
-        <span className="shrink-0 rounded-[1px] border border-game-line-strong px-1 font-game-num text-[10px] tracking-[0.06em] text-game-ink-700">
-          {header.tag}
+  // Countries get a rich header: the coat of arms at its native atlas size
+  // (72px) alongside the tag, name, and headline stats. Non-country entities
+  // (markets) have no flag, so they stay a compact color-swatch + name label.
+  if (!header.tag) {
+    return (
+      <span className="inline-flex max-w-full min-w-0 items-center gap-2">
+        <span
+          className="h-3.5 w-3.5 shrink-0 rounded-[1px] border border-black/25"
+          style={{ backgroundColor: header.colorHex }}
+        />
+        <span className="truncate font-game-ui text-sm font-semibold text-game-ink-300">
+          {header.name}
         </span>
-      )}
-      <span className="truncate font-game-ui text-sm font-semibold text-game-ink-300">
-        {header.name}
       </span>
+    );
+  }
+
+  return (
+    <span className="flex min-w-0 items-center gap-3">
+      <Eu5Flag
+        flag={header.flag}
+        colorHex={header.colorHex}
+        size="xl"
+        alt={`${header.name} flag`}
+        className="shrink-0 rounded-[2px] border border-black/30 shadow-sm"
+      />
+      <span className="flex min-w-0 flex-col gap-1">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="shrink-0 rounded-[1px] border border-game-line-strong px-1 font-game-num text-[10px] tracking-[0.06em] text-game-ink-700">
+            {header.tag}
+          </span>
+          <span className="truncate font-game-ui text-base font-semibold text-game-ink-100">
+            {header.name}
+          </span>
+        </span>
+        <span className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
+          <HeadlineStat label="Locations" value={formatInt(header.headline.locationCount)} />
+          <HeadlineStat label="Development" value={formatInt(header.headline.totalDevelopment)} />
+          <HeadlineStat
+            label="Population"
+            value={formatCompact(header.headline.totalPopulation, 1)}
+          />
+        </span>
+      </span>
+    </span>
+  );
+}
+
+function HeadlineStat({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="flex items-baseline gap-1">
+      <span className="font-game-num text-[13px] font-medium text-game-ink-100 tabular-nums">
+        {value}
+      </span>
+      <span className="text-[10px] tracking-[0.06em] text-game-ink-500 uppercase">{label}</span>
     </span>
   );
 }

--- a/src/app/app/features/eu5/components/flags/Eu5Flag.tsx
+++ b/src/app/app/features/eu5/components/flags/Eu5Flag.tsx
@@ -1,0 +1,83 @@
+import { cx } from "class-variance-authority";
+import { Sprite } from "@/components/Sprite";
+import { FLAG_CELL_HEIGHT, flagSprite } from "./index";
+
+/**
+ * Rendered flag heights (width follows the 1.5:1 aspect ratio).
+ *
+ * `xl` renders at the atlas' native cell size (72×48), so it displays 1:1 from
+ * the base atlas and pulls the 144×96 tile on a 2x retina display.
+ */
+const SIZE_HEIGHT = {
+  xs: 12,
+  sm: 16,
+  base: 24,
+  lg: 32,
+  xl: 48,
+} as const;
+
+export type Eu5FlagSize = keyof typeof SIZE_HEIGHT;
+
+/**
+ * Renders an EU5 country flag (coat of arms) from the pre-rendered atlas.
+ *
+ * `flag` is the country's coat of arms key (`CountryRef.flag`). Unknown or
+ * missing keys fall back to a solid swatch of the country's color when
+ * available, otherwise a neutral placeholder box.
+ */
+export function Eu5Flag({
+  flag,
+  colorHex,
+  size = "base",
+  alt = "",
+  className,
+}: {
+  flag: string | null | undefined;
+  colorHex?: string;
+  size?: Eu5FlagSize;
+  alt?: string;
+  className?: string;
+}) {
+  const height = SIZE_HEIGHT[size];
+  const width = Math.round(height * 1.5);
+  const sprite = flagSprite(flag);
+
+  // The flag image is sized to the exact 1.5:1 box, while any caller-supplied
+  // chrome (border/ring/rounding) lives on a shrink-to-fit wrapper so it sits
+  // *outside* the flag. With the global `box-sizing: border-box`, a border on
+  // the sized element would otherwise eat into the artwork and skew both the
+  // aspect ratio and the sprite's centering.
+  const inner =
+    sprite === undefined ? (
+      <span
+        aria-hidden
+        style={{
+          display: "block",
+          width,
+          height,
+          backgroundColor: colorHex ?? "var(--color-gray-400, #9ca3af)",
+        }}
+      />
+    ) : (
+      <Sprite
+        src={sprite.src}
+        srcSet={[
+          [sprite.src, "1x"],
+          [sprite.srcHi, "2x"],
+        ]}
+        alt={alt}
+        index={sprite.index}
+        dimensions={sprite.dimensions}
+        scale={height / FLAG_CELL_HEIGHT}
+      />
+    );
+
+  return (
+    <span
+      className={cx("inline-block overflow-hidden leading-none", className)}
+      style={{ backgroundColor: colorHex }}
+    >
+      {inner}
+    </span>
+  );
+}

--- a/src/app/app/features/eu5/components/flags/index.ts
+++ b/src/app/app/features/eu5/components/flags/index.ts
@@ -1,0 +1,78 @@
+import { spriteDimension } from "@/components/Sprite";
+
+/** EU5 flags are rendered at a 1.5:1 aspect ratio. */
+export const FLAG_CELL_WIDTH = 72;
+export const FLAG_CELL_HEIGHT = 48;
+
+const indexes = import.meta.glob<Record<string, number>>(
+  "../../../../../../../assets/game/eu5/common/images/flags/flags-*.json",
+  { eager: true, import: "default" },
+);
+const atlas72 = import.meta.glob<string>(
+  "../../../../../../../assets/game/eu5/common/images/flags/flags-*_x72.webp",
+  { eager: true, query: "?url", import: "default" },
+);
+const atlas144 = import.meta.glob<string>(
+  "../../../../../../../assets/game/eu5/common/images/flags/flags-*_x144.webp",
+  { eager: true, query: "?url", import: "default" },
+);
+
+export type FlagSprite = {
+  index: number;
+  dimensions: ReturnType<typeof spriteDimension>;
+  src: string;
+  srcHi: string;
+};
+
+const groupFromPath = (path: string) => path.match(/flags-([a-z0-9]+)(?:_x\d+)?\./)?.[1];
+
+const byGroup = <T>(files: Record<string, T>): Record<string, T> =>
+  Object.fromEntries(
+    Object.entries(files).map(([path, value]) => {
+      const group = groupFromPath(path);
+      if (group === undefined) throw new Error(`Invalid EU5 flag atlas path: ${path}`);
+      return [group, value];
+    }),
+  );
+
+const indexByGroup = byGroup(indexes);
+const atlas72ByGroup = byGroup(atlas72);
+const atlas144ByGroup = byGroup(atlas144);
+
+const dimensionsByGroup = Object.fromEntries(
+  Object.entries(indexByGroup).map(([group, data]) => [
+    group,
+    spriteDimension({
+      data,
+      spriteCell: { width: FLAG_CELL_WIDTH, height: FLAG_CELL_HEIGHT },
+    }),
+  ]),
+);
+
+const locationByKey = new Map<string, { group: string; index: number }>();
+for (const [group, data] of Object.entries(indexByGroup)) {
+  for (const [key, index] of Object.entries(data)) {
+    locationByKey.set(key, { group, index });
+  }
+}
+
+/**
+ * Look up a resolved coat of arms key's atlas tile index, if present.
+ *
+ * The key is already fully resolved by the wasm business logic
+ * (`CountryRef.flag`), so this is a direct atlas lookup — no government/tag
+ * heuristics. Unknown keys return `undefined` (the caller draws a swatch).
+ */
+export function flagSprite(key: string | null | undefined): FlagSprite | undefined {
+  if (!key) return undefined;
+  const location = locationByKey.get(key);
+  if (location === undefined) return undefined;
+  const { group, index } = location;
+  const dimensions = dimensionsByGroup[group];
+  const src = atlas72ByGroup[group];
+  const srcHi = atlas144ByGroup[group];
+  if (index === undefined || dimensions === undefined || src === undefined || srcHi === undefined) {
+    return undefined;
+  }
+  return { index, dimensions, src, srcHi };
+}

--- a/src/app/app/features/eu5/features/profiles/EntityLink.tsx
+++ b/src/app/app/features/eu5/features/profiles/EntityLink.tsx
@@ -6,6 +6,8 @@ import { usePanToEntity } from "../../usePanToEntity";
 import { useEu5Engine } from "../../store";
 import { useEu5MapHoverTarget } from "../../useEu5MapHoverTarget";
 import type { Eu5MapHoverTarget } from "../../useEu5MapHoverTarget";
+import { Eu5Flag } from "../../components/flags/Eu5Flag";
+import type { Eu5FlagSize } from "../../components/flags/Eu5Flag";
 
 const sizeClasses = {
   xs: {
@@ -63,6 +65,7 @@ type LinkBodyProps = SharedProps & {
   hoverTarget: Eu5MapHoverTarget;
   colorHex: string;
   isPlayer: boolean;
+  visual?: React.ReactNode;
   tag?: React.ReactNode;
   name: string;
   onActivate: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -72,6 +75,7 @@ function LinkBody({
   hoverTarget,
   colorHex,
   isPlayer,
+  visual,
   tag,
   name,
   onActivate,
@@ -89,7 +93,7 @@ function LinkBody({
         {...hoverProps}
         className={cx("inline-flex max-w-full min-w-0 items-center", s.wrapper, className)}
       >
-        <EntitySwatch colorHex={colorHex} isPlayer={isPlayer} className={s.swatch} />
+        {visual ?? <EntitySwatch colorHex={colorHex} isPlayer={isPlayer} className={s.swatch} />}
         {tag}
         {children ?? (
           <span
@@ -116,7 +120,7 @@ function LinkBody({
         className,
       )}
     >
-      <EntitySwatch colorHex={colorHex} isPlayer={isPlayer} className={s.swatch} />
+      {visual ?? <EntitySwatch colorHex={colorHex} isPlayer={isPlayer} className={s.swatch} />}
       {tag}
       {children ?? (
         <span
@@ -132,6 +136,12 @@ function LinkBody({
     </button>
   );
 }
+
+const flagSizeByLinkSize: Record<Size, Eu5FlagSize> = {
+  xs: "xs",
+  sm: "sm",
+  md: "base",
+};
 
 export function CountryLink({ country, ...props }: SharedProps & { country: CountryRef }) {
   const nav = usePanelNav();
@@ -170,6 +180,17 @@ export function CountryLink({ country, ...props }: SharedProps & { country: Coun
       hoverTarget={{ kind: "country", countryIdx: country.country.key }}
       colorHex={country.colorHex}
       isPlayer={country.isPlayer}
+      visual={
+        <Eu5Flag
+          flag={country.flag}
+          colorHex={country.colorHex}
+          size={flagSizeByLinkSize[props.size ?? "sm"]}
+          className={cx(
+            "shrink-0 rounded-[1px] border border-black/30",
+            country.isPlayer && "ring-2 ring-game-ink-100 ring-offset-1 ring-offset-game-page",
+          )}
+        />
+      }
       tag={tag}
       name={country.country.name}
       onActivate={onActivate}

--- a/src/app/tsconfig.json
+++ b/src/app/tsconfig.json
@@ -4,6 +4,7 @@
     "rootDirs": [".", "./.react-router/types"],
     "paths": {
       "@/images/eu4/*": ["../../assets/game/eu4/common/images/*"],
+      "@/images/eu5/*": ["../../assets/game/eu5/common/images/*"],
       "@/*": ["./app/*"]
     },
     "types": [

--- a/src/eu5app/src/entity_profile.rs
+++ b/src/eu5app/src/entity_profile.rs
@@ -137,6 +137,8 @@ pub struct EntityHeader {
     pub kind: EntityKind,
     pub name: String,
     pub tag: Option<String>,
+    /// Coat of arms key for the country's flag (`None` for non-country entities).
+    pub flag: Option<String>,
     pub color_hex: Srgb,
     pub anchor_location_idx: u32,
     pub headline: HeadlineStats,
@@ -260,6 +262,8 @@ pub struct CountryRef {
     pub country: Localized<UiCountryIdx>,
     pub anchor_location_idx: UiLocationIdx,
     pub tag: String,
+    /// Resolved coat of arms key for the country's pre-rendered flag.
+    pub flag: Option<String>,
     pub color_hex: Srgb,
     pub is_player: bool,
 }
@@ -344,6 +348,7 @@ impl Present for EntityHeaderSource {
                     kind: EntityKind::Country,
                     name: cref.country.name,
                     tag: Some(cref.tag),
+                    flag: cref.flag,
                     color_hex: cref.color_hex,
                     anchor_location_idx: cref.anchor_location_idx.value(),
                     headline: self.headline,
@@ -355,6 +360,7 @@ impl Present for EntityHeaderSource {
                     kind: EntityKind::Market,
                     name: mref.market.name,
                     tag: None,
+                    flag: None,
                     color_hex: mref.color_hex,
                     anchor_location_idx: mref.anchor_location_idx.value(),
                     headline: self.headline,

--- a/src/eu5app/src/presentation.rs
+++ b/src/eu5app/src/presentation.rs
@@ -354,6 +354,10 @@ impl Present for CountryRefSource {
             tag: data
                 .map(|_| entry.tag().to_str().to_string())
                 .unwrap_or_else(|| "---".to_string()),
+            flag: data.map(|data| match data.flag.as_ref() {
+                Some(flag) => flag.to_str().to_string(),
+                None => entry.tag().to_str().to_string(),
+            }),
             color_hex,
             is_player,
         }

--- a/src/eu5save/src/models/countries.rs
+++ b/src/eu5save/src/models/countries.rs
@@ -269,6 +269,10 @@ pub struct Country<'bump> {
     pub country_name: CountryName<'bump>,
     #[arena(default)]
     pub color: Color,
+    /// The coat of arms key this country flies (e.g. `flag=MER`). Used to look
+    /// up the pre-rendered flag in the web UI.
+    #[arena(default)]
+    pub flag: Option<BStr<'bump>>,
     pub capital: Option<LocationId>,
     #[arena(default)]
     pub historical_population: &'bump [f64],

--- a/src/pdx-assets/Cargo.toml
+++ b/src/pdx-assets/Cargo.toml
@@ -18,12 +18,14 @@ eu5app = { workspace = true, default-features = false, features = ["game-install
 eu5save = { workspace = true, default-features = false }
 flate2 = { workspace = true, default-features = false, features = ["zlib-rs"]}
 image = { workspace = true, features = ["png", "pnm"] }
+image_dds = { workspace = true }
 jomini = { workspace = true }
 pdx-map = { workspace = true, default-features = false }
 pdx-zstd = { workspace = true, default-features = false, features = ["zstd_c"] }
 postcard = { workspace = true }
 rawbmp = { workspace = true }
 rawzip = { workspace = true }
+rayon = { workspace = true }
 regex = { workspace = true }
 schemas = { workspace = true, features = ["inline"] }
 serde = { workspace = true }

--- a/src/pdx-assets/src/coat_of_arms.rs
+++ b/src/pdx-assets/src/coat_of_arms.rs
@@ -1,0 +1,26 @@
+//! Game-agnostic coat of arms (heraldry) compositor.
+//!
+//! Paradox's Clausewitz engine composes flags procedurally from a `pattern`
+//! background, recolorable `colored_emblem`s / full-color `textured_emblem`s,
+//! and named color slots. The same system is shared across CK3, Imperator,
+//! Victoria 3, and EU5. This module ports the parse + composite pipeline from
+//! pdx_unlimiter so an asset build can pre-render flags into a sprite atlas.
+//!
+//! Pipeline:
+//! 1. [`parse_named_colors`] loads the `name -> sRGB` palette.
+//! 2. [`CoaDefinitions`] parses the definition files (resolving `@` macros,
+//!    inline colors, color references and `parent` templates).
+//! 3. [`render`] composites a resolved [`CoatOfArms`] into an RGBA raster.
+//!
+//! Callers supply a [`TextureSource`] (decoded emblem/pattern images) and a
+//! [`GameCoaConfig`] (canvas size, texture directories, missing color).
+
+pub mod color;
+mod model;
+mod preprocess;
+mod render;
+
+pub use color::{FColor, NamedColors, hsv_to_rgb};
+pub use model::{CoaDefinitions, CoatOfArms, Node, parse_entries, parse_named_colors};
+pub use preprocess::preprocess;
+pub use render::{GameCoaConfig, TextureSource, render};

--- a/src/pdx-assets/src/coat_of_arms/color.rs
+++ b/src/pdx-assets/src/coat_of_arms/color.rs
@@ -1,0 +1,203 @@
+//! Color model for coat of arms compositing.
+//!
+//! Colors are resolved to sRGB and composited using the same straight-alpha
+//! "over" math as the game (ported from pdx_unlimiter's `CoatOfArmsRenderer`).
+
+use std::collections::HashMap;
+
+/// A floating point sRGB color with straight (non-premultiplied) alpha, all
+/// channels in `[0, 1]`. Mirrors JavaFX `Color` semantics used by pdx_unlimiter.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FColor {
+    pub r: f64,
+    pub g: f64,
+    pub b: f64,
+    pub a: f64,
+}
+
+impl FColor {
+    pub fn opaque(rgb: [u8; 3]) -> Self {
+        FColor {
+            r: rgb[0] as f64 / 255.0,
+            g: rgb[1] as f64 / 255.0,
+            b: rgb[2] as f64 / 255.0,
+            a: 1.0,
+        }
+    }
+
+    pub fn rgba(r: f64, g: f64, b: f64, a: f64) -> Self {
+        FColor { r, g, b, a }
+    }
+
+    /// Returns this color with a replaced alpha (game `withAlpha`).
+    pub fn with_alpha(self, a: f64) -> Self {
+        FColor { a, ..self }
+    }
+
+    /// Alpha-composites `top` over `self` (`self` is the bottom layer), matching
+    /// pdx_unlimiter's `overlayColors`.
+    pub fn over(self, top: FColor) -> FColor {
+        let alpha = top.a + self.a * (1.0 - top.a);
+        if alpha == 0.0 {
+            return FColor::rgba(0.0, 0.0, 0.0, 0.0);
+        }
+        let blend = |t: f64, b: f64| (t * top.a + b * self.a * (1.0 - top.a)) / alpha;
+        FColor {
+            r: blend(top.r, self.r),
+            g: blend(top.g, self.g),
+            b: blend(top.b, self.b),
+            a: alpha,
+        }
+    }
+
+    /// Truncating conversion to 8-bit sRGB, matching the game's `intFromColor`
+    /// (`(int)(channel * 0xFF)`).
+    pub fn to_rgb8(self) -> [u8; 3] {
+        let c = |v: f64| (v.clamp(0.0, 1.0) * 255.0) as u8;
+        [c(self.r), c(self.g), c(self.b)]
+    }
+
+    /// Like [`Self::to_rgb8`] but carries the alpha channel through as well.
+    pub fn to_rgba8(self) -> [u8; 4] {
+        let rgb = self.to_rgb8();
+        [
+            rgb[0],
+            rgb[1],
+            rgb[2],
+            (self.a.clamp(0.0, 1.0) * 255.0).round() as u8,
+        ]
+    }
+}
+
+/// Convert an HSV color to sRGB. `h` in `[0, 360)`, `s`/`v` in `[0, 1]`.
+/// Matches the standard formula used across the codebase (`eu5app::color`).
+pub fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [u8; 3] {
+    let s = s.clamp(0.0, 1.0);
+    let v = v.clamp(0.0, 1.0);
+    let c = v * s;
+    let h = h.rem_euclid(360.0);
+    let x = c * (1.0 - ((h / 60.0) % 2.0 - 1.0).abs());
+    let m = v - c;
+    let (r, g, b) = if h < 60.0 {
+        (c, x, 0.0)
+    } else if h < 120.0 {
+        (x, c, 0.0)
+    } else if h < 180.0 {
+        (0.0, c, x)
+    } else if h < 240.0 {
+        (0.0, x, c)
+    } else if h < 300.0 {
+        (x, 0.0, c)
+    } else {
+        (c, 0.0, x)
+    };
+    [
+        ((r + m) * 255.0).round() as u8,
+        ((g + m) * 255.0).round() as u8,
+        ((b + m) * 255.0).round() as u8,
+    ]
+}
+
+/// Parse an inline Paradox color tag body, e.g. `rgb { 1 0 1 }` or
+/// `hsv360 { 42 85 72 }`, returning sRGB. `tag` is the keyword and `body` the
+/// whitespace-separated values inside the braces.
+pub fn parse_tagged_color(tag: &str, body: &str) -> Option<[u8; 3]> {
+    let nums: Vec<f32> = body
+        .split_whitespace()
+        .filter_map(|s| s.parse::<f32>().ok())
+        .collect();
+    let (a, b, c) = (
+        nums.first().copied().unwrap_or(0.0),
+        nums.get(1).copied().unwrap_or(0.0),
+        nums.get(2).copied().unwrap_or(0.0),
+    );
+    match tag {
+        "rgb" => {
+            // Values <= 1 across the board are treated as unit floats.
+            let unit = nums.iter().all(|&v| v <= 1.0);
+            let d = if unit { 255.0 } else { 1.0 };
+            Some([
+                (a * d).clamp(0.0, 255.0).round() as u8,
+                (b * d).clamp(0.0, 255.0).round() as u8,
+                (c * d).clamp(0.0, 255.0).round() as u8,
+            ])
+        }
+        "hsv" => Some(hsv_to_rgb(a * 360.0, b, c)),
+        "hsv360" => Some(hsv_to_rgb(a, b / 100.0, c / 100.0)),
+        "hex" => hex_to_rgb(body.trim()),
+        _ => None,
+    }
+}
+
+/// Decode a `#rrggbb` (or bare `rrggbb`) hex string to sRGB.
+fn hex_to_rgb(value: &str) -> Option<[u8; 3]> {
+    let hex = value.trim_start_matches('#');
+    let n = u32::from_str_radix(hex, 16).ok()?;
+    Some([
+        ((n >> 16) & 0xFF) as u8,
+        ((n >> 8) & 0xFF) as u8,
+        (n & 0xFF) as u8,
+    ])
+}
+
+/// Map of named colors (e.g. `red`) to sRGB, loaded from a game's
+/// `named_colors` file.
+pub type NamedColors = HashMap<String, [u8; 3]>;
+
+/// The five color slots (`color1`..`color5`) that a sub/emblem can reference.
+pub const COLOR_SLOTS: [&str; 5] = ["color1", "color2", "color3", "color4", "color5"];
+
+/// Resolve a color slot string to sRGB.
+///
+/// The value is either a `#rrggbb` literal (inline colors are pre-resolved to
+/// hex during preprocessing) or a named color. Color *references* (`color1`..)
+/// are resolved earlier during model parsing and never reach here. Returns
+/// `None` for unknown names so the caller can substitute the missing color.
+pub fn resolve_named(value: &str, named: &NamedColors) -> Option<[u8; 3]> {
+    if value.starts_with('#') {
+        return hex_to_rgb(value);
+    }
+    named.get(value).copied()
+}
+
+/// Resolve a color slot value (a named color or `#rrggbb` literal) to an opaque
+/// [`FColor`], substituting `missing` for unknown names.
+pub fn resolve_color(value: &str, named: &NamedColors, missing: FColor) -> FColor {
+    resolve_named(value, named)
+        .map(FColor::opaque)
+        .unwrap_or(missing)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_supported_color_tags() {
+        assert_eq!(parse_tagged_color("rgb", "1 0.5 0"), Some([255, 128, 0]));
+        assert_eq!(parse_tagged_color("rgb", "12 34 56"), Some([12, 34, 56]));
+        assert_eq!(parse_tagged_color("hex", "#0c2238"), Some([12, 34, 56]));
+        assert_eq!(
+            parse_tagged_color("hsv360", "120 100 50"),
+            Some([0, 128, 0])
+        );
+    }
+
+    #[test]
+    fn resolves_hex_and_named_colors() {
+        let mut named = NamedColors::default();
+        named.insert("cloth_red".to_string(), [180, 20, 30]);
+
+        assert_eq!(resolve_named("#abcdef", &named), Some([171, 205, 239]));
+        assert_eq!(resolve_named("cloth_red", &named), Some([180, 20, 30]));
+        assert_eq!(resolve_named("missing", &named), None);
+    }
+
+    #[test]
+    fn alpha_composition_matches_straight_over() {
+        let bottom = FColor::rgba(0.0, 0.0, 1.0, 1.0);
+        let top = FColor::rgba(1.0, 0.0, 0.0, 0.5);
+
+        assert_eq!(bottom.over(top).to_rgba8(), [127, 0, 127, 255]);
+    }
+}

--- a/src/pdx-assets/src/coat_of_arms/model.rs
+++ b/src/pdx-assets/src/coat_of_arms/model.rs
@@ -1,0 +1,604 @@
+//! Parse preprocessed coat of arms script into an owned model.
+//!
+//! Ported from pdx_unlimiter's `CoatOfArms`/`Emblem` model. Input text must have
+//! already been run through [`super::preprocess::preprocess`], so every value is
+//! a plain scalar, number array, or object (no `@` macros or tagged colors).
+
+use std::collections::HashMap;
+
+use super::color::{COLOR_SLOTS, FColor, NamedColors, resolve_color, resolve_named};
+use super::preprocess::preprocess;
+use anyhow::{Context, Result, bail};
+
+/// The color environment used to resolve `colorN` slots at model-build time, so
+/// the rendered model carries [`FColor`]s rather than unresolved name strings.
+#[derive(Debug, Clone, Copy)]
+pub struct ColorEnv<'a> {
+    pub named: &'a NamedColors,
+    /// Substituted for unknown/unspecified colors (e.g. magenta for EU5).
+    pub missing: FColor,
+}
+
+/// Parse a game's `named_colors` coat of arms file into a name -> sRGB map.
+///
+/// Accepts raw (un-preprocessed) file text; inline `hsv360`/`rgb`/`hex` colors
+/// are resolved during preprocessing to `#rrggbb` scalars.
+pub fn parse_named_colors(raw: &str) -> Result<NamedColors> {
+    let text = preprocess(raw)?;
+    let mut colors = NamedColors::default();
+    for (key, node) in parse_entries(&text)? {
+        if key != "colors" {
+            continue;
+        }
+        if let Node::Object(fields) = node {
+            for (name, value) in fields {
+                if let Some(rgb) = value.as_str().and_then(|s| resolve_named(s, &colors)) {
+                    colors.insert(name, rgb);
+                }
+            }
+        }
+    }
+    Ok(colors)
+}
+
+/// A generic owned node parsed from jomini text.
+#[derive(Debug, Clone)]
+pub enum Node {
+    Scalar(String),
+    Array(Vec<Node>),
+    Object(Vec<(String, Node)>),
+}
+
+impl Node {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Node::Scalar(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    fn as_f64(&self) -> Option<f64> {
+        self.as_str()?.parse().ok()
+    }
+
+    /// The values of the first array/object matching a numeric list.
+    fn num_list(&self) -> Vec<f64> {
+        match self {
+            Node::Array(items) => items.iter().filter_map(Node::as_f64).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Node> {
+        match self {
+            Node::Object(fields) => fields.iter().find(|(k, _)| k == key).map(|(_, v)| v),
+            _ => None,
+        }
+    }
+
+    pub fn get_all(&self, key: &str) -> Vec<&Node> {
+        match self {
+            Node::Object(fields) => fields
+                .iter()
+                .filter(|(k, _)| k == key)
+                .map(|(_, v)| v)
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Parse a preprocessed file into ordered top-level `(key, node)` entries.
+pub fn parse_entries(text: &str) -> Result<Vec<(String, Node)>> {
+    let tape = jomini::TextTape::from_slice(text.as_bytes())
+        .context("could not parse preprocessed coat of arms script")?;
+    let reader = tape.utf8_reader();
+    let mut entries = Vec::new();
+    for (key, _, value) in reader.fields() {
+        entries.push((key.read_string(), build_node(&value)));
+    }
+    Ok(entries)
+}
+
+fn build_node<'data, 'tokens, E>(value: &jomini::text::ValueReader<'data, 'tokens, E>) -> Node
+where
+    E: jomini::Encoding + Clone,
+{
+    if let Ok(scalar) = value.read_str() {
+        return Node::Scalar(scalar.into_owned());
+    }
+    if let Ok(obj) = value.read_object()
+        && obj.fields_len() > 0
+    {
+        let mut fields = Vec::new();
+        for (key, _, val) in obj.fields() {
+            fields.push((key.read_string(), build_node(&val)));
+        }
+        return Node::Object(fields);
+    }
+    if let Ok(arr) = value.read_array() {
+        let mut items = Vec::new();
+        for val in arr.values() {
+            items.push(build_node(&val));
+        }
+        return Node::Array(items);
+    }
+    Node::Object(Vec::new())
+}
+
+/// A fully resolved coat of arms: a list of layered subs.
+#[derive(Debug, Clone)]
+pub struct CoatOfArms {
+    pub subs: Vec<Sub>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Sub {
+    pub x: f64,
+    pub y: f64,
+    pub scale_x: f64,
+    pub scale_y: f64,
+    pub pattern: Option<String>,
+    /// `color1`..`color5`, resolved to sRGB (`None` for unspecified slots).
+    pub colors: [Option<FColor>; 5],
+    pub emblems: Vec<Emblem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Emblem {
+    pub file: Option<String>,
+    /// `Some` for colored emblems (recolored), `None` for textured (as-is).
+    pub colors: Option<[Option<FColor>; 3]>,
+    pub mask: Vec<i64>,
+    pub instances: Vec<Instance>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Instance {
+    pub x: f64,
+    pub y: f64,
+    pub scale_x: f64,
+    pub scale_y: f64,
+    pub rotation: f64,
+    pub depth: f64,
+}
+
+impl Default for Instance {
+    fn default() -> Self {
+        Instance {
+            x: 0.5,
+            y: 0.5,
+            scale_x: 1.0,
+            scale_y: 1.0,
+            rotation: 0.0,
+            depth: 0.0,
+        }
+    }
+}
+
+/// Resolves a `parent`/template key to its definition node.
+pub type ParentResolver<'a> = dyn Fn(&str) -> Option<&'a Node> + 'a;
+
+impl CoatOfArms {
+    /// Build a coat of arms from a definition node, resolving `parent`
+    /// templates and nested `sub` blocks (ported from pdxu `CoatOfArms.fromNode`).
+    pub fn from_node(node: &Node, resolver: &ParentResolver, env: ColorEnv) -> Result<CoatOfArms> {
+        let mut parent_stack = Vec::new();
+        let mut subs = Sub::from_node(node, resolver, env, &mut parent_stack)?;
+        for sub_node in node.get_all("sub") {
+            subs.extend(Sub::from_node(sub_node, resolver, env, &mut parent_stack)?);
+        }
+        Ok(CoatOfArms { subs })
+    }
+}
+
+impl Sub {
+    fn from_node(
+        node: &Node,
+        resolver: &ParentResolver,
+        env: ColorEnv,
+        parent_stack: &mut Vec<String>,
+    ) -> Result<Vec<Sub>> {
+        if !matches!(node, Node::Object(_)) {
+            return Ok(Vec::new());
+        }
+        let instances = node.get_all("instance");
+        if instances.is_empty() {
+            Ok(vec![Self::sub_instance(
+                node,
+                None,
+                resolver,
+                env,
+                parent_stack,
+            )?])
+        } else {
+            instances
+                .into_iter()
+                .map(|inst| Self::sub_instance(node, Some(inst), resolver, env, parent_stack))
+                .collect()
+        }
+    }
+
+    fn sub_instance(
+        node: &Node,
+        instance: Option<&Node>,
+        resolver: &ParentResolver,
+        env: ColorEnv,
+        parent_stack: &mut Vec<String>,
+    ) -> Result<Sub> {
+        // Resolve the parent template first, then override.
+        let parent_name = node.get("parent").and_then(Node::as_str);
+        let parent_node = parent_name.and_then(resolver);
+        let mut sub = match (parent_name, parent_node) {
+            (Some(name), Some(parent)) => {
+                if let Some(cycle_start) = parent_stack.iter().position(|item| item == name) {
+                    let mut cycle = parent_stack[cycle_start..].to_vec();
+                    cycle.push(name.to_string());
+                    bail!("coat of arms parent cycle: {}", cycle.join(" -> "));
+                }
+                parent_stack.push(name.to_string());
+                let result = Self::sub_instance(parent, None, resolver, env, parent_stack);
+                parent_stack.pop();
+                result?
+            }
+            (None, _) => Sub {
+                x: 0.0,
+                y: 0.0,
+                scale_x: 1.0,
+                scale_y: 1.0,
+                pattern: None,
+                colors: Default::default(),
+                emblems: Vec::new(),
+            },
+            (Some(_), None) => Sub {
+                x: 0.0,
+                y: 0.0,
+                scale_x: 1.0,
+                scale_y: 1.0,
+                pattern: None,
+                colors: Default::default(),
+                emblems: Vec::new(),
+            },
+        };
+
+        // Resolve `color1..color5`: literals override the inherited palette,
+        // then references (`color2 = color1`) resolve against this sub's colors.
+        apply_color_literals(node, &mut sub.colors, env);
+        let palette = sub.colors;
+        apply_color_refs(node, &mut sub.colors, &palette);
+
+        // Inherit the parent's emblems, then replace with our own if present.
+        if let Some(parent) = parent_node {
+            let mut inherited: Vec<Emblem> = parent
+                .get_all("colored_emblem")
+                .into_iter()
+                .map(|n| Emblem::from_colored(n, &sub, env))
+                .collect();
+            inherited.extend(
+                parent
+                    .get_all("textured_emblem")
+                    .into_iter()
+                    .map(Emblem::from_textured),
+            );
+            sub.emblems = inherited;
+        }
+
+        if let Some(pattern) = node.get("pattern").and_then(Node::as_str) {
+            sub.pattern = Some(pattern.to_string());
+        }
+
+        let mut emblems: Vec<Emblem> = node
+            .get_all("colored_emblem")
+            .into_iter()
+            .map(|n| Emblem::from_colored(n, &sub, env))
+            .collect();
+        emblems.extend(
+            node.get_all("textured_emblem")
+                .into_iter()
+                .map(Emblem::from_textured),
+        );
+        if !emblems.is_empty() {
+            sub.emblems = emblems;
+        }
+
+        if let Some(instance) = instance {
+            if let Some(offset) = instance.get("offset") {
+                let nums = offset.num_list();
+                if nums.len() >= 2 {
+                    sub.x = nums[0];
+                    sub.y = nums[1];
+                }
+            }
+            if let Some(scale) = instance.get("scale") {
+                let nums = scale.num_list();
+                if nums.len() >= 2 {
+                    sub.scale_x = nums[0].min(1.0 - sub.x);
+                    sub.scale_y = nums[1].min(1.0 - sub.y);
+                }
+            }
+        }
+
+        Ok(sub)
+    }
+}
+
+impl Emblem {
+    fn from_textured(node: &Node) -> Emblem {
+        Emblem {
+            file: node.get("texture").and_then(Node::as_str).map(String::from),
+            colors: None,
+            mask: parse_mask(node),
+            instances: parse_instances(node),
+        }
+    }
+
+    fn from_colored(node: &Node, sub: &Sub, env: ColorEnv) -> Emblem {
+        // Emblem literals live on the emblem, but references resolve against the
+        // enclosing sub's palette (`color2 = color1` == the sub's color1).
+        let mut colors: [Option<FColor>; 3] = Default::default();
+        apply_color_literals(node, &mut colors, env);
+        apply_color_refs(node, &mut colors, &sub.colors);
+        Emblem {
+            file: node.get("texture").and_then(Node::as_str).map(String::from),
+            colors: Some(colors),
+            mask: parse_mask(node),
+            instances: parse_instances(node),
+        }
+    }
+}
+
+/// Resolve the literal color-slot values on `node` (a named color or `#hex`) to
+/// sRGB, leaving slots that are absent or reference another slot untouched.
+fn apply_color_literals(node: &Node, out: &mut [Option<FColor>], env: ColorEnv) {
+    for (i, slot) in COLOR_SLOTS.iter().take(out.len()).enumerate() {
+        if let Some(value) = node.get(slot).and_then(Node::as_str)
+            && !COLOR_SLOTS.contains(&value)
+        {
+            out[i] = Some(resolve_color(value, env.named, env.missing));
+        }
+    }
+}
+
+/// Resolve color-slot references (`color2 = color1`) on `node`, pulling each
+/// referenced slot's value from `palette`.
+fn apply_color_refs(node: &Node, out: &mut [Option<FColor>], palette: &[Option<FColor>]) {
+    for (i, slot) in COLOR_SLOTS.iter().take(out.len()).enumerate() {
+        if let Some(value) = node.get(slot).and_then(Node::as_str)
+            && let Some(idx) = COLOR_SLOTS.iter().position(|s| *s == value)
+        {
+            out[i] = palette.get(idx).cloned().flatten();
+        }
+    }
+}
+
+fn parse_mask(node: &Node) -> Vec<i64> {
+    match node.get("mask") {
+        Some(n) => n.num_list().into_iter().map(|v| v as i64).collect(),
+        None => Vec::new(),
+    }
+}
+
+fn parse_instances(node: &Node) -> Vec<Instance> {
+    let mut instances: Vec<Instance> = node
+        .get_all("instance")
+        .into_iter()
+        .map(|inst| {
+            let mut instance = Instance::default();
+            if let Some(pos) = inst.get("position") {
+                let nums = pos.num_list();
+                if nums.len() >= 2 {
+                    instance.x = nums[0];
+                    instance.y = nums[1];
+                }
+            }
+            if let Some(scale) = inst.get("scale") {
+                let nums = scale.num_list();
+                if nums.len() == 1 {
+                    instance.scale_x = nums[0];
+                    instance.scale_y = 1.0;
+                } else if nums.len() >= 2 {
+                    instance.scale_x = nums[0];
+                    instance.scale_y = nums[1];
+                }
+            }
+            if let Some(rot) = inst.get("rotation").and_then(Node::as_f64) {
+                instance.rotation = rot;
+            }
+            if let Some(depth) = inst.get("depth").and_then(Node::as_f64) {
+                instance.depth = depth;
+            }
+            instance
+        })
+        .collect();
+    if instances.is_empty() {
+        instances.push(Instance::default());
+    }
+    instances
+}
+
+/// A merged library of coat of arms definitions keyed by tag/template name.
+#[derive(Debug)]
+pub struct CoaDefinitions {
+    map: HashMap<String, Node>,
+}
+
+impl CoaDefinitions {
+    pub fn new() -> Self {
+        CoaDefinitions {
+            map: HashMap::new(),
+        }
+    }
+
+    /// Merge a coat of arms definition file's entries. Accepts raw text; later
+    /// inserts win for duplicate keys. Returns the top-level keys added, in
+    /// source order, so callers can track which keys a given file contributes.
+    pub fn add_file(&mut self, raw: &str) -> Result<Vec<String>> {
+        let text = preprocess(raw)?;
+        let entries = parse_entries(&text)?;
+        let keys: Vec<String> = entries.iter().map(|(k, _)| k.clone()).collect();
+        for (key, node) in entries {
+            self.map.insert(key, node);
+        }
+        Ok(keys)
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Node> {
+        self.map.get(key)
+    }
+
+    pub fn contains(&self, key: &str) -> bool {
+        self.map.contains_key(key)
+    }
+
+    /// Resolve a key to a fully composed, color-resolved coat of arms model.
+    pub fn resolve(
+        &self,
+        key: &str,
+        named: &NamedColors,
+        missing: FColor,
+    ) -> Result<Option<CoatOfArms>> {
+        let Some(node) = self.map.get(key) else {
+            return Ok(None);
+        };
+        let resolver = |name: &str| self.map.get(name);
+        let env = ColorEnv { named, missing };
+        CoatOfArms::from_node(node, &resolver, env).map(Some)
+    }
+}
+
+impl Default for CoaDefinitions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_palette() -> NamedColors {
+        let mut named = NamedColors::default();
+        named.insert("red".to_string(), [255, 0, 0]);
+        named.insert("green".to_string(), [0, 255, 0]);
+        named.insert("blue".to_string(), [0, 0, 255]);
+        named
+    }
+
+    const MISSING: FColor = FColor {
+        r: 1.0,
+        g: 0.0,
+        b: 1.0,
+        a: 1.0,
+    };
+
+    #[test]
+    fn named_colors_resolve_inline_tags_and_references() {
+        let colors = parse_named_colors(
+            r##"
+            colors = {
+                red = rgb { 255 0 0 }
+                green = hsv360 { 120 100 50 }
+                blue = hex { #0000ff }
+            }
+            "##,
+        )
+        .unwrap();
+
+        assert_eq!(colors.get("red"), Some(&[255, 0, 0]));
+        assert_eq!(colors.get("green"), Some(&[0, 128, 0]));
+        assert_eq!(colors.get("blue"), Some(&[0, 0, 255]));
+    }
+
+    #[test]
+    fn definitions_return_keys_in_source_order_and_later_files_win() {
+        let mut definitions = CoaDefinitions::new();
+        assert_eq!(
+            definitions
+                .add_file("AAA = { color1 = red }\nBBB = { color1 = blue }")
+                .unwrap(),
+            ["AAA", "BBB"]
+        );
+        assert_eq!(
+            definitions.add_file("AAA = { color1 = green }").unwrap(),
+            ["AAA"]
+        );
+
+        let coa = definitions
+            .resolve("AAA", &test_palette(), MISSING)
+            .unwrap()
+            .expect("AAA should resolve");
+        assert_eq!(coa.subs[0].colors[0], Some(FColor::opaque([0, 255, 0])));
+    }
+
+    #[test]
+    fn resolve_inherits_parent_colors_patterns_and_emblems() {
+        let mut definitions = CoaDefinitions::new();
+        definitions
+            .add_file(
+                r#"
+            template = {
+                pattern = "pattern.dds"
+                color1 = red
+                color2 = color1
+                colored_emblem = {
+                    texture = "emblem.dds"
+                    color1 = color2
+                    mask = { 1 3 }
+                    instance = { position = { 0.25 0.75 } scale = { 0.4 0.5 } depth = 7 }
+                }
+            }
+            CHILD = {
+                parent = template
+                color1 = blue
+                color2 = color1
+                instance = { offset = { 0.25 0.5 } scale = { 0.25 0.25 } }
+            }
+            "#,
+            )
+            .unwrap();
+
+        let coa = definitions
+            .resolve("CHILD", &test_palette(), MISSING)
+            .unwrap()
+            .expect("CHILD should resolve");
+        let sub = &coa.subs[0];
+        let blue = FColor::opaque([0, 0, 255]);
+        assert_eq!(sub.pattern.as_deref(), Some("pattern.dds"));
+        assert_eq!(sub.colors[0], Some(blue));
+        assert_eq!(sub.colors[1], Some(blue));
+        assert_eq!(
+            (sub.x, sub.y, sub.scale_x, sub.scale_y),
+            (0.25, 0.5, 0.25, 0.25)
+        );
+        assert_eq!(sub.emblems.len(), 1);
+        assert_eq!(sub.emblems[0].file.as_deref(), Some("emblem.dds"));
+        assert_eq!(sub.emblems[0].colors.as_ref().unwrap()[0], Some(blue));
+        assert_eq!(sub.emblems[0].mask, [1, 3]);
+        assert_eq!(
+            (sub.emblems[0].instances[0].x, sub.emblems[0].instances[0].y),
+            (0.25, 0.75)
+        );
+    }
+
+    #[test]
+    fn rejects_parent_cycles() {
+        let mut definitions = CoaDefinitions::new();
+        definitions
+            .add_file("A = { parent = B }\nB = { parent = A }")
+            .unwrap();
+
+        let error = definitions
+            .resolve("A", &test_palette(), MISSING)
+            .unwrap_err();
+        assert!(error.to_string().contains("parent cycle"));
+    }
+
+    #[test]
+    fn rejects_malformed_definition_files() {
+        let mut definitions = CoaDefinitions::new();
+        definitions.add_file("A = {").unwrap_err();
+        definitions
+            .add_file("A = { x = @[unknown(1)] }")
+            .unwrap_err();
+    }
+}

--- a/src/pdx-assets/src/coat_of_arms/preprocess.rs
+++ b/src/pdx-assets/src/coat_of_arms/preprocess.rs
@@ -1,0 +1,252 @@
+//! Textual preprocessing of Paradox coat of arms script into plain jomini text.
+//!
+//! jomini does not evaluate Paradox's `@variable` / `@[math]` preprocessor
+//! macros, and its generic value reader does not expose the body of tagged
+//! colors (`hsv360 { .. }`). We resolve both here so the downstream parser only
+//! ever sees plain scalars, arrays, and objects:
+//!
+//! * `@name = <number|@[expr]>` definitions are collected and dropped.
+//! * `@name` references and `@[expr]` expressions are substituted with numbers.
+//! * inline `hsv360|hsv|rgb|hex { .. }` colors become `"#rrggbb"` string values.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use anyhow::{Result, bail};
+use regex::{Captures, Regex};
+
+use super::color::parse_tagged_color;
+
+static DEF_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?m)^[ \t]*@([A-Za-z_][A-Za-z0-9_]*)[ \t]*=[ \t]*([^#\r\n]*)").unwrap()
+});
+static EXPR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"@\[([^\]]*)\]").unwrap());
+static VAR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"@([A-Za-z_][A-Za-z0-9_]*)").unwrap());
+static COLOR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\b(hsv360|hsv|rgb|hex)\s*\{\s*([^}]*)\}").unwrap());
+
+/// Resolve `@` macros and inline colors in a coat of arms script file.
+pub fn preprocess(input: &str) -> Result<String> {
+    let vars = collect_vars(input)?;
+
+    // Drop the `@name = ...` definition lines; they are not real keys.
+    let without_defs = DEF_RE.replace_all(input, "");
+
+    // Substitute `@[expr]` then bare `@name` references with numbers.
+    let mut invalid_expr = None;
+    let expr_subbed = EXPR_RE.replace_all(&without_defs, |caps: &Captures| {
+        match eval_expr(&caps[1], &vars) {
+            Some(value) => format_num(value),
+            None => {
+                invalid_expr = Some(caps[1].to_string());
+                caps[0].to_string()
+            }
+        }
+    });
+    if let Some(expr) = invalid_expr {
+        bail!("could not evaluate coat of arms expression `@[{expr}]`");
+    }
+    let var_subbed = VAR_RE.replace_all(&expr_subbed, |caps: &Captures| match vars.get(&caps[1]) {
+        Some(v) => format_num(*v),
+        None => caps[0].to_string(),
+    });
+
+    // Resolve inline tagged colors to `"#rrggbb"` literals.
+    Ok(COLOR_RE
+        .replace_all(&var_subbed, |caps: &Captures| {
+            match parse_tagged_color(&caps[1].to_lowercase(), &caps[2]) {
+                Some(rgb) => format!("\"#{:02x}{:02x}{:02x}\"", rgb[0], rgb[1], rgb[2]),
+                None => caps[0].to_string(),
+            }
+        })
+        .into_owned())
+}
+
+/// Build the `@name -> value` map, evaluating definitions in source order so
+/// later definitions can reference earlier ones.
+fn collect_vars(input: &str) -> Result<HashMap<String, f64>> {
+    let mut vars: HashMap<String, f64> = HashMap::new();
+    for caps in DEF_RE.captures_iter(input) {
+        let name = caps[1].to_string();
+        let rhs = caps[2].trim();
+        let Some(value) = eval_rhs(rhs, &vars) else {
+            bail!("could not evaluate coat of arms variable `@{name} = {rhs}`");
+        };
+        vars.insert(name, value);
+    }
+    Ok(vars)
+}
+
+/// Evaluate the right-hand side of an `@name = ...` definition.
+fn eval_rhs(rhs: &str, vars: &HashMap<String, f64>) -> Option<f64> {
+    let rhs = rhs.trim();
+    if let Some(inner) = rhs.strip_prefix("@[").and_then(|s| s.strip_suffix(']')) {
+        return eval_expr(inner, vars);
+    }
+    if let Some(name) = rhs.strip_prefix('@') {
+        return vars.get(name).copied();
+    }
+    rhs.parse::<f64>().ok()
+}
+
+/// Format a number for substitution back into the script.
+fn format_num(v: f64) -> String {
+    // `{}` gives a shortest round-trippable decimal without exponents for the
+    // magnitudes used here (normalized 0..1 coordinates and small constants).
+    let s = format!("{v}");
+    if s.contains('e') || s.contains('E') {
+        format!("{v:.6}")
+    } else {
+        s
+    }
+}
+
+/// Evaluate a `@[..]` arithmetic expression: `+ - * /`, parentheses, numeric
+/// literals, and bare variable names (resolved against `vars`).
+fn eval_expr(expr: &str, vars: &HashMap<String, f64>) -> Option<f64> {
+    let mut parser = ExprParser { expr, pos: 0, vars };
+    let value = parser.parse_expr()?;
+    parser.skip_ws();
+    (parser.pos == parser.expr.len() && value.is_finite()).then_some(value)
+}
+
+struct ExprParser<'a> {
+    expr: &'a str,
+    pos: usize,
+    vars: &'a HashMap<String, f64>,
+}
+
+impl ExprParser<'_> {
+    fn peek(&self) -> Option<u8> {
+        self.expr.as_bytes().get(self.pos).copied()
+    }
+
+    fn bump(&mut self) {
+        self.pos += 1;
+    }
+
+    fn skip_ws(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t' | b'\r' | b'\n')) {
+            self.bump();
+        }
+    }
+
+    fn consume(&mut self, byte: u8) -> bool {
+        self.skip_ws();
+        if self.peek() == Some(byte) {
+            self.bump();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn parse_expr(&mut self) -> Option<f64> {
+        let mut value = self.parse_term()?;
+        loop {
+            if self.consume(b'+') {
+                value += self.parse_term()?;
+            } else if self.consume(b'-') {
+                value -= self.parse_term()?;
+            } else {
+                break;
+            }
+        }
+        Some(value)
+    }
+
+    fn parse_term(&mut self) -> Option<f64> {
+        let mut value = self.parse_factor()?;
+        loop {
+            if self.consume(b'*') {
+                value *= self.parse_factor()?;
+            } else if self.consume(b'/') {
+                value /= self.parse_factor()?;
+            } else {
+                break;
+            }
+        }
+        Some(value)
+    }
+
+    fn parse_factor(&mut self) -> Option<f64> {
+        self.skip_ws();
+        match self.peek()? {
+            b'0'..=b'9' | b'.' => self.parse_number(),
+            b'a'..=b'z' | b'A'..=b'Z' | b'_' => self.parse_ident(),
+            b'-' => {
+                self.bump();
+                Some(-self.parse_factor()?)
+            }
+            b'(' => {
+                self.bump();
+                let value = self.parse_expr()?;
+                self.consume(b')').then_some(value)
+            }
+            _ => None,
+        }
+    }
+
+    fn parse_number(&mut self) -> Option<f64> {
+        let start = self.pos;
+        while matches!(self.peek(), Some(b'0'..=b'9' | b'.')) {
+            self.bump();
+        }
+        self.expr[start..self.pos].parse().ok()
+    }
+
+    fn parse_ident(&mut self) -> Option<f64> {
+        let start = self.pos;
+        while matches!(
+            self.peek(),
+            Some(b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+        ) {
+            self.bump();
+        }
+        self.vars.get(&self.expr[start..self.pos]).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_header_vars_and_math() {
+        let input = "@half = @[1/2]\n@semy = 0.27\nX = { scale = { @half @semy } }";
+        let out = preprocess(input).unwrap();
+        assert!(out.contains("scale = { 0.5 0.27 }"), "got: {out}");
+        assert!(!out.contains('@'));
+    }
+
+    #[test]
+    fn resolves_nested_math_with_vars() {
+        let input = "@o = 0.1\nX = { position = { @[0.5 + (o*2)] 0.5 } }";
+        let out = preprocess(input).unwrap();
+        assert!(out.contains("position = { 0.7 0.5 }"), "got: {out}");
+    }
+
+    #[test]
+    fn resolves_inline_colors_to_hex() {
+        let input = "X = { color1 = rgb { 255 0 0 } color2 = hsv360 { 0 0 15 } }";
+        let out = preprocess(input).unwrap();
+        assert!(out.contains("color1 = \"#ff0000\""), "got: {out}");
+        assert!(out.to_lowercase().contains("color2 = \"#"), "got: {out}");
+    }
+
+    #[test]
+    fn preserves_color_references_and_names() {
+        let input = "X = { color1 = \"red\" color2 = color1 }";
+        let out = preprocess(input).unwrap();
+        assert!(out.contains("color1 = \"red\""));
+        assert!(out.contains("color2 = color1"));
+    }
+
+    #[test]
+    fn rejects_unsupported_or_non_finite_expressions() {
+        preprocess("X = { x = @[min(1, 2)] }").unwrap_err();
+        preprocess("X = { x = @[1 / 0] }").unwrap_err();
+        preprocess("@x = nope\nX = { x = @x }").unwrap_err();
+    }
+}

--- a/src/pdx-assets/src/coat_of_arms/render.rs
+++ b/src/pdx-assets/src/coat_of_arms/render.rs
@@ -1,0 +1,591 @@
+//! Composite a resolved [`CoatOfArms`] into an RGBA raster.
+//!
+//! Ported from pdx_unlimiter's `CoatOfArmsRenderer`: pattern channel recolor,
+//! colored/textured emblems, per-instance affine placement, and channel-culling
+//! masks.
+
+use std::sync::Arc;
+
+use image::{Rgba, RgbaImage};
+
+use super::color::FColor;
+use super::model::{CoatOfArms, Emblem, Instance, Sub};
+
+/// Per-game configuration for the shared compositor.
+#[derive(Debug, Clone)]
+pub struct GameCoaConfig {
+    /// Output canvas width in pixels.
+    pub width: u32,
+    /// Output canvas height in pixels.
+    pub height: u32,
+    /// Color substituted for missing/unknown colors (e.g. magenta for EU5).
+    pub missing_color: FColor,
+}
+
+/// Provides decoded RGBA textures (patterns and emblems) by filename.
+pub trait TextureSource: Sync {
+    fn pattern(&self, file: &str) -> Option<Arc<RgbaImage>>;
+    fn colored_emblem(&self, file: &str) -> Option<Arc<RgbaImage>>;
+    fn textured_emblem(&self, file: &str) -> Option<Arc<RgbaImage>>;
+}
+
+/// Render a coat of arms (with colors already resolved) into an RGBA image.
+pub fn render(coa: &CoatOfArms, textures: &dyn TextureSource, cfg: &GameCoaConfig) -> RgbaImage {
+    let w = cfg.width;
+    let h = cfg.height;
+    let fill = cfg.missing_color.to_rgba8();
+    let mut canvas = RgbaImage::from_pixel(w, h, Rgba(fill));
+
+    for sub in &coa.subs {
+        let raw_pattern = draw_pattern(&mut canvas, sub, textures, cfg);
+        for emblem in &sub.emblems {
+            draw_emblem(
+                &mut canvas,
+                raw_pattern.as_deref(),
+                sub,
+                emblem,
+                textures,
+                cfg,
+            );
+        }
+    }
+
+    canvas
+}
+
+/// Draw the sub's pattern, returning the raw (un-recolored) pattern for masks.
+fn draw_pattern(
+    canvas: &mut RgbaImage,
+    sub: &Sub,
+    textures: &dyn TextureSource,
+    cfg: &GameCoaConfig,
+) -> Option<Arc<RgbaImage>> {
+    let pattern_file = sub.pattern.as_deref()?;
+    let raw = textures.pattern(pattern_file)?;
+
+    let c1 = sub.colors[0].unwrap_or(cfg.missing_color);
+    let c2 = sub.colors[1].unwrap_or(cfg.missing_color);
+    let c3 = sub.colors[2].unwrap_or(cfg.missing_color);
+
+    // Recolor: overlay color1/2/3 weighted by the pattern's R/G/B channels.
+    let mut recolored = (*raw).clone();
+    for px in recolored.pixels_mut() {
+        let [r, g, b, a] = px.0;
+        let mut nc = c1.with_alpha(r as f64 / 255.0);
+        nc = nc.over(c2.with_alpha(g as f64 / 255.0));
+        nc = nc.over(c3.with_alpha(b as f64 / 255.0));
+        let rgb = nc.to_rgb8();
+        px.0 = [rgb[0], rgb[1], rgb[2], a];
+    }
+
+    let dst_x = sub.x * cfg.width as f64;
+    let dst_y = sub.y * cfg.height as f64;
+    let dst_w = sub.scale_x * cfg.width as f64;
+    let dst_h = sub.scale_y * cfg.height as f64;
+    blit_scaled(canvas, &recolored, dst_x, dst_y, dst_w, dst_h);
+
+    Some(raw)
+}
+
+/// Scale `src` to `dst_w`x`dst_h` at `(dst_x, dst_y)` and composite over canvas.
+fn blit_scaled(
+    canvas: &mut RgbaImage,
+    src: &RgbaImage,
+    dst_x: f64,
+    dst_y: f64,
+    dst_w: f64,
+    dst_h: f64,
+) {
+    if dst_w <= 0.0 || dst_h <= 0.0 {
+        return;
+    }
+    let (cw, ch) = (canvas.width() as i64, canvas.height() as i64);
+    let x0 = dst_x.floor() as i64;
+    let y0 = dst_y.floor() as i64;
+    let x1 = (dst_x + dst_w).ceil() as i64;
+    let y1 = (dst_y + dst_h).ceil() as i64;
+
+    for py in y0.max(0)..y1.min(ch) {
+        for px in x0.max(0)..x1.min(cw) {
+            let u = (px as f64 + 0.5 - dst_x) / dst_w;
+            let v = (py as f64 + 0.5 - dst_y) / dst_h;
+            if !(0.0..1.0).contains(&u) || !(0.0..1.0).contains(&v) {
+                continue;
+            }
+            let sample = sample_bilinear(
+                src,
+                u * src.width() as f64 - 0.5,
+                v * src.height() as f64 - 0.5,
+            );
+            composite_pixel(canvas, px as u32, py as u32, sample);
+        }
+    }
+}
+
+fn draw_emblem(
+    canvas: &mut RgbaImage,
+    raw_pattern: Option<&RgbaImage>,
+    sub: &Sub,
+    emblem: &Emblem,
+    textures: &dyn TextureSource,
+    cfg: &GameCoaConfig,
+) {
+    let Some(file) = emblem.file.as_deref() else {
+        return;
+    };
+
+    // Colored emblems are recolored into an owned buffer; textured emblems are
+    // used straight from the (shared) cache without copying.
+    let colored;
+    let textured;
+    let emblem_img: &RgbaImage = match &emblem.colors {
+        Some(colors) => {
+            let Some(src) = textures.colored_emblem(file) else {
+                return;
+            };
+            let e1 = colors[0].unwrap_or(cfg.missing_color);
+            let e2 = colors[1].unwrap_or(cfg.missing_color);
+            let e3 = colors[2].unwrap_or(cfg.missing_color);
+            let mut img = (*src).clone();
+            for px in img.pixels_mut() {
+                let [r, g, b, a] = px.0;
+                let mut nc = e1.with_alpha(1.0);
+                // Paradox colored-emblem masks intentionally map green to
+                // color2 and red to color3 (unlike pattern RGB slots). This
+                // matches pdx_unlimiter's CoatOfArmsRenderer.
+                nc = nc.over(e2.with_alpha(g as f64 / 255.0));
+                nc = nc.over(e3.with_alpha(r as f64 / 255.0));
+                let dark = 255 - (b as i32 * 2).min(255);
+                nc = nc.over(FColor::rgba(0.0, 0.0, 0.0, dark as f64 / 255.0));
+                let light = ((b as i32 - 127) * 2).clamp(0, 255);
+                nc = nc.over(FColor::rgba(1.0, 1.0, 1.0, light as f64 / 255.0));
+                let rgb = nc.to_rgb8();
+                px.0 = [rgb[0], rgb[1], rgb[2], a];
+            }
+            colored = img;
+            &colored
+        }
+        None => {
+            let Some(img) = textures.textured_emblem(file) else {
+                return;
+            };
+            textured = img;
+            &textured
+        }
+    };
+
+    let has_mask = emblem.mask.iter().any(|&i| i != 0);
+    let clip = sub_clip(sub, cfg);
+
+    // With a mask, accumulate all instances into a scratch buffer, cull against
+    // the raw pattern, then composite. Without, composite instances directly.
+    if has_mask {
+        let mut scratch = RgbaImage::new(cfg.width, cfg.height);
+        for instance in sorted_instances(emblem) {
+            draw_instance(&mut scratch, emblem_img, sub, instance, cfg, None);
+        }
+        if let Some(pattern) = raw_pattern {
+            apply_culling_mask(&mut scratch, pattern, sub, &emblem.mask);
+        }
+        composite_buffer(canvas, &scratch, &clip);
+    } else {
+        for instance in sorted_instances(emblem) {
+            draw_instance(canvas, emblem_img, sub, instance, cfg, Some(&clip));
+        }
+    }
+}
+
+fn sorted_instances(emblem: &Emblem) -> Vec<&Instance> {
+    let mut instances: Vec<&Instance> = emblem.instances.iter().collect();
+    instances.sort_by(|a, b| {
+        a.depth
+            .partial_cmp(&b.depth)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    instances
+}
+
+/// A clip rectangle in canvas pixel coordinates.
+#[derive(Debug, Clone, Copy)]
+struct Rect {
+    x0: i64,
+    y0: i64,
+    x1: i64,
+    y1: i64,
+}
+
+fn sub_clip(sub: &Sub, cfg: &GameCoaConfig) -> Rect {
+    let x = (sub.x * cfg.width as f64).floor() as i64;
+    let y = (sub.y * cfg.height as f64).floor() as i64;
+    let w = (sub.scale_x * cfg.width as f64).ceil() as i64;
+    let h = (sub.scale_y * cfg.height as f64).ceil() as i64;
+    Rect {
+        x0: x.max(0),
+        y0: y.max(0),
+        x1: (x + w).min(cfg.width as i64),
+        y1: (y + h).min(cfg.height as i64),
+    }
+}
+
+/// Place one emblem instance via its affine transform.
+fn draw_instance(
+    target: &mut RgbaImage,
+    src: &RgbaImage,
+    sub: &Sub,
+    instance: &Instance,
+    cfg: &GameCoaConfig,
+    clip: Option<&Rect>,
+) {
+    let (w, h) = (cfg.width as f64, cfg.height as f64);
+    let (iw, ih) = (src.width() as f64, src.height() as f64);
+    if iw == 0.0 || ih == 0.0 {
+        return;
+    }
+
+    let scale_x = (w / iw) * instance.scale_x * sub.scale_x;
+    let scale_y = (h / ih) * instance.scale_y * sub.scale_y;
+    let tx = w * (sub.x + sub.scale_x * instance.x);
+    let ty = h * (sub.y + sub.scale_y * instance.y);
+
+    // Compose source->dest transform in the same order as pdxu (each op is
+    // right-multiplied, i.e. applied to the point first-to-last bottom-up).
+    let mut m = Mat::translate(tx, ty);
+    m = m.mul(&Mat::scale(iw / ih, 1.0));
+    m = m.mul(&Mat::scale(scale_x.abs(), scale_y.abs()));
+    if instance.rotation != 0.0 {
+        m = m.mul(&Mat::rotate(instance.rotation.to_radians()));
+    }
+    if instance.scale_x < 0.0 {
+        m = m.mul(&Mat::scale(-1.0, 1.0));
+    }
+    if instance.scale_y < 0.0 {
+        m = m.mul(&Mat::scale(1.0, -1.0));
+    }
+    m = m.mul(&Mat::scale(ih / iw, 1.0));
+    m = m.mul(&Mat::translate(-iw / 2.0, -ih / 2.0));
+
+    let Some(inv) = m.inverse() else {
+        return;
+    };
+
+    // Destination bounding box from the forward-transformed source corners.
+    let corners = [(0.0, 0.0), (iw, 0.0), (0.0, ih), (iw, ih)];
+    let mut min_x = f64::MAX;
+    let mut min_y = f64::MAX;
+    let mut max_x = f64::MIN;
+    let mut max_y = f64::MIN;
+    for (sx, sy) in corners {
+        let (dx, dy) = m.apply(sx, sy);
+        min_x = min_x.min(dx);
+        min_y = min_y.min(dy);
+        max_x = max_x.max(dx);
+        max_y = max_y.max(dy);
+    }
+
+    let mut bx0 = min_x.floor() as i64;
+    let mut by0 = min_y.floor() as i64;
+    let mut bx1 = max_x.ceil() as i64;
+    let mut by1 = max_y.ceil() as i64;
+    if let Some(c) = clip {
+        bx0 = bx0.max(c.x0);
+        by0 = by0.max(c.y0);
+        bx1 = bx1.min(c.x1);
+        by1 = by1.min(c.y1);
+    }
+    bx0 = bx0.max(0);
+    by0 = by0.max(0);
+    bx1 = bx1.min(target.width() as i64);
+    by1 = by1.min(target.height() as i64);
+
+    for py in by0..by1 {
+        for px in bx0..bx1 {
+            let (sx, sy) = inv.apply(px as f64 + 0.5, py as f64 + 0.5);
+            if sx < 0.0 || sy < 0.0 || sx >= iw || sy >= ih {
+                continue;
+            }
+            let sample = sample_bilinear(src, sx - 0.5, sy - 0.5);
+            composite_pixel(target, px as u32, py as u32, sample);
+        }
+    }
+}
+
+/// Cull the emblem scratch buffer's alpha against the raw pattern channels.
+fn apply_culling_mask(emblem: &mut RgbaImage, pattern: &RgbaImage, sub: &Sub, indices: &[i64]) {
+    let (pw, ph) = (pattern.width() as f64, pattern.height() as f64);
+    let (ew, eh) = (emblem.width() as f64, emblem.height() as f64);
+    let x_f = pw / ew;
+    let y_f = ph / eh;
+    let mask_r = if indices.contains(&1) { 1.0 } else { 0.0 };
+    let mask_g = if indices.contains(&2) { 1.0 } else { 0.0 };
+    let mask_b = if indices.contains(&3) { 1.0 } else { 0.0 };
+
+    for y in 0..emblem.height() {
+        for x in 0..emblem.width() {
+            let cx = ((x_f * x as f64 - pw * sub.x) / sub.scale_x).floor();
+            let cy = ((y_f * y as f64 - ph * sub.y) / sub.scale_y).floor();
+            if cx < 0.0 || cy < 0.0 || cx >= pw || cy >= ph {
+                continue;
+            }
+            let p = pattern.get_pixel(cx as u32, cy as u32).0;
+            let (pr, pg, pb) = (
+                p[0] as f64 / 255.0,
+                p[1] as f64 / 255.0,
+                p[2] as f64 / 255.0,
+            );
+            let mr = (pr - pg - pb).clamp(0.0, 1.0);
+            let mg = (pg - pb).clamp(0.0, 1.0);
+            let mb = pb;
+            let t = (mr * mask_r + mg * mask_g + mb * mask_b).clamp(0.0, 1.0);
+            let px = emblem.get_pixel_mut(x, y);
+            px.0[3] = (px.0[3] as f64 * t).round() as u8;
+        }
+    }
+}
+
+/// Composite an entire buffer over the canvas within a clip rectangle.
+fn composite_buffer(canvas: &mut RgbaImage, src: &RgbaImage, clip: &Rect) {
+    for py in clip.y0..clip.y1 {
+        for px in clip.x0..clip.x1 {
+            let s = src.get_pixel(px as u32, py as u32).0;
+            if s[3] == 0 {
+                continue;
+            }
+            let sample = FColor::rgba(
+                s[0] as f64 / 255.0,
+                s[1] as f64 / 255.0,
+                s[2] as f64 / 255.0,
+                s[3] as f64 / 255.0,
+            );
+            composite_pixel(canvas, px as u32, py as u32, sample);
+        }
+    }
+}
+
+/// Alpha-composite `top` over the canvas pixel at `(x, y)`.
+fn composite_pixel(canvas: &mut RgbaImage, x: u32, y: u32, top: FColor) {
+    if top.a <= 0.0 {
+        return;
+    }
+    let px = canvas.get_pixel_mut(x, y);
+    let bottom = FColor::rgba(
+        px.0[0] as f64 / 255.0,
+        px.0[1] as f64 / 255.0,
+        px.0[2] as f64 / 255.0,
+        px.0[3] as f64 / 255.0,
+    );
+    px.0 = bottom.over(top).to_rgba8();
+}
+
+/// Bilinearly sample `src` at pixel-center coordinates `(x, y)`.
+fn sample_bilinear(src: &RgbaImage, x: f64, y: f64) -> FColor {
+    let x0 = x.floor();
+    let y0 = y.floor();
+    let fx = x - x0;
+    let fy = y - y0;
+    let sample = |ix: f64, iy: f64| -> FColor {
+        let cx = (ix as i64).clamp(0, src.width() as i64 - 1) as u32;
+        let cy = (iy as i64).clamp(0, src.height() as i64 - 1) as u32;
+        let p = src.get_pixel(cx, cy).0;
+        FColor::rgba(
+            p[0] as f64 / 255.0,
+            p[1] as f64 / 255.0,
+            p[2] as f64 / 255.0,
+            p[3] as f64 / 255.0,
+        )
+    };
+    let c00 = sample(x0, y0);
+    let c10 = sample(x0 + 1.0, y0);
+    let c01 = sample(x0, y0 + 1.0);
+    let c11 = sample(x0 + 1.0, y0 + 1.0);
+    let lerp = |a: f64, b: f64, t: f64| a + (b - a) * t;
+    FColor {
+        r: lerp(lerp(c00.r, c10.r, fx), lerp(c01.r, c11.r, fx), fy),
+        g: lerp(lerp(c00.g, c10.g, fx), lerp(c01.g, c11.g, fx), fy),
+        b: lerp(lerp(c00.b, c10.b, fx), lerp(c01.b, c11.b, fx), fy),
+        a: lerp(lerp(c00.a, c10.a, fx), lerp(c01.a, c11.a, fx), fy),
+    }
+}
+
+/// A 2D affine transform (`dest = M * src`).
+#[derive(Debug, Clone, Copy)]
+struct Mat {
+    a: f64,
+    b: f64,
+    c: f64,
+    d: f64,
+    e: f64,
+    f: f64,
+}
+
+impl Mat {
+    fn translate(tx: f64, ty: f64) -> Self {
+        Mat {
+            a: 1.0,
+            b: 0.0,
+            c: 0.0,
+            d: 1.0,
+            e: tx,
+            f: ty,
+        }
+    }
+    fn scale(sx: f64, sy: f64) -> Self {
+        Mat {
+            a: sx,
+            b: 0.0,
+            c: 0.0,
+            d: sy,
+            e: 0.0,
+            f: 0.0,
+        }
+    }
+    fn rotate(theta: f64) -> Self {
+        let (s, c) = theta.sin_cos();
+        Mat {
+            a: c,
+            b: s,
+            c: -s,
+            d: c,
+            e: 0.0,
+            f: 0.0,
+        }
+    }
+
+    /// `self * other` (apply `other` to the point first).
+    fn mul(&self, o: &Mat) -> Mat {
+        Mat {
+            a: self.a * o.a + self.c * o.b,
+            b: self.b * o.a + self.d * o.b,
+            c: self.a * o.c + self.c * o.d,
+            d: self.b * o.c + self.d * o.d,
+            e: self.a * o.e + self.c * o.f + self.e,
+            f: self.b * o.e + self.d * o.f + self.f,
+        }
+    }
+
+    fn apply(&self, x: f64, y: f64) -> (f64, f64) {
+        (
+            self.a * x + self.c * y + self.e,
+            self.b * x + self.d * y + self.f,
+        )
+    }
+
+    fn inverse(&self) -> Option<Mat> {
+        let det = self.a * self.d - self.b * self.c;
+        if det.abs() < 1e-12 {
+            return None;
+        }
+        let inv_det = 1.0 / det;
+        let a = self.d * inv_det;
+        let b = -self.b * inv_det;
+        let c = -self.c * inv_det;
+        let d = self.a * inv_det;
+        Some(Mat {
+            a,
+            b,
+            c,
+            d,
+            e: -(a * self.e + c * self.f),
+            f: -(b * self.e + d * self.f),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeTextures {
+        pattern: Option<Arc<RgbaImage>>,
+        colored: Option<Arc<RgbaImage>>,
+        textured: Option<Arc<RgbaImage>>,
+    }
+
+    impl TextureSource for FakeTextures {
+        fn pattern(&self, _: &str) -> Option<Arc<RgbaImage>> {
+            self.pattern.clone()
+        }
+
+        fn colored_emblem(&self, _: &str) -> Option<Arc<RgbaImage>> {
+            self.colored.clone()
+        }
+
+        fn textured_emblem(&self, _: &str) -> Option<Arc<RgbaImage>> {
+            self.textured.clone()
+        }
+    }
+
+    fn cfg() -> GameCoaConfig {
+        GameCoaConfig {
+            width: 4,
+            height: 4,
+            missing_color: FColor::rgba(1.0, 0.0, 1.0, 1.0),
+        }
+    }
+
+    #[test]
+    fn renders_pattern_with_named_slot_colors() {
+        let mut pattern = RgbaImage::new(1, 1);
+        pattern.put_pixel(0, 0, Rgba([255, 0, 0, 255]));
+        let textures = FakeTextures {
+            pattern: Some(Arc::new(pattern)),
+            ..Default::default()
+        };
+        let coa = CoatOfArms {
+            subs: vec![Sub {
+                x: 0.0,
+                y: 0.0,
+                scale_x: 1.0,
+                scale_y: 1.0,
+                pattern: Some("pattern.dds".to_string()),
+                colors: [
+                    Some(FColor::opaque([255, 0, 0])),
+                    Some(FColor::opaque([0, 255, 0])),
+                    Some(FColor::opaque([0, 0, 255])),
+                    None,
+                    None,
+                ],
+                emblems: Vec::new(),
+            }],
+        };
+
+        let image = render(&coa, &textures, &cfg());
+        assert_eq!(image.get_pixel(0, 0).0, [255, 0, 0, 255]);
+        assert_eq!(image.get_pixel(3, 3).0, [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn textured_emblems_are_layered_by_depth() {
+        let mut red = RgbaImage::new(1, 1);
+        red.put_pixel(0, 0, Rgba([255, 0, 0, 255]));
+        let textures = FakeTextures {
+            textured: Some(Arc::new(red)),
+            ..Default::default()
+        };
+        let coa = CoatOfArms {
+            subs: vec![Sub {
+                x: 0.0,
+                y: 0.0,
+                scale_x: 1.0,
+                scale_y: 1.0,
+                pattern: None,
+                colors: Default::default(),
+                emblems: vec![Emblem {
+                    file: Some("emblem.dds".to_string()),
+                    colors: None,
+                    mask: Vec::new(),
+                    instances: vec![Instance {
+                        scale_x: 0.5,
+                        scale_y: 0.5,
+                        depth: 10.0,
+                        ..Default::default()
+                    }],
+                }],
+            }],
+        };
+
+        let image = render(&coa, &textures, &cfg());
+        assert_eq!(image.get_pixel(1, 1).0, [255, 0, 0, 255]);
+        assert_eq!(image.get_pixel(0, 0).0, [255, 0, 255, 255]);
+    }
+}

--- a/src/pdx-assets/src/eu5.rs
+++ b/src/pdx-assets/src/eu5.rs
@@ -1,1 +1,2 @@
+pub mod coat_of_arms;
 pub mod compiler;

--- a/src/pdx-assets/src/eu5/coat_of_arms.rs
+++ b/src/pdx-assets/src/eu5/coat_of_arms.rs
@@ -1,0 +1,268 @@
+//! EU5 wiring for the game-agnostic coat of arms compositor.
+//!
+//! Loads EU5's heraldry definitions and named colors from a game file provider,
+//! decodes the BC7 `.dds` emblem/pattern textures (pure-Rust via `image_dds`,
+//! since ImageMagick's DDS coder cannot read BC7), and renders country flags.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use image::RgbaImage;
+use rayon::prelude::*;
+
+use crate::coat_of_arms::{
+    CoaDefinitions, CoatOfArms, FColor, GameCoaConfig, NamedColors, TextureSource,
+    parse_named_colors, render,
+};
+use crate::file_provider::FileProvider;
+use crate::images::Geometry;
+
+const MAIN_MENU: &str = "game/main_menu";
+const PATTERNS_DIR: &str = "game/main_menu/gfx/coat_of_arms/patterns";
+const COLORED_DIR: &str = "game/main_menu/gfx/coat_of_arms/colored_emblems";
+const TEXTURED_DIR: &str = "game/main_menu/gfx/coat_of_arms/textured_emblems";
+const COA_DEFS_DIR: &str = "game/main_menu/common/coat_of_arms/coat_of_arms";
+
+/// The coat of arms definition files whose keys we pre-render into the atlas.
+const SCOPED_FILES: [&str; 2] = [
+    "pre_scripted_countries.txt",
+    "pre_scripted_countries_formable.txt",
+];
+
+/// EU5 flags are rendered at 1.5:1. This is the source resolution fed to the
+/// montage step (which downsamples to the atlas tile sizes).
+const RENDER_WIDTH: u32 = 384;
+const RENDER_HEIGHT: u32 = 256;
+
+/// EU5 render configuration (magenta stands in for missing colors, as in-game).
+pub fn eu5_config() -> GameCoaConfig {
+    GameCoaConfig {
+        width: RENDER_WIDTH,
+        height: RENDER_HEIGHT,
+        missing_color: FColor::rgba(1.0, 0.0, 1.0, 1.0),
+    }
+}
+
+/// The multi-resolution tile sizes for the EU5 flag atlas. Flags are 1.5:1;
+/// tile sizes stay in that ratio (the game uses 72x48 / 144x96).
+pub fn flag_montage_geometries() -> Vec<Geometry> {
+    vec![Geometry::new(72, 48), Geometry::new(144, 96)]
+}
+
+/// Renders EU5 country flags from a game file provider: merged heraldry
+/// definitions, resolved into render-ready models, plus an on-demand BC7 texture
+/// cache. Load once, then [`trace`](Self::trace) or
+/// [`render_to_pngs`](Self::render_to_pngs).
+#[derive(Debug)]
+pub struct Eu5FlagRenderer<'a, P: FileProvider + ?Sized> {
+    textures: ProviderTextures<'a, P>,
+    config: GameCoaConfig,
+    /// Scoped keys resolved to color-resolved models, sorted by key.
+    flags: Vec<(String, CoatOfArms)>,
+}
+
+impl<'a, P: FileProvider + ?Sized> Eu5FlagRenderer<'a, P> {
+    /// Load and resolve every scoped flag from `provider`. Errors if the EU5
+    /// coat of arms assets are not present.
+    pub fn load(provider: &'a P) -> Result<Self> {
+        let coa_marker = format!("{MAIN_MENU}/common/named_colors/01_coa.txt");
+        anyhow::ensure!(
+            provider.file_exists(&coa_marker),
+            "EU5 coat of arms assets not found (expected {coa_marker})"
+        );
+        let (definitions, named_colors, render_keys) = load_definitions(provider)?;
+        let config = eu5_config();
+
+        // Resolve each scoped key to a fully composed, color-resolved model,
+        // dropping unknown keys, and sort for deterministic atlas ordering.
+        let mut flags: Vec<(String, CoatOfArms)> = render_keys
+            .iter()
+            .map(|key| {
+                definitions
+                    .resolve(key, &named_colors, config.missing_color)
+                    .map(|coa| coa.map(|coa| (key.clone(), coa)))
+            })
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect();
+        flags.sort_by(|a, b| a.0.cmp(&b.0));
+
+        Ok(Self {
+            textures: ProviderTextures::new(provider),
+            config,
+            flags,
+        })
+    }
+
+    /// Load (and cache) every texture referenced by the resolved flags, without
+    /// rendering. Used to register texture files during bundle tracing.
+    pub fn trace(&self) {
+        for (_, coa) in &self.flags {
+            prewarm(&self.textures, coa);
+        }
+    }
+
+    /// Render flags in parallel and write each PNG immediately, keeping only
+    /// one full-resolution bitmap per Rayon worker alive at a time.
+    pub fn render_to_pngs(&self, output_dir: &Path) -> Result<Vec<(String, PathBuf)>> {
+        self.flags
+            .par_iter()
+            .map(|(key, coa)| {
+                let image = render(coa, &self.textures, &self.config);
+                let path = output_dir.join(format!("{key}.png"));
+                image
+                    .save(&path)
+                    .with_context(|| format!("could not write rendered flag {key}"))?;
+                Ok((key.clone(), path))
+            })
+            .collect()
+    }
+}
+
+/// Load EU5 coat of arms definitions and named colors, returning the merged
+/// definitions, the named-color palette, and the scoped render keys (in source
+/// order, deduped across scoped files).
+fn load_definitions<P: FileProvider + ?Sized>(
+    provider: &P,
+) -> Result<(CoaDefinitions, NamedColors, Vec<String>)> {
+    // Named colors: base (jomini) first, then main_menu overrides.
+    let mut named_colors = NamedColors::default();
+    for dir in [
+        "jomini/loading_screen/common/named_colors",
+        "game/main_menu/common/named_colors",
+    ] {
+        for file in provider
+            .walk_directory(dir, &[".txt"])
+            .with_context(|| format!("could not list named colors in {dir}"))?
+        {
+            let text = provider
+                .read_to_string(&file)
+                .with_context(|| format!("could not read named colors from {file}"))?;
+            for (name, rgb) in parse_named_colors(&text)
+                .with_context(|| format!("could not parse named colors from {file}"))?
+            {
+                named_colors.insert(name, rgb);
+            }
+        }
+    }
+
+    // Merge every coat of arms definition file for `parent`/template resolution,
+    // but only track keys from the scoped files as the render set.
+    let mut definitions = CoaDefinitions::new();
+    let mut scoped_keys: Vec<String> = Vec::new();
+    let all_files = provider
+        .walk_directory(COA_DEFS_DIR, &[".txt"])
+        .context("could not list coat of arms definitions")?;
+    let mut seen = std::collections::HashSet::new();
+    for file in &all_files {
+        let text = read_latin1(provider, file)?;
+        let keys = definitions
+            .add_file(&text)
+            .with_context(|| format!("could not parse coat of arms definitions from {file}"))?;
+        if SCOPED_FILES.iter().any(|f| file.ends_with(f)) {
+            // Dedupe keys shared across scoped files (e.g. RUS is defined in both
+            // the base and formable files); `resolve` returns the merged winner.
+            for key in keys {
+                if seen.insert(key.clone()) {
+                    scoped_keys.push(key);
+                }
+            }
+        }
+    }
+
+    Ok((definitions, named_colors, scoped_keys))
+}
+
+/// Read a game file as text, decoding bytes as Latin-1 so non-UTF-8 comment
+/// bytes never fail the read (only ASCII structure matters downstream).
+fn read_latin1<P: FileProvider + ?Sized>(provider: &P, path: &str) -> Result<String> {
+    let bytes = provider
+        .read_file(path)
+        .with_context(|| format!("could not read {path}"))?;
+    Ok(bytes.iter().map(|&b| b as char).collect())
+}
+
+/// A [`TextureSource`] backed by a file provider that decodes BC7 `.dds` on
+/// demand and memoizes the results (emblems recur heavily across flags).
+pub struct ProviderTextures<'a, P: ?Sized> {
+    provider: &'a P,
+    cache: Mutex<HashMap<String, Option<Arc<RgbaImage>>>>,
+}
+
+impl<P: FileProvider + ?Sized> std::fmt::Debug for ProviderTextures<'_, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderTextures")
+            .field("cached", &self.cache().len())
+            .finish()
+    }
+}
+
+impl<'a, P: FileProvider + ?Sized> ProviderTextures<'a, P> {
+    pub fn new(provider: &'a P) -> Self {
+        ProviderTextures {
+            provider,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn load(&self, dir: &str, file: &str) -> Option<Arc<RgbaImage>> {
+        let path = format!("{dir}/{file}");
+        if let Some(cached) = self.cache().get(&path) {
+            return cached.clone();
+        }
+        let decoded = self
+            .provider
+            .read_file(&path)
+            .ok()
+            .and_then(|bytes| decode_dds(&bytes))
+            .map(Arc::new);
+        self.cache().insert(path, decoded.clone());
+        decoded
+    }
+
+    fn cache(&self) -> std::sync::MutexGuard<'_, HashMap<String, Option<Arc<RgbaImage>>>> {
+        self.cache
+            .lock()
+            .expect("provider texture cache mutex poisoned")
+    }
+}
+
+impl<P: FileProvider + ?Sized> TextureSource for ProviderTextures<'_, P> {
+    fn pattern(&self, file: &str) -> Option<Arc<RgbaImage>> {
+        self.load(PATTERNS_DIR, file)
+    }
+    fn colored_emblem(&self, file: &str) -> Option<Arc<RgbaImage>> {
+        self.load(COLORED_DIR, file)
+    }
+    fn textured_emblem(&self, file: &str) -> Option<Arc<RgbaImage>> {
+        self.load(TEXTURED_DIR, file)
+    }
+}
+
+/// Decode BC7 (and other) DDS bytes into an RGBA image.
+fn decode_dds(bytes: &[u8]) -> Option<RgbaImage> {
+    let dds = image_dds::ddsfile::Dds::read(std::io::Cursor::new(bytes)).ok()?;
+    image_dds::image_from_dds(&dds, 0).ok()
+}
+
+/// Load (and cache) every texture referenced by a resolved coat of arms, so it
+/// is registered during bundle tracing and warm before rendering.
+fn prewarm<P: FileProvider + ?Sized>(textures: &ProviderTextures<P>, coa: &CoatOfArms) {
+    for sub in &coa.subs {
+        if let Some(pattern) = &sub.pattern {
+            let _ = textures.pattern(pattern);
+        }
+        for emblem in &sub.emblems {
+            if let Some(file) = &emblem.file {
+                if emblem.colors.is_some() {
+                    let _ = textures.colored_emblem(file);
+                } else {
+                    let _ = textures.textured_emblem(file);
+                }
+            }
+        }
+    }
+}

--- a/src/pdx-assets/src/eu5/compiler.rs
+++ b/src/pdx-assets/src/eu5/compiler.rs
@@ -20,6 +20,7 @@ const FRONTEND_GOODS_ICONS_DIR: &str = concat!(
 );
 
 const TRADE_GOODS_ICON_PATH: &str = "game/main_menu/gfx/interface/icons/trade_goods";
+const FLAGS_PER_ATLAS: usize = 128;
 
 struct FileProviderAdapter<P>(P);
 
@@ -103,6 +104,13 @@ where
             Ok((name, f.path))
         })
         .collect::<Result<_>>()?;
+
+    // Load coat of arms definitions and warm/trace the referenced emblem and
+    // pattern textures now (before the dry_run check) so they are recorded for
+    // bundle tracing even when we skip image processing. EU5 flag assets are
+    // required; `load` fails loudly if they are absent.
+    let flag_renderer = crate::eu5::coat_of_arms::Eu5FlagRenderer::load(fs)?;
+    flag_renderer.trace();
 
     // If we are bundle tracing no need to do expensive image processing or create bundle
     if options.dry_run {
@@ -216,7 +224,57 @@ where
             output_dir = %frontend_goods_dir.display(),
             "EU5 goods icon atlas generated"
         );
+
+        translate_flags(imaging, &version_dir, &flag_renderer)?;
     }
+
+    Ok(())
+}
+
+/// Render every scoped coat of arms to temporary PNGs and montage consecutive
+/// chunks of 128 sorted keys into multi-resolution flag atlases. Sorting makes
+/// the split reproducible and usually keeps a country's named variants together.
+fn translate_flags<I, P>(
+    imaging: &I,
+    version_dir: &Path,
+    renderer: &crate::eu5::coat_of_arms::Eu5FlagRenderer<P>,
+) -> Result<()>
+where
+    I: ImageProcessor,
+    P: FileProvider + ?Sized,
+{
+    let temp = tempfile::tempdir()?;
+    let flag_images = renderer.render_to_pngs(temp.path())?;
+
+    let flags_dir = version_dir.join("common").join("images").join("flags");
+    if flags_dir.exists() {
+        std::fs::remove_dir_all(&flags_dir)?;
+    }
+    std::fs::create_dir_all(&flags_dir)?;
+
+    for (atlas_index, atlas_images) in flag_images.chunks(FLAGS_PER_ATLAS).enumerate() {
+        imaging.montage(MontageRequest {
+            images: atlas_images,
+            output_path: flags_dir.join(format!("flags-{atlas_index:02}.webp")),
+            format: OutputFormat::Webp {
+                quality: WebpQuality::Quality(90),
+            },
+            sizing: MontageSizing::Scaled {
+                sizes: crate::eu5::coat_of_arms::flag_montage_geometries(),
+                filter: ScaleFilter::Lanczos,
+            },
+            background: Some(Color::Transparent),
+            additional_args: vec![],
+        })?;
+    }
+
+    tracing::info!(
+        name: "eu5.flags.complete",
+        output_dir = %flags_dir.display(),
+        flag_count = flag_images.len(),
+        atlas_count = flag_images.len().div_ceil(FLAGS_PER_ATLAS),
+        "EU5 country flag atlas generated"
+    );
 
     Ok(())
 }

--- a/src/pdx-assets/src/file_provider.rs
+++ b/src/pdx-assets/src/file_provider.rs
@@ -10,7 +10,7 @@ pub struct FsFile {
     pub path: PathBuf,
 }
 
-pub trait FileProvider {
+pub trait FileProvider: Send + Sync {
     fn read_file(&self, path: &str) -> Result<Vec<u8>>;
     fn read_to_string(&self, path: &str) -> Result<String>;
     fn file_exists(&self, path: &str) -> bool;
@@ -251,7 +251,9 @@ impl FileProvider for ZipProvider {
 }
 
 // Helper function to create appropriate provider based on path
-pub fn create_provider<P: AsRef<Path>>(source_path: P) -> Result<Box<dyn FileProvider>> {
+pub fn create_provider<P: AsRef<Path>>(
+    source_path: P,
+) -> Result<Box<dyn FileProvider + Send + Sync>> {
     let path = source_path.as_ref();
 
     if path.is_dir() {
@@ -263,7 +265,10 @@ pub fn create_provider<P: AsRef<Path>>(source_path: P) -> Result<Box<dyn FilePro
     }
 }
 
-impl FileProvider for Box<dyn FileProvider> {
+impl<P> FileProvider for Box<P>
+where
+    P: FileProvider + ?Sized,
+{
     fn read_file(&self, path: &str) -> Result<Vec<u8>> {
         self.as_ref().read_file(path)
     }
@@ -291,7 +296,7 @@ impl FileProvider for Box<dyn FileProvider> {
 
 impl<P> FileProvider for &P
 where
-    P: FileProvider,
+    P: FileProvider + ?Sized,
 {
     fn read_file(&self, path: &str) -> Result<Vec<u8>> {
         (*self).read_file(path)

--- a/src/pdx-assets/src/file_tracker.rs
+++ b/src/pdx-assets/src/file_tracker.rs
@@ -1,28 +1,24 @@
 use super::file_provider::{FileProvider, FsFile};
 use anyhow::Result;
-use std::cell::RefCell;
 use std::collections::HashSet;
 use std::io::Read;
+use std::sync::Mutex;
 
 #[derive(Debug)]
 pub struct FileAccessTracker<P: FileProvider> {
     provider: P,
-    accessed_files: RefCell<HashSet<String>>,
+    accessed_files: Mutex<HashSet<String>>,
     enabled: bool,
 }
 
 impl<P: FileProvider> FileProvider for FileAccessTracker<P> {
     fn read_file(&self, path: &str) -> Result<Vec<u8>> {
-        if self.enabled {
-            self.accessed_files.borrow_mut().insert(path.to_string());
-        }
+        self.track_access(path);
         self.provider.read_file(path)
     }
 
     fn read_to_string(&self, path: &str) -> Result<String> {
-        if self.enabled {
-            self.accessed_files.borrow_mut().insert(path.to_string());
-        }
+        self.track_access(path);
         self.provider.read_to_string(path)
     }
 
@@ -34,7 +30,7 @@ impl<P: FileProvider> FileProvider for FileAccessTracker<P> {
     fn walk_directory(&self, path: &str, ends_with: &[&str]) -> Result<Vec<String>> {
         let files = self.provider.walk_directory(path, ends_with)?;
         if self.enabled {
-            let mut accessed = self.accessed_files.borrow_mut();
+            let mut accessed = self.accessed_files();
             for file in &files {
                 accessed.insert(file.clone());
             }
@@ -43,16 +39,12 @@ impl<P: FileProvider> FileProvider for FileAccessTracker<P> {
     }
 
     fn fs_file(&self, path: &str) -> Result<FsFile> {
-        if self.enabled {
-            self.accessed_files.borrow_mut().insert(path.to_string());
-        }
+        self.track_access(path);
         self.provider.fs_file(path)
     }
 
     fn open_file(&self, path: &str) -> Result<Box<dyn Read>> {
-        if self.enabled {
-            self.accessed_files.borrow_mut().insert(path.to_string());
-        }
+        self.track_access(path);
         self.provider.open_file(path)
     }
 }
@@ -61,12 +53,24 @@ impl<P: FileProvider> FileAccessTracker<P> {
     pub fn new(provider: P) -> Self {
         Self {
             provider,
-            accessed_files: RefCell::new(HashSet::new()),
+            accessed_files: Mutex::new(HashSet::new()),
             enabled: true,
         }
     }
 
     pub fn get_accessed_files(&self) -> HashSet<String> {
-        self.accessed_files.borrow().clone()
+        self.accessed_files().clone()
+    }
+
+    fn track_access(&self, path: &str) {
+        if self.enabled {
+            self.accessed_files().insert(path.to_string());
+        }
+    }
+
+    fn accessed_files(&self) -> std::sync::MutexGuard<'_, HashSet<String>> {
+        self.accessed_files
+            .lock()
+            .expect("file access tracker mutex poisoned")
     }
 }

--- a/src/pdx-assets/src/lib.rs
+++ b/src/pdx-assets/src/lib.rs
@@ -1,6 +1,7 @@
 mod asset_compilers;
 mod bundler;
 mod cli;
+pub mod coat_of_arms;
 pub mod de;
 pub mod eu4;
 pub mod eu5;


### PR DESCRIPTION
Add support for rendering eu5 coat of arms, shipping a rule set engine, and creating an atlas of flags.

<img width="620" height="82" alt="image" src="https://github.com/user-attachments/assets/1afafd23-f607-4315-b380-85720f00c8a4" />


