### PR TITLE
Fix colored fringes on flags and other sprite icons

### DIFF
--- a/src/app/app/features/eu4/components/AdvisorImage.tsx
+++ b/src/app/app/features/eu4/components/AdvisorImage.tsx
@@ -30,6 +30,7 @@ export function AdvisorImage({
 
   const index = spriteData[id as keyof typeof spriteData];
   srcSet ??= [
+    [advisor48, `1x`],
     [advisor64, `1.33x`],
     [advisor77, `1.60x`],
   ];

--- a/src/app/app/features/eu4/components/avatars/FlagAvatar.tsx
+++ b/src/app/app/features/eu4/components/avatars/FlagAvatar.tsx
@@ -166,6 +166,7 @@ const FlagSprite = ({ index, size }: { index: number; size?: AvatarSize }) => {
     <Sprite
       src={flag48}
       srcSet={[
+        [flag48, "1x"],
         [flag64, "1.33x"],
         [flag128, "2.66x"],
       ]}

--- a/src/pdx-assets/src/images/imagemagick.rs
+++ b/src/pdx-assets/src/images/imagemagick.rs
@@ -332,6 +332,12 @@ impl ImageProcessor for ImageMagickProcessor {
                     WebpQuality::Quality(q) => {
                         cmd.arg("-quality");
                         cmd.arg(q.to_string());
+
+                        // Deblocking smooths across block boundaries, which in
+                        // an atlas are the seams between sprites, leaving each
+                        // one fringed with its neighbors.
+                        cmd.arg("-define");
+                        cmd.arg("webp:filter-strength=0");
                     }
                 },
                 OutputFormat::Png => {


### PR DESCRIPTION
Icons picked up a thin band of the neighboring icon's colors along their edges. Two causes:

The image compressor smooths across block edges. In a packed sprite sheet those edges sit between icons, so it blended each icon into its neighbor. Turning the smoothing off removes the fringe and doesn't change file size.

The browser was never offered the normal-size sprite sheet, only the larger ones, so it always downloaded a big sheet and shrank it. Now it gets the right one: sharper icons and a smaller download.