### PR TITLE
Encode webp montages with quality that actually works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,6 +2819,7 @@ dependencies = [
  "eu5app",
  "eu5save",
  "flate2",
+ "image",
  "jomini",
  "mimalloc",
  "pdx-map",
@@ -2834,6 +2835,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+ "webp",
  "zstd",
 ]
 

--- a/src/pdx-assets/Cargo.toml
+++ b/src/pdx-assets/Cargo.toml
@@ -17,6 +17,7 @@ eu4save = { default-features = false , workspace = true, features = ["zstd_c"] }
 eu5app = { workspace = true, default-features = false, features = ["game-install", "zstd_c"] }
 eu5save = { workspace = true, default-features = false }
 flate2 = { workspace = true, default-features = false, features = ["zlib-rs"]}
+image = { workspace = true, features = ["png", "pnm"] }
 jomini = { workspace = true }
 pdx-map = { workspace = true, default-features = false }
 pdx-zstd = { workspace = true, default-features = false, features = ["zstd_c"] }
@@ -31,6 +32,7 @@ tempfile = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 walkdir = { workspace = true }
+webp = { workspace = true }
 zstd = { workspace = true }
 
 [target.'cfg(target_env = "musl")'.dependencies]

--- a/src/pdx-assets/src/eu4/compiler.rs
+++ b/src/pdx-assets/src/eu4/compiler.rs
@@ -19,6 +19,10 @@ use std::collections::{HashMap, HashSet};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
+// Empirically, q88 is the knee where higher quality adds substantially more
+// bytes than fidelity across both continuous-tone and transparent atlases.
+const MONTAGE_WEBP_QUALITY: u8 = 88;
+
 struct GameData<'a> {
     countries: &'a [Country],
     trade_companies: &'a HashMap<String, String>,
@@ -230,7 +234,7 @@ where
             images: &sprite_images,
             output_path: image_out_dir.join("investments.webp"),
             format: crate::images::OutputFormat::Webp {
-                quality: crate::images::WebpQuality::Quality(90),
+                quality: crate::images::WebpQuality::Quality(MONTAGE_WEBP_QUALITY),
             },
             sizing: crate::images::MontageSizing::Native,
             background: None,
@@ -317,7 +321,7 @@ where
             images: &personalities_order,
             output_path: image_out_dir.join("personalities.webp"),
             format: crate::images::OutputFormat::Webp {
-                quality: crate::images::WebpQuality::Quality(90),
+                quality: crate::images::WebpQuality::Quality(MONTAGE_WEBP_QUALITY),
             },
             sizing: crate::images::MontageSizing::Native,
             background: Some(crate::images::Color::Transparent),
@@ -380,7 +384,7 @@ where
             images: &advisors_montage,
             output_path: image_out_dir.join("advisors.webp"),
             format: crate::images::OutputFormat::Webp {
-                quality: crate::images::WebpQuality::Quality(90),
+                quality: crate::images::WebpQuality::Quality(MONTAGE_WEBP_QUALITY),
             },
             // The UI displays advisors at 32px or 48px; generate one atlas at
             // the native 77px size and let the browser downscale it.
@@ -694,7 +698,7 @@ where
         images: &flags_with_paths,
         output_path: base_flag_path.join("flags.webp"),
         format: crate::images::OutputFormat::Webp {
-            quality: crate::images::WebpQuality::Quality(90),
+            quality: crate::images::WebpQuality::Quality(MONTAGE_WEBP_QUALITY),
         },
         sizing: crate::images::MontageSizing::Scaled {
             sizes: vec![
@@ -756,7 +760,7 @@ where
         images: &achieves,
         output_path: base_achievements_path.join("achievements.webp"),
         format: crate::images::OutputFormat::Webp {
-            quality: crate::images::WebpQuality::Quality(90),
+            quality: crate::images::WebpQuality::Quality(MONTAGE_WEBP_QUALITY),
         },
         sizing: crate::images::MontageSizing::Scaled {
             sizes: vec![crate::images::Geometry::new(64, 64)],
@@ -850,7 +854,7 @@ where
         images: &western_buildings,
         output_path: base_path.join("westerngfx.webp"),
         format: crate::images::OutputFormat::Webp {
-            quality: crate::images::WebpQuality::Quality(90),
+            quality: crate::images::WebpQuality::Quality(MONTAGE_WEBP_QUALITY),
         },
         sizing: crate::images::MontageSizing::Native,
         background: Some(crate::images::Color::White),
@@ -863,7 +867,7 @@ where
         images: &global_buildings,
         output_path: base_path.join("global.webp"),
         format: crate::images::OutputFormat::Webp {
-            quality: crate::images::WebpQuality::Quality(90),
+            quality: crate::images::WebpQuality::Quality(MONTAGE_WEBP_QUALITY),
         },
         sizing: crate::images::MontageSizing::Native,
         background: Some(crate::images::Color::White),

--- a/src/pdx-assets/src/images/imagemagick.rs
+++ b/src/pdx-assets/src/images/imagemagick.rs
@@ -5,9 +5,9 @@ use super::{
 use crate::images::ImageError;
 use anyhow::{Context, Result, bail, ensure};
 use std::fs;
-use std::io::{BufWriter, Write};
+use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 /// Creates an ImageMagick command with the given subcommand.
 /// Automatically handles both ImageMagick 7+ ("magick <subcommand>") and ImageMagick 6 ("<subcommand>") installations.
@@ -325,31 +325,8 @@ impl ImageProcessor for ImageMagickProcessor {
                 cmd.arg(color_to_string(color));
             }
 
-            // Output format settings
-            match &request.format {
-                OutputFormat::Webp { quality } => match quality {
-                    WebpQuality::Lossless => {
-                        cmd.arg("-define");
-                        cmd.arg("webp:lossless=true");
-                    }
-                    WebpQuality::Quality(q) => {
-                        cmd.arg("-quality");
-                        cmd.arg(q.to_string());
-
-                        // Deblocking smooths across block boundaries, which in
-                        // an atlas are the seams between sprites, leaving each
-                        // one fringed with its neighbors.
-                        cmd.arg("-define");
-                        cmd.arg("webp:filter-strength=0");
-                    }
-                },
-                OutputFormat::Png => {
-                    // PNG doesn't need special args
-                }
-                OutputFormat::Raw => {
-                    // Raw format not supported for montage
-                    bail!("Raw format is not supported for montage operations");
-                }
+            if matches!(request.format, OutputFormat::Raw) {
+                bail!("Raw format is not supported for montage operations");
             }
 
             // Determine output path with or without size suffix
@@ -366,21 +343,97 @@ impl ImageProcessor for ImageMagickProcessor {
 
             // Input files from response file
             cmd.arg(format!("@{}", response_file.path().display()));
-            cmd.arg(&output_path);
+            match &request.format {
+                OutputFormat::Webp { quality } => {
+                    // PAM is an uncompressed, self-describing RGBA stream.
+                    // It avoids both a temporary file and the encode/decode
+                    // overhead of using PNG as an intermediate format.
+                    cmd.arg("pam:-");
+                    cmd.stdout(Stdio::piped());
+                    cmd.stderr(Stdio::piped());
+                    let mut child = cmd.spawn().context("unable to start ImageMagick montage")?;
+                    let stdout = child
+                        .stdout
+                        .take()
+                        .context("unable to read montage output")?;
+                    let mut stderr = child
+                        .stderr
+                        .take()
+                        .context("unable to read ImageMagick errors")?;
+                    let stderr_task = std::thread::spawn(move || {
+                        let mut contents = Vec::new();
+                        stderr.read_to_end(&mut contents).map(|_| contents)
+                    });
+                    let decoded = image::codecs::pnm::PnmDecoder::new(BufReader::new(stdout))
+                        .and_then(image::DynamicImage::from_decoder)
+                        .map(image::DynamicImage::into_rgba8);
+                    let status = child.wait()?;
+                    let stderr = stderr_task
+                        .join()
+                        .map_err(|_| anyhow::anyhow!("ImageMagick stderr reader panicked"))??;
 
-            let output = cmd.output()?;
+                    if !status.success() {
+                        return Err(ImageError::ImageMagickFailed {
+                            command: "montage".to_string(),
+                            stderr: String::from_utf8_lossy(&stderr).to_string(),
+                        }
+                        .into());
+                    }
 
-            if !output.status.success() {
-                return Err(ImageError::ImageMagickFailed {
-                    command: "montage".to_string(),
-                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                    let image = decoded.context("unable to decode ImageMagick montage output")?;
+                    encode_webp(&image, &output_path, quality)?;
                 }
-                .into());
+                OutputFormat::Png => {
+                    cmd.arg(&output_path);
+                    let output = cmd.output()?;
+                    if !output.status.success() {
+                        return Err(ImageError::ImageMagickFailed {
+                            command: "montage".to_string(),
+                            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                        }
+                        .into());
+                    }
+                }
+                OutputFormat::Raw => unreachable!(),
             }
         }
 
         Ok(())
     }
+}
+
+fn encode_webp(
+    image: &image::RgbaImage,
+    output_path: &std::path::Path,
+    quality: &WebpQuality,
+) -> Result<()> {
+    let encoder = webp::Encoder::from_rgba(image.as_raw(), image.width(), image.height());
+
+    let encoded = match quality {
+        WebpQuality::Lossless => encoder.encode_simple(true, 75.0).map_err(|error| {
+            anyhow::anyhow!("unable to encode lossless WebP montage: {error:?}")
+        })?,
+        WebpQuality::Quality(quality) => {
+            ensure!(*quality <= 100, "WebP quality must be between 0 and 100");
+            let mut config = webp::WebPConfig::new()
+                .map_err(|_| anyhow::anyhow!("unable to create WebP config"))?;
+            config.quality = f32::from(*quality);
+            // Filtering can blend pixels across neighboring sprites in an
+            // atlas, causing visible fringes when individual cells are drawn.
+            config.filter_strength = 0;
+            // Preserve saturated, high-contrast sprite edges during WebP's
+            // RGB-to-YUV conversion. Encoding is slower, but these are static
+            // build assets and the visual improvement is substantial.
+            config.use_sharp_yuv = 1;
+            encoder.encode_advanced(&config).map_err(|error| {
+                anyhow::anyhow!("unable to encode lossy WebP montage: {error:?}")
+            })?
+        }
+    };
+
+    fs::write(output_path, &*encoded)
+        .with_context(|| format!("unable to write montage: {}", output_path.display()))?;
+    Ok(())
 }
 
 /// ImageMagick response file that gets deleted when dropped
@@ -450,5 +503,42 @@ fn color_to_string(color: &Color) -> String {
         Color::Transparent => "transparent".to_string(),
         Color::White => "white".to_string(),
         Color::Black => "black".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn montage_webp_quality_controls_encoded_output() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let source_path = temp.path().join("gradient.png");
+        let source = image::RgbaImage::from_fn(128, 128, |x, y| {
+            image::Rgba([x as u8, y as u8, (x ^ y) as u8, 255])
+        });
+        source.save(&source_path)?;
+        let images = vec![("gradient".to_string(), source_path)];
+        let processor = ImageMagickProcessor::create()?;
+
+        let encode = |quality, name: &str| -> Result<PathBuf> {
+            let output_path = temp.path().join(name);
+            processor.montage(MontageRequest {
+                images: &images,
+                output_path: output_path.clone(),
+                format: OutputFormat::Webp {
+                    quality: WebpQuality::Quality(quality),
+                },
+                sizing: MontageSizing::Native,
+                background: Some(Color::Transparent),
+                additional_args: vec![],
+            })?;
+            Ok(output_path)
+        };
+
+        let low = encode(20, "low.webp")?;
+        let high = encode(90, "high.webp")?;
+        assert!(fs::metadata(low)?.len() < fs::metadata(high)?.len());
+        Ok(())
     }
 }

--- a/src/pdx-assets/src/main.rs
+++ b/src/pdx-assets/src/main.rs
@@ -11,7 +11,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
-#[command(propagate_version = true)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,


### PR DESCRIPTION
Turns out that imagemagick quality knob isn't working for webp montages. Trying quality 1-99 yielded the same as quality 75. So this uses webp crate to encode the imagemagick output with quality 88 (and webp is based on libwebp). It's a bit of a file size increase but I think some flags like PAP look meaningfully better