### PR TITLE
Update save cards with a new layout

### DIFF
--- a/src/app/app/features/account/SaveCard.tsx
+++ b/src/app/app/features/account/SaveCard.tsx
@@ -3,11 +3,22 @@ import { DeleteSave } from "../eu4/components/DeleteSave";
 import { AchievementAvatar, Flag } from "@/features/eu4/components/avatars";
 import { Link } from "@/components/Link";
 import { Card } from "@/components/Card";
-import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { ArrowTopRightOnSquareIcon, UserGroupIcon } from "@heroicons/react/24/outline";
 import { formatInt } from "@/lib/format";
-import { difficultyColor } from "@/lib/difficulty";
-import { ogImageUrl } from "@/lib/media";
+import { difficultyColor, difficultyText } from "@/lib/difficulty";
+import { ogImageSize, ogImageUrl } from "@/lib/media";
 import type { useSavesGroupedByPlaythrough } from "./UserSaveTable";
+import type { GameDifficulty } from "@/services/appApi";
+
+const ogImageStyle = { aspectRatio: `${ogImageSize.width} / ${ogImageSize.height}` };
+
+function PatchLine({ patch, difficulty }: { patch: string; difficulty: GameDifficulty }) {
+  return (
+    <div className="text-sm text-gray-600 dark:text-gray-400">
+      {patch} <span className={difficultyColor(difficulty)}>({difficultyText(difficulty)})</span>
+    </div>
+  );
+}
 
 export function SaveCard({
   save,
@@ -18,76 +29,78 @@ export function SaveCard({
   canDelete: boolean;
 }) {
   return (
-    <Card className="mt-2 flex flex-col gap-2 lg:flex-row lg:overflow-hidden">
+    <Card className="mt-2 overflow-hidden">
       <img
-        className="w-full rounded-t-md object-cover lg:h-96 lg:w-0 lg:min-w-0 lg:flex-1 lg:rounded-l-md lg:rounded-tr-none lg:object-contain"
+        className="w-full object-contain"
+        style={ogImageStyle}
         alt={`preview of save ${save.id}`}
-        width={1200}
-        height={630}
+        width={ogImageSize.width}
+        height={ogImageSize.height}
         src={ogImageUrl(save.id)}
         loading="lazy"
       />
-      <div className="flex min-w-56 shrink-0 flex-col gap-2 p-4 lg:w-64 lg:gap-4">
-        <div className="flex flex-col flex-wrap justify-around gap-4">
-          <div>
-            <div className="text-center text-gray-600 dark:text-gray-400">
-              <TimeAgo date={save.upload_time} />
-            </div>
 
-            {save.user_id && save.user_name && (
-              <div className="line-clamp-1 text-center break-all">
-                <Link href={`/users/${save.user_id}`}>{save.user_name}</Link>
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-gray-400/50 p-3">
+        {save.players <= 1 ? (
+          <Flag tag={save.player_tag} name={save.player_tag_name ?? save.player_tag}>
+            <div className="flex min-w-0 items-center gap-3">
+              <Flag.Image size="large" />
+              <div className="min-w-0">
+                <Flag.CountryName className="line-clamp-1 text-lg leading-tight font-semibold" />
+                <PatchLine patch={save.patch} difficulty={save.game_difficulty} />
               </div>
-            )}
-
-            {save.filename !== save.name && (
-              <div className="line-clamp-1 text-center break-all text-gray-600 dark:text-gray-400">
-                {save.filename}
+            </div>
+          </Flag>
+        ) : (
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-gray-200 dark:bg-slate-700">
+              <UserGroupIcon className="h-7 w-7 text-gray-600 dark:text-gray-300" />
+            </div>
+            <div className="min-w-0">
+              <div className="text-lg leading-tight font-semibold">
+                {formatInt(save.players)} players
               </div>
-            )}
-          </div>
-
-          {save.players <= 1 ? (
-            <div className="flex flex-col items-center gap-2 lg:my-3">
-              <Flag tag={save.player_tag} name={save.player_tag_name ?? save.player_tag}>
-                <Flag.Image size="xl" />
-                <div className="text-center">
-                  <Flag.CountryName className="line-clamp-2 text-lg leading-tight font-semibold" />
-                  <div className="text-gray-600 dark:text-gray-400">
-                    {save.patch}{" "}
-                    <span
-                      className={
-                        difficultyColor(save.game_difficulty) ?? "text-gray-600 dark:text-gray-400"
-                      }
-                    >
-                      ({save.game_difficulty})
-                    </span>
-                  </div>
-                </div>
-              </Flag>
-            </div>
-          ) : (
-            <div className="text-center">
-              {formatInt(save.players)} players on {save.patch}
-            </div>
-          )}
-        </div>
-
-        {save.achievements.length > 0 && (
-          <div className="mt-3 flex flex-col items-center space-y-2">
-            <div className="text-lg">Achievements</div>
-            <div className="flex flex-wrap justify-center gap-2">
-              {save.achievements.map((x) => (
-                <AchievementAvatar key={x} size={40} id={x} />
-              ))}
+              <PatchLine patch={save.patch} difficulty={save.game_difficulty} />
             </div>
           </div>
         )}
 
-        <div className="my-2 grow border-b border-gray-600" />
-        <div className="flex justify-evenly gap-4">
-          {canDelete && <DeleteSave saveId={save.id} variant="ghost" shape="none" />}
-          <Link to={`/eu4/saves/${save.id}`} target="_blank">
+        <div className="min-w-0 text-sm text-gray-600 dark:text-gray-400">
+          {save.user_id && save.user_name && (
+            <div className="line-clamp-1 break-all">
+              <Link href={`/users/${save.user_id}`}>{save.user_name}</Link>
+            </div>
+          )}
+
+          <TimeAgo date={save.upload_time} />
+
+          {save.filename !== save.name && (
+            <div className="line-clamp-1 break-all">{save.filename}</div>
+          )}
+        </div>
+
+        <div className="ml-auto flex items-center gap-4">
+          {save.achievements.length > 0 && (
+            <div
+              role="group"
+              aria-label="Achievements"
+              className="flex flex-wrap justify-end gap-2"
+            >
+              {save.achievements.map((x) => (
+                <AchievementAvatar key={x} size={40} id={x} />
+              ))}
+            </div>
+          )}
+
+          {canDelete && (
+            <DeleteSave saveId={save.id} variant="ghost" shape="none" className="shrink-0" />
+          )}
+          <Link
+            className="shrink-0"
+            to={`/eu4/saves/${save.id}`}
+            target="_blank"
+            aria-label="Open save"
+          >
             <ArrowTopRightOnSquareIcon className="h-8 w-8" />
           </Link>
         </div>

--- a/src/app/app/lib/media.ts
+++ b/src/app/app/lib/media.ts
@@ -2,6 +2,8 @@ import type { LinksFunction } from "react-router";
 
 export const mediaOrigin = import.meta.env.VITE_MEDIA_ORIGIN;
 
+export const ogImageSize = { width: 1200, height: 630 } as const;
+
 // Production reads bypass the Worker through the R2 custom domain. Dev and test
 // builds omit VITE_MEDIA_ORIGIN and use the local MEDIA_BUCKET Worker route.
 export const ogImageUrl = (saveId: string, game = "eu4") =>

--- a/src/app/app/lib/seo.ts
+++ b/src/app/app/lib/seo.ts
@@ -1,3 +1,5 @@
+import { ogImageSize } from "./media";
+
 export function seo({
   title,
   description,
@@ -26,8 +28,8 @@ export function seo({
             ? image
             : `${import.meta.env.VITE_EXTERNAL_ADDRESS ?? ""}${image}`,
         },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
+        { property: "og:image:width", content: `${ogImageSize.width}` },
+        { property: "og:image:height", content: `${ogImageSize.height}` },
       ]
     : [];
 


### PR DESCRIPTION
The current layout was proving troublesome with wrapping data and gaps between the thumbnail and the sidebar. Putting the save metadata in the footer solved this nicely

<img width="1252" height="757" alt="image" src="https://github.com/user-attachments/assets/7e55470c-8a26-4455-8a7c-cb0e90d673a5" />

<img width="1252" height="767" alt="image" src="https://github.com/user-attachments/assets/6e15fe60-5a19-4667-9810-cbb2c4bbeb25" />

Still locks decent on mobile:

<img width="465" height="826" alt="image" src="https://github.com/user-attachments/assets/2ad3be5c-6955-4577-a05a-f6823f969fac" />
