### PR TITLE
Improve framing for multiplayer EU4 screenshots

### DIFF
--- a/src/pdx-map/src/layers/date_layer.rs
+++ b/src/pdx-map/src/layers/date_layer.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
-use crate::{RenderLayer, ViewportBounds};
+use crate::{PhysicalSize, RenderLayer, ViewportBounds};
 
 const GLYPH_PATTERN_WIDTH: usize = 5;
 const GLYPH_PATTERN_HEIGHT: usize = 7;
@@ -40,8 +40,7 @@ struct OverlayGeometry {
 /// Pending pixel data awaiting GPU upload
 struct PendingUpload {
     pixels: Vec<u8>,
-    width: u32,
-    height: u32,
+    size: PhysicalSize<u32>,
 }
 
 pub struct DateLayer {
@@ -64,6 +63,12 @@ impl DateLayer {
             geometry: None,
             pending_upload: None,
         }
+    }
+
+    /// Rasterize a date overlay for composition outside a render target.
+    pub fn rasterize(text: &str, glyph_scale: u32) -> (Vec<u8>, PhysicalSize<u32>) {
+        assert!(glyph_scale > 0, "glyph scale must be at least 1");
+        rasterize_text_overlay(text, glyph_scale)
     }
 
     fn ensure_pipeline(&mut self, device: &wgpu::Device, format: wgpu::TextureFormat) {
@@ -161,20 +166,18 @@ impl DateLayer {
     }
 
     fn rebuild_resources(&mut self, device: &wgpu::Device, target_width: u32, target_height: u32) {
-        let (pixels, overlay_width, overlay_height) =
-            rasterize_text_overlay(&self.text, self.glyph_scale);
+        let (pixels, overlay_size) = rasterize_text_overlay(&self.text, self.glyph_scale);
 
         self.pending_upload = Some(PendingUpload {
             pixels,
-            width: overlay_width,
-            height: overlay_height,
+            size: overlay_size,
         });
 
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("Date Layer Texture"),
             size: wgpu::Extent3d {
-                width: overlay_width,
-                height: overlay_height,
+                width: overlay_size.width,
+                height: overlay_size.height,
                 depth_or_array_layers: 1,
             },
             mip_level_count: 1,
@@ -206,8 +209,8 @@ impl DateLayer {
         let vertices = quad_vertices(
             target_width as f32,
             target_height as f32,
-            overlay_width,
-            overlay_height,
+            overlay_size.width,
+            overlay_size.height,
         );
 
         let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -242,12 +245,12 @@ impl DateLayer {
             &upload.pixels,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
-                bytes_per_row: Some(upload.width * 4),
-                rows_per_image: Some(upload.height),
+                bytes_per_row: Some(upload.size.width * 4),
+                rows_per_image: Some(upload.size.height),
             },
             wgpu::Extent3d {
-                width: upload.width,
-                height: upload.height,
+                width: upload.size.width,
+                height: upload.size.height,
                 depth_or_array_layers: 1,
             },
         );
@@ -296,7 +299,7 @@ struct OverlayVertex {
     uv: [f32; 2],
 }
 
-fn rasterize_text_overlay(text: &str, glyph_scale: u32) -> (Vec<u8>, u32, u32) {
+fn rasterize_text_overlay(text: &str, glyph_scale: u32) -> (Vec<u8>, PhysicalSize<u32>) {
     let glyphs: Vec<char> = text.chars().collect();
     let glyph_count = glyphs.len() as u32;
     let glyph_width = GLYPH_PATTERN_WIDTH as u32 * glyph_scale;
@@ -341,7 +344,7 @@ fn rasterize_text_overlay(text: &str, glyph_scale: u32) -> (Vec<u8>, u32, u32) {
         cursor_x += glyph_width + letter_spacing;
     }
 
-    (pixels, overlay_width, overlay_height)
+    (pixels, PhysicalSize::new(overlay_width, overlay_height))
 }
 
 fn fill_glyph_block(

--- a/src/pdx-map/src/layers/date_layer.rs
+++ b/src/pdx-map/src/layers/date_layer.rs
@@ -66,6 +66,12 @@ impl DateLayer {
         }
     }
 
+    /// Rasterize a date overlay for composition outside a render target.
+    pub fn rasterize(text: &str, glyph_scale: u32) -> (Vec<u8>, u32, u32) {
+        assert!(glyph_scale > 0, "glyph scale must be at least 1");
+        rasterize_text_overlay(text, glyph_scale)
+    }
+
     fn ensure_pipeline(&mut self, device: &wgpu::Device, format: wgpu::TextureFormat) {
         if let Some(pipeline) = &self.pipeline
             && pipeline.format == format

--- a/src/pdx-screenshot/src/eu4/colors.rs
+++ b/src/pdx-screenshot/src/eu4/colors.rs
@@ -2,7 +2,7 @@ use eu4game::game::Game;
 use eu4save::{CountryTag, models::Eu4Save};
 use std::collections::HashMap;
 
-const OCEAN: [u8; 4] = [69, 94, 119, 255];
+pub(super) const OCEAN: [u8; 4] = [69, 94, 119, 255];
 const WASTELAND: [u8; 4] = [61, 61, 61, 255];
 const UNOWNED_COLOR: [u8; 4] = [94, 94, 94, 128];
 

--- a/src/pdx-screenshot/src/eu4/renderer.rs
+++ b/src/pdx-screenshot/src/eu4/renderer.rs
@@ -9,6 +9,37 @@ use super::{PatchScreenshotAssets, ScreenshotError};
 use pdx_map::WorldPoint;
 use pdx_map::layers::DateLayer;
 
+/// Blend a straight-alpha RGBA overlay into the left edge of an image, starting
+/// at row `origin_y`. Rows that do not fit in the image are dropped.
+fn blend_overlay(
+    image: &mut [u8],
+    image_width: u32,
+    origin_y: u32,
+    overlay: &[u8],
+    overlay_width: u32,
+) {
+    debug_assert!(overlay_width <= image_width, "overlay is wider than image");
+
+    let image_stride = image_width as usize * 4;
+    let overlay_stride = overlay_width as usize * 4;
+
+    for (src_row, dst_row) in overlay
+        .chunks_exact(overlay_stride)
+        .zip(image.chunks_exact_mut(image_stride).skip(origin_y as usize))
+    {
+        let dst_row = &mut dst_row[..overlay_stride];
+        for (src, dst) in src_row.chunks_exact(4).zip(dst_row.chunks_exact_mut(4)) {
+            let alpha = u32::from(src[3]);
+            for channel in 0..3 {
+                let blended =
+                    u32::from(src[channel]) * alpha + u32::from(dst[channel]) * (255 - alpha);
+                dst[channel] = ((blended + 127) / 255) as u8;
+            }
+            dst[3] = 255;
+        }
+    }
+}
+
 /// Render a screenshot from parsed save data
 #[tracing::instrument(
     level = "debug",
@@ -26,6 +57,7 @@ pub async fn render_screenshot(
     game_data: &[u8],
 ) -> Result<Vec<u8>, ScreenshotError> {
     let game = eu4game::game::Game::from_flatbuffer(game_data);
+    let is_multiplayer = parsed.is_multiplayer();
 
     let (primary_colors, secondary_colors) = super::colors::generate_political_colors(
         parsed.query.save(),
@@ -81,7 +113,7 @@ pub async fn render_screenshot(
             .set(LocationFlags::NO_LOCATION_BORDERS);
     }
 
-    let viewport = if parsed.is_multiplayer() {
+    let viewport = if is_multiplayer {
         viewport::calculate_mp_viewport()
     } else {
         let center = viewport::player_capital_anchor(&parsed.query, &game)
@@ -96,6 +128,11 @@ pub async fn render_screenshot(
     };
 
     let output_size = viewport::OUTPUT_IMAGE_SIZE;
+    let map_image_size = if is_multiplayer {
+        viewport::MP_MAP_IMAGE_SIZE
+    } else {
+        output_size
+    };
     let texture_size = viewport::EU4_HEMISPHERE_SIZE.physical();
     let west_view = gpu.create_texture(&patch_assets.west_r16, texture_size, "West Texture");
     let east_view = gpu.create_texture(&patch_assets.east_r16, texture_size, "East Texture");
@@ -104,13 +141,16 @@ pub async fn render_screenshot(
         gpu.clone(),
         west_view,
         east_view,
-        output_size.width,
-        output_size.height,
+        map_image_size.width,
+        map_image_size.height,
     )
     .map_err(ScreenshotError::CreateRenderer)?;
 
-    let date_layer = DateLayer::new(parsed.date(), ((output_size.height / 400).max(1)) * 2);
-    renderer.add_layer(date_layer);
+    let date_scale = ((map_image_size.height / 400).max(1)) * 2;
+
+    if is_multiplayer {
+        renderer.set_location_borders(false);
+    }
     renderer.update_locations(&location_arrays);
 
     let viewport_data = renderer
@@ -118,15 +158,35 @@ pub async fn render_screenshot(
         .await
         .map_err(ScreenshotError::CaptureViewport)?;
 
-    let mut image_buffer = vec![0u8; (output_size.width * output_size.height * 4) as usize];
+    let image_stride = output_size.width as usize * 4;
+    let mut image_buffer = vec![0u8; image_stride * output_size.height as usize];
+
     for (src, dst) in viewport_data
         .rows()
-        .zip(image_buffer.chunks_exact_mut(output_size.width as usize * 4))
+        .zip(image_buffer.chunks_exact_mut(image_stride))
     {
         dst.copy_from_slice(src);
     }
-
     viewport_data.finish();
+
+    // The band below the map continues the ocean, so the seam is invisible.
+    let ocean_row = super::colors::OCEAN.repeat(output_size.width as usize);
+    for dst in image_buffer
+        .chunks_exact_mut(image_stride)
+        .skip(map_image_size.height as usize)
+    {
+        dst.copy_from_slice(&ocean_row);
+    }
+
+    let (date_pixels, date_size) = DateLayer::rasterize(&parsed.date(), date_scale);
+    let date_y = output_size.height - date_size.height;
+    blend_overlay(
+        &mut image_buffer,
+        output_size.width,
+        date_y,
+        &date_pixels,
+        date_size.width,
+    );
 
     Ok(image_buffer)
 }

--- a/src/pdx-screenshot/src/eu4/renderer.rs
+++ b/src/pdx-screenshot/src/eu4/renderer.rs
@@ -9,6 +9,37 @@ use super::{PatchScreenshotAssets, ScreenshotError};
 use pdx_map::WorldPoint;
 use pdx_map::layers::DateLayer;
 
+/// Blend a straight-alpha RGBA overlay into the left edge of an image, starting
+/// at row `origin_y`. Rows that do not fit in the image are dropped.
+fn blend_overlay(
+    image: &mut [u8],
+    image_width: u32,
+    origin_y: u32,
+    overlay: &[u8],
+    overlay_width: u32,
+) {
+    debug_assert!(overlay_width <= image_width, "overlay is wider than image");
+
+    let image_stride = image_width as usize * 4;
+    let overlay_stride = overlay_width as usize * 4;
+
+    for (src_row, dst_row) in overlay
+        .chunks_exact(overlay_stride)
+        .zip(image.chunks_exact_mut(image_stride).skip(origin_y as usize))
+    {
+        let dst_row = &mut dst_row[..overlay_stride];
+        for (src, dst) in src_row.chunks_exact(4).zip(dst_row.chunks_exact_mut(4)) {
+            let alpha = u32::from(src[3]);
+            for channel in 0..3 {
+                let blended =
+                    u32::from(src[channel]) * alpha + u32::from(dst[channel]) * (255 - alpha);
+                dst[channel] = ((blended + 127) / 255) as u8;
+            }
+            dst[3] = 255;
+        }
+    }
+}
+
 /// Render a screenshot from parsed save data
 #[tracing::instrument(
     level = "debug",
@@ -26,6 +57,7 @@ pub async fn render_screenshot(
     game_data: &[u8],
 ) -> Result<Vec<u8>, ScreenshotError> {
     let game = eu4game::game::Game::from_flatbuffer(game_data);
+    let is_multiplayer = parsed.is_multiplayer();
 
     let (primary_colors, secondary_colors) = super::colors::generate_political_colors(
         parsed.query.save(),
@@ -81,7 +113,7 @@ pub async fn render_screenshot(
             .set(LocationFlags::NO_LOCATION_BORDERS);
     }
 
-    let viewport = if parsed.is_multiplayer() {
+    let viewport = if is_multiplayer {
         viewport::calculate_mp_viewport()
     } else {
         let center = viewport::player_capital_anchor(&parsed.query, &game)
@@ -96,6 +128,11 @@ pub async fn render_screenshot(
     };
 
     let output_size = viewport::OUTPUT_IMAGE_SIZE;
+    let map_image_size = if is_multiplayer {
+        viewport::MP_MAP_IMAGE_SIZE
+    } else {
+        output_size
+    };
     let texture_size = viewport::EU4_HEMISPHERE_SIZE.physical();
     let west_view = gpu.create_texture(&patch_assets.west_r16, texture_size, "West Texture");
     let east_view = gpu.create_texture(&patch_assets.east_r16, texture_size, "East Texture");
@@ -104,13 +141,20 @@ pub async fn render_screenshot(
         gpu.clone(),
         west_view,
         east_view,
-        output_size.width,
-        output_size.height,
+        map_image_size.width,
+        map_image_size.height,
     )
     .map_err(ScreenshotError::CreateRenderer)?;
 
-    let date_layer = DateLayer::new(parsed.date(), ((output_size.height / 400).max(1)) * 2);
-    renderer.add_layer(date_layer);
+    let date_scale = ((map_image_size.height / 400).max(1)) * 2;
+
+    // Singleplayer fills the frame, so the date is drawn on the map itself.
+    // Multiplayer keeps the map clear and blends the date into the band below.
+    if is_multiplayer {
+        renderer.set_location_borders(false);
+    } else {
+        renderer.add_layer(DateLayer::new(parsed.date(), date_scale));
+    }
     renderer.update_locations(&location_arrays);
 
     let viewport_data = renderer
@@ -118,12 +162,36 @@ pub async fn render_screenshot(
         .await
         .map_err(ScreenshotError::CaptureViewport)?;
 
-    let mut image_buffer = vec![0u8; (output_size.width * output_size.height * 4) as usize];
+    let image_stride = output_size.width as usize * 4;
+    let mut image_buffer = vec![0u8; image_stride * output_size.height as usize];
+
     for (src, dst) in viewport_data
         .rows()
-        .zip(image_buffer.chunks_exact_mut(output_size.width as usize * 4))
+        .zip(image_buffer.chunks_exact_mut(image_stride))
     {
         dst.copy_from_slice(src);
+    }
+
+    // The band below the map continues the ocean, so the seam is invisible.
+    let ocean_row = super::colors::OCEAN.repeat(output_size.width as usize);
+    for dst in image_buffer
+        .chunks_exact_mut(image_stride)
+        .skip(map_image_size.height as usize)
+    {
+        dst.copy_from_slice(&ocean_row);
+    }
+
+    if is_multiplayer {
+        let (date_pixels, date_width, date_height) =
+            DateLayer::rasterize(&parsed.date(), date_scale);
+        let date_y = output_size.height - date_height;
+        blend_overlay(
+            &mut image_buffer,
+            output_size.width,
+            date_y,
+            &date_pixels,
+            date_width,
+        );
     }
 
     viewport_data.finish();

--- a/src/pdx-screenshot/src/eu4/viewport.rs
+++ b/src/pdx-screenshot/src/eu4/viewport.rs
@@ -5,6 +5,10 @@ use pdx_map::{HemisphereSize, PhysicalSize, ViewportBounds, WorldPoint, WorldSiz
 pub(super) const EU4_HEMISPHERE_SIZE: HemisphereSize<u32> = HemisphereSize::new(2816, 2048);
 pub(super) const EU4_WORLD_SIZE: WorldSize<u32> = EU4_HEMISPHERE_SIZE.world();
 pub(super) const OUTPUT_IMAGE_SIZE: PhysicalSize<u32> = PhysicalSize::new(1200, 630);
+/// Multiplayer draws the map short of the output height. The remaining rows are
+/// the ocean band that holds the date overlay, so this must stay narrower than
+/// the world and short enough to leave room for the rasterized date.
+pub(super) const MP_MAP_IMAGE_SIZE: PhysicalSize<u32> = PhysicalSize::new(1200, 570);
 
 fn viewport_bounds(origin: WorldPoint<u32>, size: WorldSize<u32>) -> ViewportBounds {
     let mut viewport = ViewportBounds::new(size);
@@ -34,11 +38,15 @@ pub fn calculate_sp_viewport(center: WorldPoint<u32>) -> ViewportBounds {
 
 /// Calculate viewport for multiplayer (full world)
 pub fn calculate_mp_viewport() -> ViewportBounds {
-    // Match CSS object-fit: cover. The OG image is slightly narrower than the
-    // EU4 world aspect ratio, so use full height and crop the east/west edges.
-    let width = EU4_WORLD_SIZE.height * OUTPUT_IMAGE_SIZE.width / OUTPUT_IMAGE_SIZE.height;
+    // Use the full map height and crop the east/west edges.
+    // Apply most of the crop to the Americas to keep East Asia in view.
+    let width = EU4_WORLD_SIZE.height * MP_MAP_IMAGE_SIZE.width / MP_MAP_IMAGE_SIZE.height;
+    let horizontal_crop = EU4_WORLD_SIZE
+        .width
+        .checked_sub(width)
+        .expect("multiplayer output must be narrower than the world");
     viewport_bounds(
-        WorldPoint::new((EU4_WORLD_SIZE.width - width) / 2, 0),
+        WorldPoint::new(horizontal_crop * 3 / 4, 0),
         WorldSize::new(width, EU4_WORLD_SIZE.height),
     )
 }
@@ -61,9 +69,9 @@ mod tests {
     fn multiplayer_viewport_covers_output_aspect() {
         let viewport = calculate_mp_viewport();
 
-        assert_eq!(viewport.rect.size.width, 3900);
+        assert_eq!(viewport.rect.size.width, 4311);
         assert_eq!(viewport.rect.size.height, EU4_WORLD_SIZE.height);
-        assert_eq!(viewport.rect.origin.x, 866);
+        assert_eq!(viewport.rect.origin.x, 990);
         assert_eq!(viewport.rect.origin.y, 0);
     }
 


### PR DESCRIPTION
Cutting off korea and japan seem like two areas that _shouldn't_ be cut off.

Before:
<img width="1200" height="630" alt="PREMADE2-original" src="https://github.com/user-attachments/assets/0ff41cbc-7997-4dde-84a7-e3f9c832c4f3" />

After:
<img width="1200" height="630" alt="PREMADE2-no-province-borders" src="https://github.com/user-attachments/assets/a8e3af4b-f9e6-4bbe-aacc-0fb540b615c4" />
