### PR TITLE
Align EU4 multiplayer detection with player count

### DIFF
--- a/src/app/app/features/eu4/worker/init.ts
+++ b/src/app/app/features/eu4/worker/init.ts
@@ -75,6 +75,7 @@ export function getMeta(savefile: mod.SaveFile) {
     warnings,
     ...saveInfo,
     ...meta,
+    multiplayer: saveInfo.mode === "Multiplayer",
   };
 }
 

--- a/src/applib/src/parser.rs
+++ b/src/applib/src/parser.rs
@@ -89,6 +89,7 @@ pub fn parse_save_data(data: &[u8]) -> Result<ParseResult, ParseFileError> {
         .iter()
         .map(|x| x.name.clone())
         .collect::<Vec<_>>();
+    let is_multiplayer = eu4game::shared::is_multiplayer(&query);
     let player_tag_name = save_game_query.localize_country(&query.save().meta.player);
     let player_start_tag = query
         .starting_country(&player_histories)
@@ -117,7 +118,7 @@ pub fn parse_save_data(data: &[u8]) -> Result<ParseResult, ParseFileError> {
         },
         encoding,
         is_ironman: meta.is_ironman,
-        is_multiplayer: meta.multiplayer,
+        is_multiplayer,
         playthrough_id,
         game_difficulty,
         player_names,

--- a/src/eu4game/src/shared.rs
+++ b/src/eu4game/src/shared.rs
@@ -129,6 +129,15 @@ pub fn playthrough_id(query: &Query) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes)
 }
 
+/// Return true when the save contains more than one parsed player.
+pub fn is_multiplayer(query: &Query) -> bool {
+    is_multiplayer_from_player_count(query.players().len())
+}
+
+fn is_multiplayer_from_player_count(player_count: usize) -> bool {
+    player_count > 1
+}
+
 pub fn hash_countries(hash: &mut impl HighwayHash, content_date: Eu4Date, save: &Eu4Save) {
     let events = save
         .game
@@ -358,5 +367,12 @@ mod tests {
         summer.append(b"world");
         let hash = summer.finish().unwrap();
         assert_eq!(hash, "/p54eGIaz1s/t1mJgg7qSZwKd+s+R19l1t1xcdou/Yc=");
+    }
+
+    #[test]
+    fn multiplayer_requires_multiple_players() {
+        assert!(is_multiplayer_from_player_count(2));
+        assert!(!is_multiplayer_from_player_count(1));
+        assert!(!is_multiplayer_from_player_count(0));
     }
 }

--- a/src/pdx-screenshot/src/eu4/save.rs
+++ b/src/pdx-screenshot/src/eu4/save.rs
@@ -30,7 +30,7 @@ impl ParsedSave {
     }
 
     pub fn is_multiplayer(&self) -> bool {
-        self.query.save().meta.multiplayer
+        eu4game::shared::is_multiplayer(&self.query)
     }
 
     pub fn date(&self) -> String {

--- a/src/wasm-eu4/src/savefile/mod.rs
+++ b/src/wasm-eu4/src/savefile/mod.rs
@@ -985,7 +985,7 @@ impl SaveFileImpl {
     }
 
     pub fn save_mode(&self) -> SaveMode {
-        if self.query.save().meta.multiplayer {
+        if eu4game::shared::is_multiplayer(&self.query) {
             return SaveMode::Multiplayer;
         }
 


### PR DESCRIPTION
## Summary

- classify saves as multiplayer when they contain more than one parsed player
- use the shared rule for upload metadata, screenshots, and the loaded-save UI
- match the newest-saves multiplayer icon, which uses the database player-array cardinality

## Validation

- cargo test -p eu4game shared::tests::multiplayer_requires_multiple_players
- cargo test -p pdx-screenshot --features eu4
- cargo test -p wasm-eu4 --lib
- pnpm typecheck