### PR TITLE
Update jomini dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "arena-serde"
 version = "0.1.0"
-source = "git+https://github.com/rakaly/jomini.git#7af1b8a842fbadef0942a777b4faa21e0e0f7784"
+source = "git+https://github.com/rakaly/jomini.git#432c1b6738bab99179a8c80a531e61807ccea0b6"
 dependencies = [
  "arena-serde-derive",
  "bumpalo",
@@ -187,7 +187,7 @@ dependencies = [
 [[package]]
 name = "arena-serde-derive"
 version = "0.1.0"
-source = "git+https://github.com/rakaly/jomini.git#7af1b8a842fbadef0942a777b4faa21e0e0f7784"
+source = "git+https://github.com/rakaly/jomini.git#432c1b6738bab99179a8c80a531e61807ccea0b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "ck3save"
 version = "0.4.3"
-source = "git+https://github.com/rakaly/jomini.git#7af1b8a842fbadef0942a777b4faa21e0e0f7784"
+source = "git+https://github.com/rakaly/jomini.git#432c1b6738bab99179a8c80a531e61807ccea0b6"
 dependencies = [
  "jomini",
  "serde",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "eu4save"
 version = "0.8.2"
-source = "git+https://github.com/rakaly/jomini.git#7af1b8a842fbadef0942a777b4faa21e0e0f7784"
+source = "git+https://github.com/rakaly/jomini.git#432c1b6738bab99179a8c80a531e61807ccea0b6"
 dependencies = [
  "flate2",
  "jomini",
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "eu5save"
 version = "0.1.0"
-source = "git+https://github.com/rakaly/jomini.git#7af1b8a842fbadef0942a777b4faa21e0e0f7784"
+source = "git+https://github.com/rakaly/jomini.git#432c1b6738bab99179a8c80a531e61807ccea0b6"
 dependencies = [
  "arena-serde",
  "bumpalo",
@@ -1512,7 +1512,7 @@ checksum = "9040319a6910b901d5d49cbada4a99db52836a1b63228a05f7e2b7f8feef89b1"
 [[package]]
 name = "hoi4save"
 version = "0.4.0"
-source = "git+https://github.com/rakaly/jomini.git#7af1b8a842fbadef0942a777b4faa21e0e0f7784"
+source = "git+https://github.com/rakaly/jomini.git#432c1b6738bab99179a8c80a531e61807ccea0b6"
 dependencies = [
  "jomini",
  "serde",
@@ -1763,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "imperator-save"
 version = "0.4.2"
-source = "git+https://github.com/rakaly/jomini.git#7af1b8a842fbadef0942a777b4faa21e0e0f7784"
+source = "git+https://github.com/rakaly/jomini.git#432c1b6738bab99179a8c80a531e61807ccea0b6"
 dependencies = [
  "jomini",
  "serde",
@@ -1919,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "jomini"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef806465c9b19d5a0bddbfa67dfd81633e781244464bab474937d9341e00627f"
+checksum = "22859b7991714f9b194a3e35321a29d9068c9901647ec523d3bad60dfbbf6fe7"
 dependencies = [
  "flate2",
  "itoa",
@@ -3285,7 +3285,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3577,7 +3577,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3647,7 +3647,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4103,7 +4103,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4548,7 +4548,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vic3save"
 version = "0.1.0"
-source = "git+https://github.com/rakaly/jomini.git#7af1b8a842fbadef0942a777b4faa21e0e0f7784"
+source = "git+https://github.com/rakaly/jomini.git#432c1b6738bab99179a8c80a531e61807ccea0b6"
 dependencies = [
  "getrandom 0.3.4",
  "jomini",
@@ -5232,7 +5232,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ image_dds = { version = "0.7", default-features = false, features = [
 ] }
 imperator-save = { git = "https://github.com/rakaly/jomini.git" }
 insta = { version = "1.47", features = ["json"] }
-jomini = { version = "0.36", features = ["envelope"] }
+jomini = { version = "0.36.1", features = ["envelope"] }
 js-sys = "0.3.95"
 mimalloc = "0.1.48"
 nu-ansi-term = "0.50.3"

--- a/src/eu5app/src/session/save_loader.rs
+++ b/src/eu5app/src/session/save_loader.rs
@@ -50,7 +50,7 @@ impl Eu5SaveLoader<(), ()> {
                     month: meta.metadata.date.month(),
                     day: meta.metadata.date.day(),
                 },
-                playthrough_name: meta.metadata.playthrough_name.to_string(),
+                playthrough_name: meta.metadata.name().unwrap_or_default().to_owned(),
             }
         };
 


### PR DESCRIPTION
## Summary

- Update all jomini workspace crates to the merged EU4dll decoding changes
- Use the released crates.io `jomini 0.36.1` dependency
- Use the latest EU5 metadata name fallback

## Validation

- `cargo check --workspace --locked`
- `cargo fmt --all --check`
- `mise run lint`
- `cargo test -p eu4game --locked`
- `cargo test -p eu5app --locked`

Upstream: https://github.com/rakaly/jomini/pull/273